### PR TITLE
storagenetwork: whereabouts cni is not always installed properly.

### DIFF
--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -30,11 +30,11 @@ There are some prerequisites before configuring the Harvester Storage Network se
 
 :::caution
 
-If the Harvester cluster is upgraded from v1.0.3, please check if Whereabouts CNI is installed properly before you move on to the next step. We will always recommend following this guide to check. [Issue 3168](https://github.com/harvester/harvester/issues/3168) describes that the Harvester cluster will not always install Whereabouts CNI properly.
+If the Harvester cluster was upgraded from v1.0.3, please check if Whereabouts CNI is installed properly before you move on to the next step. We will always recommend following this guide to check. [Issue 3168](https://github.com/harvester/harvester/issues/3168) describes that the Harvester cluster will not always install Whereabouts CNI properly.
 
-- We should get `ippools.whereabouts.cni.cncf.io` without errors in the following command.
+- Verify the `ippools.whereabouts.cni.cncf.io` CRD exists with the following command.
     - `kubectl get crd ippools.whereabouts.cni.cncf.io`
-- If the Harvester cluster didn't have `ippools.whereabouts.cni.cncf.io`, please add [these two CRDs](https://github.com/harvester/harvester/tree/v1.1.0/deploy/charts/harvester/dependency_charts/whereabouts/crds) before configuring `storage-network` setting.
+- If the Harvester cluster doesn't have `ippools.whereabouts.cni.cncf.io`, please add [these two CRDs](https://github.com/harvester/harvester/tree/v1.1.0/deploy/charts/harvester/dependency_charts/whereabouts/crds) before configuring `storage-network` setting.
 ```
 kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/v1.1.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_ippools.yaml
 kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/v1.1.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml

--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -28,6 +28,20 @@ There are some prerequisites before configuring the Harvester Storage Network se
 - All pods that are attached to Longhorn Volumes should be stopped.
     - Users could skip this step with the Harvester Storage Network setting. Harvester will stop Longhorn-related pods automatically.
 
+:::caution
+
+If the Harvester cluster is upgraded from v1.0.3, please check if Whereabouts CNI is installed properly before you move on to the next step. We will always recommend following this guide to check. [Issue 3168](https://github.com/harvester/harvester/issues/3168) describes that the Harvester cluster will not always install Whereabouts CNI properly.
+
+- We should get `ippools.whereabouts.cni.cncf.io` without errors in the following command.
+    - `kubectl get crd ippools.whereabouts.cni.cncf.io`
+- If the Harvester cluster didn't have `ippools.whereabouts.cni.cncf.io`, please add [these two CRDs](https://github.com/harvester/harvester/tree/v1.1.0/deploy/charts/harvester/dependency_charts/whereabouts/crds) before configuring `storage-network` setting.
+```
+kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/v1.1.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_ippools.yaml
+kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/v1.1.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+```
+
+:::
+
 ## Configuration Example
 
 - VLAN ID

--- a/docs/upgrade/v1-0-3-to-v1-1-0.md
+++ b/docs/upgrade/v1-0-3-to-v1-1-0.md
@@ -40,6 +40,8 @@ Related issue: [[BUG] Harvester Upgrade 1.0.3 to 1.1.0 does not handle multiple 
 
 - Starting from version v1.1.0, Harvester brings in the new [VLAN enhancement](https://github.com/harvester/harvester/issues/2236) feature. Due to the implementation changes, all user VMs must shut down during an upgrade. Please stop the VMs before an upgrade.
 
+- We introduce [Storage Network](../advanced/storagenetwork.md) feature in v1.1.0. Due to a [known issue](https://github.com/harvester/harvester/issues/3168), please [create required CRDs](../advanced/storagenetwork.md#prerequisites) before using the feature.
+
 :::
 
 Once there is an upgradable version, the Harvester GUI Dashboard page will show an upgrade button. For more details, please refer to [start an upgrade](./automatic.md#start-an-upgrade).


### PR DESCRIPTION
whereabouts cni & crds are not always installed properly after harvester is upgraded from v1.0.3 to v1.1.0 or above

Related issues: https://github.com/harvester/harvester/issues/3168