### PR TITLE
Introduce Info On Harvester Configuration Priority

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -79,6 +79,11 @@ Below is a reference of all configuration keys.
 !!!warning
     **Security Risks**: The configuration file contains credentials which should be kept secret. Please do not make the configuration file publicly accessible.
 
+!!!note
+    **Configuration Priority**: When you provide a remote Harvester Configuration file during the install of Harvester, the Harvester Configuration file will not
+    overwrite the values for the inputs you had previously filled out and selected.  Priority is given to the values that you input during the guided install.
+    For instance, if you have in your Harvester Configuration file specified `os.hostname` and during install you fill in the field of `hostname` when prompted,
+    the value that you filled in will take priority over your Harvester Configuration's `os.hostname`.  
 
 ### `server_url`
 


### PR DESCRIPTION
* a small note blurb added about configuration priority

Resolves: docs/specify-configuration-priority

**Tested Locally:**
![update-configuration-priority-info](https://user-images.githubusercontent.com/5370752/183143942-b59b7c40-1be6-4db5-880e-66a2c29bed49.png)

We may want to change the wording a bit, but I just wanted to scaffold this PR as an idea of what we might say that could convey that information :smile:  - super willing to change the text to something that might work better :+1: :smile: !
