### PR TITLE
Possibly Bump Minimum Resource CPU Spec for v1.1.0?

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ To get the Harvester server up and running, the following minimum hardware is re
 
 | Type | Requirements                                                                                                                                                                                               |
 |:---|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CPU | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum for testing; 16-core or above preferred for production                                                                 |
+| CPU | x86_64 only. Hardware-assisted virtualization is required. 12-core processor minimum for testing; 16-core or above preferred for production                                                                 |
 | Memory | 32 GB minimum; 64 GB or above preferred                                                                                                                                                                    |
 | Disk Capacity | 200 GB minimum for testing; 500 GB or above preferred for production                                                                                                                                       |
 | Disk Performance | 5,000+ random IOPS per disk (SSD/NVMe). Management nodes (first three nodes) must be [fast enough for etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd) |

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -14,7 +14,7 @@ To get the Harvester server up and running the following minimum hardware is req
   
 | Type             | Requirements                                                                                                                                                                                          |
 |:-----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CPU              | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum for testing; 16-core or above preferred for production                                                            |
+| CPU              | x86_64 only. Hardware-assisted virtualization is required. 12-core processor minimum for testing; 16-core or above preferred for production                                                            |
 | Memory           | 32 GB minimum, 64 GB or above preferred                                                                                                                                                               |
 | Disk Capacity    | 200 GB minimum for testing, 500 GB or above preferred for production                                                                                                                                  |
 | Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for Etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd) |


### PR DESCRIPTION
### Description:
Based on:
https://github.com/harvester/harvester/issues/3041#issuecomment-1291748147

Should we be bumping the minimum core-count spec on CPU for testing for v1.1.0?

Super open to close this PR if this is unneeded.