### PR TITLE
doc: Update README To Assist In Local Dev Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ This website is built using [Material for MkDocs](https://squidfunk.github.io/mk
 ## Installation
 
 Please refer to this [doc](https://squidfunk.github.io/mkdocs-material/customization/#environment-setup) to set up your local development environment.
-
+After following those instructions, while in the same `mkdocs-material` repository on your local machine, please additionally install:
+```
+pip install mkdocs-render-swagger-plugin
+```
+As referenced [here](https://github.com/bharel/mkdocs-render-swagger-plugin).
 
 ## Local Development
 


### PR DESCRIPTION
* updates the readme to assist further in local development setup,
  mentioning that the mkdocs-render-swagger-plugin is an additional
  dependency that isn't documented within the mkdocs-material
  environment setup instructions provided.

Resolves: docs/improve-local-dev-info-in-readme