### PR TITLE
Wrap RW mode image in OS troubleshooting

### DIFF
--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -45,9 +45,11 @@ Enabling read-write mode might break your system if files are modified. Please u
     ```
 
 - Reboot the system to GRUB menu. Press ESC to stay on the menu.
+
     ![](/img/v1.1/troubleshooting/os-stop-on-first-menuentry.png)
 
 - Press `e` on first menuentry. Append `rd.cos.debugrw` to the `linux (loop0)$kernel $kernelcmd` line. Press `Ctrl + x` to boot the system.
+
     ![](/img/v1.1/troubleshooting/os-edit-first-menuentry-add-debugrw.png)
 
 ## How to permanently edit kernel parameters


### PR DESCRIPTION
A minor change to fix the weird layout:
From
<img width="971" alt="Screenshot 2022-12-23 at 2 44 08 PM" src="https://user-images.githubusercontent.com/1691518/209286315-de5209cb-71b8-4911-a5cf-24c8f341ad50.png">

To
<img width="951" alt="Screenshot 2022-12-23 at 2 46 22 PM" src="https://user-images.githubusercontent.com/1691518/209286323-71124cf4-5087-43b9-b6a2-730510538ef0.png">
