### PR TITLE
Remove space from overview.md which breaks link

### DIFF
--- a/docs/networking/best-practice/overview.md
+++ b/docs/networking/best-practice/overview.md
@@ -14,7 +14,7 @@ Description: Harvester is built on top of Kubernetes, and uses the [CNI](https:/
 
 # Overview
 
-In a real production environment, we generally recommend that you have multiple NICs in your machine, one for node access and one for VM networking. If your machine has multiple NICs, please refer to [multiple NICs](multiple-nics-vlan-aware-switch.md) for best practices. Otherwise, please refer to [Single NIC] (single-nic-vlan-aware-switch.md) best practice.
+In a real production environment, we generally recommend that you have multiple NICs in your machine, one for node access and one for VM networking. If your machine has multiple NICs, please refer to [multiple NICs](multiple-nics-vlan-aware-switch.md) for best practices. Otherwise, please refer to [Single NIC](single-nic-vlan-aware-switch.md) best practice.
 
 !!! note
     If you configure a `bond` interface with multiple NICs, please refer to the single NIC scenario, unless the Harvester node has multiple `bond` interfaces.


### PR DESCRIPTION
Removed space character in link to Single NIC best practice doc which broke the link.