### PR TITLE
Update docs for cluster networks

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -509,3 +509,33 @@ system_settings:
   http-proxy: '{"httpProxy": "http://my.proxy", "httpsProxy": "https://my.proxy", "noProxy": "some.internal.svc"}'
   ui-source: auto
 ```
+
+### `cluster_networks`
+
+#### Definition
+
+You can setup the default network in Harvester by configuring `cluster_networks`. Network configuration reference:
+
+- `vlan`: Setup for VLAN network. The following fields are supported:
+    - `enable`: enable VLAN network settings or not. Default value: `false`.
+    - `description`: Additional information for `ClusterNetworks`. Default value: "".
+    - `config`: `ClusterNetworks` configuration to be used. Valid configuration fields are:
+        - `defaultPhysicalNIC` (string, required): assign a physical NIC to be external entry of VLAN network.
+
+!!! note
+    To configure the `cluster_networks`, Harvester needs to be installed in "create" mode.
+    If you install Harvester in "join" mode, this setting is ignored.
+    Installing in "join" mode will apply the `cluster_networks` configuration from the existing Harvester system.
+
+#### Example
+
+The following example sets the default physical NIC name of the VLAN network:
+
+```yaml
+cluster_networks:
+  vlan:
+    enable: true
+    description: "some description about this cluster network"
+    config:
+      defaultPhysicalNIC: ens3
+```

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -512,6 +512,8 @@ system_settings:
 
 ### `cluster_networks`
 
+_Available as of v1.0.1_
+
 #### Definition
 
 You can setup the default network in Harvester by configuring `cluster_networks`. Network configuration reference:

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -229,18 +229,6 @@ Default: `https://harvester-upgrade-responder.rancher.io/v1/checkupgrade`
 https://your.upgrade.checker-url/v99/checkupgrade
 ```
 
-## `vlan`
-
-This setting allows you to configure the default physical NIC name of the VLAN network.
-
-Default: none
-
-#### Example
-
-```
-ens3
-```
-
 ## `auto-disk-provision-paths` [Experimental]
 
 This setting allows Harvester to automatically add disks that match the given glob pattern as VM storage.


### PR DESCRIPTION
related to https://github.com/harvester/harvester/issues/1739
remove system_settings vlan option
add cluster network in install config example
if we have more kind of cluster network, we can add a new page to
descibe detail cluster network setting.

depends: 
- [x] https://github.com/harvester/harvester-installer/pull/227

Signed-off-by: Date Huang <date.huang@suse.com>