### PR TITLE
fix-2243 add monitoring troubleshooting

### DIFF
--- a/docs/monitoring/monitoring.md
+++ b/docs/monitoring/monitoring.md
@@ -116,3 +116,8 @@ In v1.0.0 and ealier versions, the related path and default value are not in the
 
 !!! attention
     When many VMs are deployed in one NODE, the OOM(out of memory)/abnormal restarting of prometheus-node-exporter POD(s) may be observed. In that case, you should change the `limits.memory` to a bigger value.
+
+### Troubleshooting
+
+When you encounter issues while using Monitoring, please refer [troubleshooting](../troubleshooting/monitoring.md) .
+

--- a/docs/troubleshooting/monitoring.md
+++ b/docs/troubleshooting/monitoring.md
@@ -1,0 +1,66 @@
+# Monitoring
+
+The following sections contain tips to troubleshoot Harvester Monitoring.
+
+## Monitoring is unusable
+
+When the Harvester dashboard displays nothing of the Monitoring, it may be caused by the below reasons.
+
+### Monitoring is unusable due to POD stucks in "Terminating"
+
+Harvester Monitoring related PODs are deployed randomly in the cluster NODEs, when the NODE hosting following PODs is accidentally down, the related PODs may stuck in status "Terminating", then the Monitoring is unusable from the WebUI.
+
+```
+$ kubectl get pods -n cattle-monitoring-system
+
+NAMESPACE                   NAME                                                     READY   STATUS        RESTARTS   AGE
+cattle-monitoring-system    prometheus-rancher-monitoring-prometheus-0               3/3     Terminating   0          3d23h
+cattle-monitoring-system    rancher-monitoring-admission-create-fwjn9                0/1     Terminating   0          137m
+cattle-monitoring-system    rancher-monitoring-crd-create-9wtzf                      0/1     Terminating   0          137m
+cattle-monitoring-system    rancher-monitoring-grafana-d9c56d79b-ph4nz               3/3     Terminating   0          3d23h
+cattle-monitoring-system    rancher-monitoring-grafana-d9c56d79b-t24sz               0/3     Init:0/2      0          132m
+
+cattle-monitoring-system    rancher-monitoring-kube-state-metrics-5bc8bb48bd-nbd92   1/1     Running       4          4d1h
+...
+
+```
+
+Monitoring can be recovered via using CLI commands to delete related PODs forcely, the cluster will deploy new PODs to replace them.
+
+```
+
+Delete each none-running POD in namespace cattle-monitoring-system.
+
+$ kubectl delete pod --force -n cattle-monitoring-system prometheus-rancher-monitoring-prometheus-0
+
+pod "prometheus-rancher-monitoring-prometheus-0" force deleted
+
+
+$ kubectl delete pod --force -n cattle-monitoring-system rancher-monitoring-admission-create-fwjn9
+
+$ kubectl delete pod --force -n cattle-monitoring-system rancher-monitoring-crd-create-9wtzf
+
+$ kubectl delete pod --force -n cattle-monitoring-system rancher-monitoring-grafana-d9c56d79b-ph4nz 
+
+$ kubectl delete pod --force -n cattle-monitoring-system rancher-monitoring-grafana-d9c56d79b-t24sz
+```
+
+Wait a few minutes, the new PODs are created and become ready. The Monitoring dashboard will be usable again.
+
+```
+$ kubectl get pods -n cattle-monitoring-system 
+
+NAME                                                     READY   STATUS     RESTARTS   AGE
+prometheus-rancher-monitoring-prometheus-0               0/3     Init:0/1   0          98s
+rancher-monitoring-grafana-d9c56d79b-cp86w               0/3     Init:0/2   0          27s
+...
+
+$ kubectl get pods -n cattle-monitoring-system 
+
+NAME                                                     READY   STATUS    RESTARTS   AGE
+prometheus-rancher-monitoring-prometheus-0               3/3     Running   0          7m57s
+rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0          6m46s
+...
+
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
     - troubleshooting/installation.md
     - troubleshooting/harvester.md
     - troubleshooting/os.md
+    - troubleshooting/monitoring.md
   - Reference:
     - reference/api.md
   - faq.md


### PR DESCRIPTION
Add monitoring troubleshooting, introduce the operations to recover from the issue.

Issue: https://github.com/harvester/harvester/issues/2243  rancher-monitoring is unusable when hosting NODE is (accidently) down