### PR TITLE
Add upgrade support matrix and air-gapped method

### DIFF
--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -11,7 +11,16 @@ Description: Harvester provides two ways to upgrade. Users can either upgrade us
 
 # Upgrading Harvester
 
-This document describes how to upgrade from Harvester `v1.0.0` to `v1.0.1`.
+## Upgrade support matrix
+
+The following table shows the upgrade path of all supported versions.
+
+| Upgrade from version | Supported new version(s) |
+|----------------------|--------------------------|
+| [v1.0.1](./v1-0-1-to-v1-0-2.md) | v1.0.2        |
+| [v1.0.0](./v1-0-0-to-v1-0-1.md) | v1.0.1        |
+
+## Start an upgrade
 
 Note we are still working towards zero-downtime upgrade, due to some known issues please follow the steps below before you upgrade your Harvester cluster:
 
@@ -48,43 +57,9 @@ Note we are still working towards zero-downtime upgrade, due to some known issue
     - NICs that connect to a PCI bridge might be renamed after an upgrade. Please check the [knowledge base article](https://harvesterhci.io/kb/nic-naming-scheme) for further information.
 
 
-## Create a version
-
-- Log in to one of your server nodes.
-- Become root and create a version:
-    ```
-    rancher@node1:~> sudo -i
-
-    node1:~ # kubectl create -f https://releases.rancher.com/harvester/v1.0.1/version.yaml
-    version.harvesterhci.io/1.0.1 created
-    ```
-
-    !!!note
-
-        By default, the ISO image is downloaded from the Harvester release server. To speed up the upgrade and make the upgrade progress smoother, the user can also download the ISO file to a local HTTP server first and substitute the `isoURL` value in the `version.yaml` manifest.
-
-        e.g., 
-
-        ```
-        # Download the ISO from release server first, assume it's store in http://10.10.0.1/harvester.iso
-        $ sudo -i
-        $ curl -fL https://releases.rancher.com/harvester/v1.0.1/version.yaml -o version.yaml
-        $ vim version.yaml 
-        apiVersion: harvesterhci.io/v1beta1
-        kind: Version
-        metadata:
-          name: v1.0.1
-          namespace: harvester-system
-        spec:
-          isoChecksum: <SHA-512 checksum of the ISO> 
-          isoURL: http://10.10.0.1/harvester.iso
-          releaseDate: 20220408
-        ```
-
-
-## Start the upgrade
-
 - Make sure to read the Warning paragraph at the top of this document first.
+- Harvester checks if there are new upgradable versions periodically. If there are new versions, an upgrade button shows up on the Dashboard page.
+    - If the cluster is in an air-gapped environment, please see [Prepare an air-gapped upgrade](#prepare-an-air-gapped-upgrade) section first. You can also speed up the ISO download by using the approach in that section.
 - Navigate to Harvester GUI and click the upgrade button on the Dashboard page.
 
     ![](./assets/upgrade_button.png)
@@ -96,93 +71,39 @@ Note we are still working towards zero-downtime upgrade, due to some known issue
 - Click the circle on the top to display the upgrade progress.
     ![](./assets/upgrade_progress.png)
 
-## Known issues
 
-### Fail to download upgrade image
+## Prepare an air-gapped upgrade
 
-- **Description**
+!!!warning
 
-    Downloading the upgrade image can't complete.
+        Make sure to check [Upgrade support matrix](#upgrade-support-matrix) section first about upgradable versions.
 
-    ![](./assets/known_issue_downloading_image_failure.png)
+- Download a Harvester ISO file from [relaese pages](https://github.com/harvester/harvester/releases).
+- Save the ISO to a local HTTP server. Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
+- Download the version file from release pages, for example, `https://releases.rancher.com/harvester/{version}/version.yaml`
 
-- **Workaround**
-
-    We can delete the current upgrade and start over.
-    
-    ```
-    # log in to one of the server nodes
-    $ sudo -i
-
-    # list current upgrade, the name changes between deployments
-    $ kubectl get upgrades.harvesterhci.io -n harvester-system
-    NAMESPACE          NAME                 AGE
-    harvester-system   hvst-upgrade-77cks   119m
-
-    $ kubectl delete upgrades.harvesterhci.io hvst-upgrade-77cks -n harvester-system
-    ```
-
-    We recommend mirroring the ISO file to a local webserver, please check the notes in the [previous section](#create-a-version).
-
-### Stuck in **Upgrading System Service**
-
-- **Description**
-    - The upgrade is stuck at **Upgrading System service**.
-    - Similar logs are found in rancher pods:
+    - Replace `isoURL` value in the `version.yaml` file:
 
         ```
-        [ERROR] available chart version (100.0.2+up0.3.8) for fleet is less than the min version (100.0.3+up0.3.9-rc1) 
-        [ERROR] Failed to find system chart fleet will try again in 5 seconds: no chart name found
+        apiVersion: harvesterhci.io/v1beta1
+        kind: Version
+        metadata:
+          name: v1.0.2
+          namespace: harvester-system
+        spec:
+          isoChecksum: <SHA-512 checksum of the ISO> 
+          isoURL: http://10.10.0.1/harvester.iso  # change to local ISO URL
+          releaseDate: 20220512
         ```
 
-- **Workaround**
+    - Assume the file is hosted at `http://10.10.0.1/version.yaml`.
 
-    Delete rancher cluster repositories and restart rancher pods.
-
-      ```
-      # login to a server node and become root first
-      kubectl delete clusterrepos.catalog.cattle.io rancher-charts
-      kubectl delete clusterrepos.catalog.cattle.io rancher-rke2-charts
-      kubectl delete clusterrepos.catalog.cattle.io rancher-partner-charts
-      kubectl delete settings.management.cattle.io chart-default-branch
-      kubectl rollout restart deployment rancher -n cattle-system
-      ```
-
-- **Related issues**
-    - [[BUG] Rancher upgrade fail: Failed to find system chart "fleet"](https://github.com/harvester/harvester/issues/2011)
-
-
-### VMs fail to migrate
-
-- **Description**
-    - A node keeps waiting in `Pre-draining` state.
-    - There are VMs on that node (checking for `virt-launcher-xxx` pods) and they can't be live-migrated out of the node.
-
-- **Workaround**
-
-    Shutdown the VMs, you can do this by:
-
-      - Using the GUI.
-      - Using the `virtctl` command.
-
-- **Related issues**
-    - [[BUG] Upgrade: VMs fail to live-migrate to other hosts in some cases](https://github.com/harvester/harvester/issues/2029)
-
-### fleet-local/local: another operation (install/upgrade/rollback) is in progress 
-
-- **Description**
-
-    You see bundles have `fleet-local/local: another operation (install/upgrade/rollback) is in progress` status in the output:
+- Log in to one of your control plane nodes.
+- Become root and create a version:
 
     ```
-    kubectl get bundles -A
+    rancher@node1:~> sudo -i
+    rancher@node1:~> kubectl create -f http://10.10.0.1/version.yaml
     ```
 
-- **Related issues**
-    - [[BUG] Upgrade: rancher-monitoring charts can't be upgraded](https://github.com/harvester/harvester/issues/1983)
-
-
-### Single node upgrade might fail if node name is too long (>24 characters)
-
-- **Related issues**
-    - [https://github.com/harvester/harvester/issues/2114](https://github.com/harvester/harvester/issues/2114)
+- An upgrade button should show up on the Harvester GUI Dashboard page.

--- a/docs/upgrade/v1-0-0-to-v1-0-1.md
+++ b/docs/upgrade/v1-0-0-to-v1-0-1.md
@@ -1,0 +1,177 @@
+# Upgrade from v1.0.0 to v1.0.1
+
+This document describes how to upgrade from Harvester `v1.0.0` to `v1.0.1`.
+
+Note we are still working towards zero-downtime upgrade, due to some known issues please follow the steps below before you upgrade your Harvester cluster:
+
+!!!warning
+
+    - Before you upgrade your Harvester cluster, we highly recommend:
+        - Shutting down all your VMs (Harvester GUI -> Virtual Machines -> Select VMs -> Actions -> Stop).
+        - Back up your VMs.
+    - Do not operate the cluster during an upgrade. For example, creating new VMs, uploading new images, etc.
+    - Make sure your hardware meets the **preferred** [hardware requirements](../index.md#hardware-requirements). This is due to there will be intermediate resources consumed by an upgrade.
+    - Make sure each node has at least 25 GB of free space (`df -h /usr/local/`).
+
+!!!warning
+
+    - Make sure all nodes' times are in sync. Using an NTP server to synchronize time is recommended. If an NTP server is not configured during the installation, you can manually add an NTP server **on each node**:
+
+        ```
+        $ sudo -i
+
+        # Add time servers
+        $ vim /etc/systemd/timesyncd.conf
+        [ntp]
+        NTP=0.pool.ntp.org
+
+        # Enable and start the systemd-timesyncd
+        $ timedatectl set-ntp true
+
+        # Check status
+        $ timedatectl status
+        ```
+
+!!!warning
+
+    - NICs that connect to a PCI bridge might be renamed after an upgrade. Please check the [knowledge base article](https://harvesterhci.io/kb/nic-naming-scheme) for further information.
+
+
+## Create a version
+
+- Log in to one of your server nodes.
+- Become root and create a version:
+    ```
+    rancher@node1:~> sudo -i
+
+    node1:~ # kubectl create -f https://releases.rancher.com/harvester/v1.0.1/version.yaml
+    version.harvesterhci.io/1.0.1 created
+    ```
+
+    !!!note
+
+        By default, the ISO image is downloaded from the Harvester release server. To speed up the upgrade and make the upgrade progress smoother, the user can also download the ISO file to a local HTTP server first and substitute the `isoURL` value in the `version.yaml` manifest.
+
+        e.g., 
+
+        ```
+        # Download the ISO from release server first, assume it's store in http://10.10.0.1/harvester.iso
+        $ sudo -i
+        $ curl -fL https://releases.rancher.com/harvester/v1.0.1/version.yaml -o version.yaml
+        $ vim version.yaml 
+        apiVersion: harvesterhci.io/v1beta1
+        kind: Version
+        metadata:
+          name: v1.0.1
+          namespace: harvester-system
+        spec:
+          isoChecksum: <SHA-512 checksum of the ISO> 
+          isoURL: http://10.10.0.1/harvester.iso
+          releaseDate: 20220408
+        ```
+
+
+## Start the upgrade
+
+- Make sure to read the Warning paragraph at the top of this document first.
+- Navigate to Harvester GUI and click the upgrade button on the Dashboard page.
+
+    ![](./assets/upgrade_button.png)
+
+- Select a version to start upgrading.
+
+    ![](./assets/upgrade_select_version.png){: style="width:50%"}
+
+- Click the circle on the top to display the upgrade progress.
+    ![](./assets/upgrade_progress.png)
+
+## Known issues
+
+### Fail to download upgrade image
+
+- **Description**
+
+    Downloading the upgrade image can't complete.
+
+    ![](./assets/known_issue_downloading_image_failure.png)
+
+- **Workaround**
+
+    We can delete the current upgrade and start over.
+    
+    ```
+    # log in to one of the server nodes
+    $ sudo -i
+
+    # list current upgrade, the name changes between deployments
+    $ kubectl get upgrades.harvesterhci.io -n harvester-system
+    NAMESPACE          NAME                 AGE
+    harvester-system   hvst-upgrade-77cks   119m
+
+    $ kubectl delete upgrades.harvesterhci.io hvst-upgrade-77cks -n harvester-system
+    ```
+
+    We recommend mirroring the ISO file to a local webserver, please check the notes in the [previous section](#create-a-version).
+
+### Stuck in **Upgrading System Service**
+
+- **Description**
+    - The upgrade is stuck at **Upgrading System service**.
+    - Similar logs are found in rancher pods:
+
+        ```
+        [ERROR] available chart version (100.0.2+up0.3.8) for fleet is less than the min version (100.0.3+up0.3.9-rc1) 
+        [ERROR] Failed to find system chart fleet will try again in 5 seconds: no chart name found
+        ```
+
+- **Workaround**
+
+    Delete rancher cluster repositories and restart rancher pods.
+
+      ```
+      # login to a server node and become root first
+      kubectl delete clusterrepos.catalog.cattle.io rancher-charts
+      kubectl delete clusterrepos.catalog.cattle.io rancher-rke2-charts
+      kubectl delete clusterrepos.catalog.cattle.io rancher-partner-charts
+      kubectl delete settings.management.cattle.io chart-default-branch
+      kubectl rollout restart deployment rancher -n cattle-system
+      ```
+
+- **Related issues**
+    - [[BUG] Rancher upgrade fail: Failed to find system chart "fleet"](https://github.com/harvester/harvester/issues/2011)
+
+
+### VMs fail to migrate
+
+- **Description**
+    - A node keeps waiting in `Pre-draining` state.
+    - There are VMs on that node (checking for `virt-launcher-xxx` pods) and they can't be live-migrated out of the node.
+
+- **Workaround**
+
+    Shutdown the VMs, you can do this by:
+
+      - Using the GUI.
+      - Using the `virtctl` command.
+
+- **Related issues**
+    - [[BUG] Upgrade: VMs fail to live-migrate to other hosts in some cases](https://github.com/harvester/harvester/issues/2029)
+
+### fleet-local/local: another operation (install/upgrade/rollback) is in progress 
+
+- **Description**
+
+    You see bundles have `fleet-local/local: another operation (install/upgrade/rollback) is in progress` status in the output:
+
+    ```
+    kubectl get bundles -A
+    ```
+
+- **Related issues**
+    - [[BUG] Upgrade: rancher-monitoring charts can't be upgraded](https://github.com/harvester/harvester/issues/1983)
+
+
+### Single node upgrade might fail if node name is too long (>24 characters)
+
+- **Related issues**
+    - [https://github.com/harvester/harvester/issues/2114](https://github.com/harvester/harvester/issues/2114)

--- a/docs/upgrade/v1-0-1-to-v1-0-2.md
+++ b/docs/upgrade/v1-0-1-to-v1-0-2.md
@@ -1,0 +1,9 @@
+# Upgrade from v1.0.1 to v1.0.2
+
+## General information
+
+The Harvester GUI Dashboard page should have an upgrade button to perform an upgrade.
+
+## Known issues
+
+Please check [Known issues](./v1-0-0-to-v1-0-1.md#known-issues) here.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,10 @@ nav:
     - install/harvester-configuration.md
     - install/management-address.md
   - airgap.md
-  - upgrade/automatic.md
+  - Upgrade:
+    - upgrade/automatic.md
+    - upgrade/v1-0-1-to-v1-0-2.md
+    - upgrade/v1-0-0-to-v1-0-1.md
   - authentication.md
   - upload-image.md
   - host/host.md


### PR DESCRIPTION
- Add a more general upgrade section because we will use the responder to refresh available versions.
- Add an air-gapped guide.
- Add support matrix.
- Move v1.0.0 -> v1.0.1 to a dedicated section.