### PR TITLE
Fixed Code block malformed from last commit

### DIFF
--- a/docs/dev/dev-mode.md
+++ b/docs/dev/dev-mode.md
@@ -22,6 +22,7 @@ Description: Developer mode (dev mode) is intended to be used for testing and de
    KUBELET_ROOT_DIR="path to your kubelet root dir"
    echo "${KUBELET_ROOT_DIR} /var/lib/kubelet none bind 0 0" >> /etc/fstab
    mkdir -p /var/lib/kubelet && mount -a
+   ```
 - [**Multus**](https://kubernetes.io/docs/concepts/cluster-administration/networking/#multus-a-multi-network-plugin) is installed across your cluster and a corresponding `NetworkAttachmentDefinition` CRD is created.
 - The Harvester Chart already contains the Kubevirt and Longhorn
 


### PR DESCRIPTION
Due to the last commit in the docs, the code block closing is broken. GitHub shows the code block correctly but not the generated website.

This pull request fixes that by adding the necessary code blocking closing.