### PR TITLE
Add "Useful Kernel Parameters" section to PXE installation

### DIFF
--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -300,3 +300,17 @@ boot
 ```
 
 The parameter `initrd=harvester-<version>-initrd` is required.
+
+## Useful Kernel Parameters
+
+Besides Harvester configuration, you can also specify other kernal parameters that are useful in different scenarios.
+See also [dracut.cmdline(7)](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
+
+### `ip=dhcp`
+
+If you have multiple network interfaces, you could add `ip=dhcp` parameter to get IP from DHCP server from all interfaces.
+
+### `rd.net.dhcp.retry=<cnt>`
+
+Failing to get IP from DHCP server would cause iPXE booting to fail. You can add parameter `rd.net.dhcp.retry=<cnt>`
+to retry DHCP request for `<cnt>` times.

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -303,14 +303,14 @@ The parameter `initrd=harvester-<version>-initrd` is required.
 
 ## Useful Kernel Parameters
 
-Besides Harvester configuration, you can also specify other kernal parameters that are useful in different scenarios.
+Besides the Harvester configuration, you can also specify other kernel parameters that are useful in different scenarios.
 See also [dracut.cmdline(7)](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
 
 ### `ip=dhcp`
 
-If you have multiple network interfaces, you could add `ip=dhcp` parameter to get IP from DHCP server from all interfaces.
+If you have multiple network interfaces, you could add the `ip=dhcp` parameter to get IP from the DHCP server from all interfaces.
 
 ### `rd.net.dhcp.retry=<cnt>`
 
-Failing to get IP from DHCP server would cause iPXE booting to fail. You can add parameter `rd.net.dhcp.retry=<cnt>`
+Failing to get IP from the DHCP server would cause iPXE booting to fail. You can add parameter `rd.net.dhcp.retry=<cnt>`
 to retry DHCP request for `<cnt>` times.


### PR DESCRIPTION
Some kernel parameters can be added while installing Harvester via PXE to improve the stability of PXE installation. It's better to document it somewhere.

## Related issues
- https://github.com/harvester/harvester/issues/1363