### PR TITLE
Add setting doc for auto disk provisioning and ssl parameter

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -483,7 +483,7 @@ install:
 #### Definition
 
 You can overwrite the default Harvester system settings by configuring `system_settings`.
-See [Settings](../../settings/settings) for available settings.
+See the [Settings](../../settings/settings) page for additional information and the list of all the options.
 
 !!! note
     Overwriting system settings only works when Harvester is installed in "create" mode.
@@ -492,7 +492,7 @@ See [Settings](../../settings/settings) for available settings.
 
 #### Example
 
-The example below overwrites `http-proxy` and `ui-source` settings. Notice that the values must be a string.
+The example below overwrites `http-proxy` and `ui-source` settings. The values must be a `string`.
 
 ```yaml
 system_settings:

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -483,6 +483,7 @@ install:
 #### Definition
 
 You can overwrite the default Harvester system settings by configuring `system_settings`.
+See [Settings](../../settings/settings) for available settings.
 
 !!! note
     Overwriting system settings only works when Harvester is installed in "create" mode.
@@ -491,13 +492,10 @@ You can overwrite the default Harvester system settings by configuring `system_s
 
 #### Example
 
-The configuration below will automatically scan and add storage devices which will match the glob
-pattern `/dev/sd*` on every Node.
-
-!!! warning
-    All the data in these storage devices will be destroyed. Use at your own risk.
+The example below overwrites `http-proxy` and `ui-source` settings. Notice that the values must be a string.
 
 ```yaml
 system_settings:
-  auto-disk-provision-paths: "/dev/sd*"
+  http-proxy: '{"httpProxy": "http://my.proxy", "httpsProxy": "https://my.proxy", "noProxy": "some.internal.svc"}'
+  ui-source: auto
 ```

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -210,6 +210,9 @@ If no value is provided, `protocols` is set to `TLSv1.2` only and the `ciphers` 
 
 Default: none
 
+!!! note
+    See [Troubleshooting](../../troubleshooting/harvester/#i-cant-access-harvester-after-i-changed-ssltls-enabled-protocols-and-ciphers) if you have misconfigured this setting and no longer have access to Harvester GUI and API.
+
 #### Example
 
 The following example sets the enabled SSL/TLS protocols to `TLSv1.2` and `TLSv1.3` and the ciphers list to

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -178,8 +178,8 @@ ens3
 
 ## `auto-disk-provision-paths`
 
-This setting allows Harvester to automatically add disks that match the given glob pattern as VM storages.
-It's possible to provide multiple patterns by separating them with comma.
+This setting allows Harvester to automatically add disks that match the given glob pattern as VM storage.
+It's possible to provide multiple patterns by separating them with a comma.
 
 !!! warning
     - This setting is applied to **every Node** in the cluster.
@@ -189,7 +189,7 @@ Default: none
 
 #### Example
 
-The following example, will add disks matching the glob pattern `/dev/sd*` or `/dev/hd*`:
+The following example will add disks matching the glob pattern `/dev/sd*` or `/dev/hd*`:
 
 ```
 /dev/sd*,/dev/hd*

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -189,7 +189,7 @@ Default: none
 
 #### Example
 
-Add disks matches glob pattern `/dev/sd*` or `/dev/hd*`:
+The following example, will add disks matching the glob pattern `/dev/sd*` or `/dev/hd*`:
 
 ```
 /dev/sd*,/dev/hd*
@@ -205,14 +205,14 @@ The following options and values can be set:
 
 - `ciphers`: Enabled ciphers. See NGINX Ingress Controller's configs [`ssl-ciphers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-ciphers) for supported input.
 
-If no value is provided, default protocols are set to `TLSv1.2` only and ciphers are
+If no value is provided, `protocols` is set to `TLSv1.2` only and the `ciphers` list is
 `ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305`.
 
 Default: none
 
 #### Example
 
-Set SSL/TLS enabled protocols to `TLSv1.2` and `TLSv1.3` and enabled ciphers to
+The following example sets the enabled SSL/TLS protocols to `TLSv1.2` and `TLSv1.3` and the ciphers list to
 `ECDHE-ECDSA-AES128-GCM-SHA256` and `ECDHE-ECDSA-CHACHA20-POLY1305`.
 
 ```

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -5,8 +5,8 @@ You can modify the custom resource `settings.harvesterhci.io` from the Dashboard
 
 ## `backup-target`
 
-This setting allows you to set a custom backup target to store VM backups. It supports NFS and S3. 
-For further information, please refer to the [Longhorn documentation][longhorn-backup-target]. 
+This setting allows you to set a custom backup target to store VM backups. It supports NFS and S3.
+For further information, please refer to the [Longhorn documentation][longhorn-backup-target].
 
 Default: none
 
@@ -34,7 +34,7 @@ Default: `{}`
 
 The following options and values can be set:
 
-- Proxy URL for HTTP requests: `"httpProxy": "http://<username>:<pswd>@<ip>:<port>"` 
+- Proxy URL for HTTP requests: `"httpProxy": "http://<username>:<pswd>@<ip>:<port>"`
 - Proxy URL for HTTPS requests: `"httpsProxy": "https://<username>:<pswd>@<ip>:<port>"`
 - Comma-separated list of hostnames and/or CIDRs: `"noProxy": "<hostname | CIDR>"`
 
@@ -50,7 +50,7 @@ The following options and values can be set:
 
 ## `log-level`
 
-This setting allows you to configure the log level for the Harvester server. 
+This setting allows you to configure the log level for the Harvester server.
 
 Default: `info`
 
@@ -126,7 +126,7 @@ https://your.static.dashboard-ui/index.html
 
 ## `ui-source`
 
-This setting allows you to configure how to load the UI source. 
+This setting allows you to configure how to load the UI source.
 
 The following values can be set:
 
@@ -142,7 +142,7 @@ external
 
 ## `upgrade-checker-enabled`
 
-This setting allows you to automatically check if there's an upgrade available for Harvester. 
+This setting allows you to automatically check if there's an upgrade available for Harvester.
 
 Default: `true`
 
@@ -174,4 +174,50 @@ Default: none
 
 ```
 ens3
+```
+
+## `auto-disk-provision-paths`
+
+This setting allows Harvester to automatically add disks that match the given glob pattern as VM storages.
+It's possible to provide multiple patterns by separating them with comma.
+
+!!! warning
+    - This setting is applied to **every Node** in the cluster.
+    - All the data in these storage devices **will be destroyed**. Use at your own risk.
+
+Default: none
+
+#### Example
+
+Add disks matches glob pattern `/dev/sd*` or `/dev/hd*`:
+
+```
+/dev/sd*,/dev/hd*
+```
+
+## `ssl-parameters`
+
+This setting allows you to change the enabled SSL/TLS protocols and ciphers of Harvester GUI and API.
+
+The following options and values can be set:
+
+- `protocols`: Enabled protocols. See NGINX Ingress Controller's configs [`ssl-protocols`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-protocols) for supported input.
+
+- `ciphers`: Enabled ciphers. See NGINX Ingress Controller's configs [`ssl-ciphers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-ciphers) for supported input.
+
+If no value is provided, default protocols are set to `TLSv1.2` only and ciphers are
+`ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305`.
+
+Default: none
+
+#### Example
+
+Set SSL/TLS enabled protocols to `TLSv1.2` and `TLSv1.3` and enabled ciphers to
+`ECDHE-ECDSA-AES128-GCM-SHA256` and `ECDHE-ECDSA-CHACHA20-POLY1305`.
+
+```
+{
+  "protocols": "TLSv1.2 TLSv1.3",
+  "ciphers": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305"
+}
 ```

--- a/docs/troubleshooting/harvester.md
+++ b/docs/troubleshooting/harvester.md
@@ -26,3 +26,37 @@ You can access the embedded Longhorn UI via `https://{{HARVESTER_IP}}/dashboard/
 
 !!! note
     We only support to use the embedded Longhorn UI for debugging and validation purpose .
+
+## I can't access Harvester after I changed SSL/TLS enabled protocols and ciphers
+
+If you changed
+[SSL/TLS enabled protocols and ciphers settings](../../settings/settings/#ssl-parameters)
+and you no longer have access to Harvester GUI and API,
+it's highly possible that NGINX Ingress Controller has stopped working due to the misconfigured SSL/TLS protocols and ciphers.
+Follow these steps to reset the setting:
+
+1. Following [FAQ](../../faq/) to SSH into Harvester node and switch to `root` user.
+```
+$ sudo -s
+```
+2. Editing setting `ssl-parameters` manually using `kubectl`:
+```
+# kubectl edit settings ssl-parameters
+```
+3. Deleting the line `value: ...` so that NGINX Ingress Controller
+will use the default protocols and ciphers.
+```
+apiVersion: harvesterhci.io/v1beta1
+default: '{}'
+kind: Setting
+metadata:
+  name: ssl-parameters
+...
+value: '{"protocols":"TLS99","ciphers":"WRONG_CIPHER"}' # <- Delete this line
+```
+4. Save the change and you should see the following response after exited from the editor:
+```
+setting.harvesterhci.io/ssl-parameters edited
+```
+
+You can further check the logs of Pod `rke2-ingress-nginx-controller` to see if NGINX Ingress Controller is working correctly.

--- a/docs/troubleshooting/harvester.md
+++ b/docs/troubleshooting/harvester.md
@@ -54,7 +54,7 @@ metadata:
 ...
 value: '{"protocols":"TLS99","ciphers":"WRONG_CIPHER"}' # <- Delete this line
 ```
-4. Save the change and you should see the following response after exited from the editor:
+4. Save the change and you should see the following response after exit from the editor:
 ```
 setting.harvesterhci.io/ssl-parameters edited
 ```


### PR DESCRIPTION
- Add systems settings `auto-disk-provision-paths` and `ssl-parameters`.
- Reference the system settings page in installer config `system_settings`.
- Add troubleshooting guide for resetting `ssl-parameters`
- Fix several trailing spaces.