### PR TITLE
fix Rancher support matrix

### DIFF
--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -22,7 +22,7 @@ _Available as of v0.3.0_
 
 | Rancher Version | Supported Harvester Version | Note |
 | :--|:--|:--|
-| v2.6.9 | v1.1.0 | |
+| v2.6.9 | v1.1.0, v1.0.3 |  |
 | v2.6.6 - v2.6.8 | v1.0.3 - v1.0.1 | |
 | v2.6.5 | v1.0.2 - v1.0.1 | |
 | v2.6.4 | v1.0.1 | |


### PR DESCRIPTION
**Description:**
Fix the Rancher v2.6.9 support matrix to include v1.0.3, in Rancher v2.6.9 we have introduced the UI plugin mechanism that will allow each Harvester cluster to serve its UI assets via the Harvester API, for older versions like Harvester v1.0.3 it will just load the embedded UI when the plugin is not available.