### PR TITLE
Network Hardware Interface MAC Support

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -54,6 +54,7 @@ install:
     harvester-mgmt:
       interfaces:
       - name: ens5
+        hwAddr: "B8:CA:3A:6A:64:7C"
       method: dhcp
   force_efi: true
   device: /dev/vda
@@ -331,6 +332,7 @@ the values are configurations for each network. Valid configuration fields are:
 - `gateway`: Gateway for this network. Required if `static` method is chosen.
 - `interfaces`: An array of interface names. If provided, the installer then combines these NICs into a single logical bonded interface.
     - `interfaces.name`: The name of the slave interface for the bonded network.
+    - `interfaces.hwAddr`: The hardware MAC address of the interface.
 - `bond_options`: Options for bonded interfaces. Refer to [here](https://www.kernel.org/doc/Documentation/networking/bonding.txt) for more info. If not provided, the following options would be used:
     - `mode: balance-tlb`
     - `miimon: 100`
@@ -352,6 +354,7 @@ install:
     harvester-mgmt:       # The management bond name. This is mandatory.
       interfaces:
       - name: ens5
+        hwAddr: "B8:CA:3A:6A:64:7D"     # The hwAddr is optional
       method: dhcp
       bond_options:
         mode: balance-tlb
@@ -360,6 +363,7 @@ install:
     harvester-vlan:       # The VLAN network bond name. User can then input `harvester-vlan` in the VLAN NIC setting in the GUI.
       interfaces:
       - name: ens6
+        hwAddr: "B8:CA:3A:6A:64:7E"     # The hwAddr is optional
       method: none
       bond_options:
         mode: balance-tlb
@@ -367,6 +371,7 @@ install:
     bond0:
       interfaces:
       - name: ens8
+        hwAddr: "B8:CA:3A:6A:64:7F"     # The hwAddr is optional
       method: static
       ip: 10.10.18.2
       subnet_mask: 255.255.255.0


### PR DESCRIPTION
**Reason:**
Show that through the configuration on a Harvester Configuration file that you can specify the interface's MAC address.
Since within the source code, we do allow for it via: 
https://github.com/harvester/harvester-installer/blob/v1.0.3-rc2/pkg/config/config.go#L18

**Tested Locally:**
![show-in-docs-you-can-add-hwaddr](https://user-images.githubusercontent.com/5370752/182945978-268f612d-d671-4fc2-894b-169847ef6d4b.png)


Resolves: docs/harvester-config-with-hwaddr-for-network-interfaces