### PR TITLE
Update site title

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,9 +6,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 const config = {
-  title:
-    "The open source hyperconverged infrastructure (HCI) solution for a cloud native world",
-  tagline: "",
+  title: "Harvester",
+  tagline: "The open source hyperconverged infrastructure (HCI) solution for a cloud native world",
   url: "https://docs.harvesterhci.io",
   baseUrl: "/",
   onBrokenLinks: "throw",


### PR DESCRIPTION
Feedback from Slack pointed out that when viewing the docs for older versions (not the latest), the yellow banner is using a long tagline. It was suggested that "Harvester" be used instead.

> This is documentation for The open source hyperconverged infrastructure (HCI) solution for a cloud native world v1.0, which is no longer actively maintained.
For up-to-date documentation, see the [latest version](https://docs.harvesterhci.io/v1.1/vm/backup-restore) (v1.1).

The feedback also mentions that the tab titles also use the same tagline, which makes it a bit hard to switch between multiple tabs of the Harvester docs open since they're all the same.

Both elements are using the config's `title` field as the source. A subsequent PR will need to be made to address the second point so that tab titles will have the form ` <page_title> | Harvester` to allow differentiation of tab titles.