### PR TITLE
Possibly Mention in a note VM-Import for OpenStack Tested On Stable/Train

### DIFF
--- a/docs/advanced/vmimport.md
+++ b/docs/advanced/vmimport.md
@@ -182,3 +182,6 @@ spec:
 :::note 
 OpenStack allows users to have multiple instances with the same name. In such a scenario, users are advised to use the Instance ID. The reconciliation logic tries to perform a name-to-ID lookup when a name is used.
 :::
+:::note 
+OpenStack vm-import has been tested on version stable/train.
+:::


### PR DESCRIPTION
Possibly leave a small note to mention that OpenStack vm-import has been tested on version stable/train.
Knowing that testing will expand to other environments later.

Super open to close this PR if this is unnecessary to mention :smile: 