### PR TITLE
Update VIP

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -88,6 +88,10 @@ The URL of the Harvester server to join as an agent.
 
 This configuration is mandatory when the installation is in `JOIN` mode. It tells the Harvester installer where the main server is.
 
+!!! note
+    To ensure a high availability (HA) Harvester cluster,
+    either use [VIP](./#installvip) of the Harvester main server or a domain name in `server_url`.
+
 #### Example
 
 ```yaml

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -92,7 +92,7 @@ install:
         miimon: 100
   device: /dev/sda
   iso_url: http://10.100.0.10/harvester/harvester-<version>-amd64.iso
-  vip: 10.100.0.100       # The VIP to access the Harvester GUI. Make sure the IP is free to use.
+  vip: 10.100.0.99        # The VIP to access the Harvester GUI. Make sure the IP is free to use.
   vip_mode: static        # Or dhcp, check configuration file for more information.
 ```
 
@@ -119,7 +119,7 @@ Create a [Harvester configuration file](./harvester-configuration.md) called `co
 
 ```YAML
 # cat /usr/share/nginx/html/harvester/config-join.yaml
-server_url: https://10.100.0.130:8443
+server_url: https://10.100.0.99:8443  # Should be the VIP set up in "CREATE" config
 token: token
 os:
   hostname: node2


### PR DESCRIPTION
- Provide a reasonable VIP for PXE installation (outside of the DHCP range).

- Users should use VIP as `server_url` in PXE installation.