### PR TITLE
doc: Provide Admin Credential Clarity

### DIFF
--- a/docs/monitoring/monitoring.md
+++ b/docs/monitoring/monitoring.md
@@ -18,6 +18,9 @@ Also, users can click the [Grafana](http://grafana.com/) dashboard link to view 
 
 Only admin users are able to view the cluster dashboard metrics.
 
+Additionally, Grafana is provided by `rancher-monitoring`, so the default admin password is: prom-operator
+
+Reference: [values.yaml](https://github.com/rancher/charts/blob/dev-v2.7/charts/rancher-project-monitoring/1.1.0%2Bup0.2.0-rc1/values.yaml#L698)
 :::
 
 

--- a/versioned_docs/version-v1.0/monitoring/monitoring.md
+++ b/versioned_docs/version-v1.0/monitoring/monitoring.md
@@ -18,6 +18,9 @@ Also, users can click the [Grafana](http://grafana.com/) dashboard link to view 
 
 Only admin users are able to view the cluster dashboard metrics.
 
+Additionally, Grafana is provided by `rancher-monitoring`, so the default admin password is: prom-operator
+
+Reference: [values.yaml](https://github.com/rancher/charts/blob/dev-v2.7/charts/rancher-project-monitoring/1.1.0%2Bup0.2.0-rc1/values.yaml#L698)
 :::
 
 

--- a/versioned_docs/version-v1.1/monitoring/monitoring.md
+++ b/versioned_docs/version-v1.1/monitoring/monitoring.md
@@ -18,6 +18,9 @@ Also, users can click the [Grafana](http://grafana.com/) dashboard link to view 
 
 Only admin users are able to view the cluster dashboard metrics.
 
+Additionally, Grafana is provided by `rancher-monitoring`, so the default admin password is: prom-operator
+
+Reference: [values.yaml](https://github.com/rancher/charts/blob/dev-v2.7/charts/rancher-project-monitoring/1.1.0%2Bup0.2.0-rc1/values.yaml#L698)
 :::
 
 


### PR DESCRIPTION
* provides admin credential clarity for logging into the Grafana that is bundled in rancher-monitoring that Harvester uses, outlining the default password for the admin user as well as a link out to the Helm Chart values for the corresponding Rancher-Monitoring chart that provides Grafana

Resolves: feat/add-additional-grafana-info

Screenshot:

![Screenshot from 2023-01-24 15-52-19](https://user-images.githubusercontent.com/5370752/214447131-d5c0887a-b163-436f-8795-a34fb198fadc.png)
