### PR TITLE
#3496 remove old informations about adding network interface from install.management interface (<v1.1)

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -360,9 +360,7 @@ install:
 
 #### Definition
 
-Configure network interfaces for the host machine. Each key-value pair
-represents a network interface. The key name becomes the network name, and
-the values are configurations for each network. Valid configuration fields are:
+Configure network interfaces for the host machine. Valid configuration fields are:
 
 - `method`: Method to assign an IP to this network. The following are supported:
     - `static`: Manually assign an IP and gateway.
@@ -377,7 +375,7 @@ the values are configurations for each network. Valid configuration fields are:
     - `mode: balance-tlb`
     - `miimon: 100`
 - `mtu`: The MTU for the interface.
-- `vlan_id`: The VLAN ID for the interface
+- `vlan_id`: The VLAN ID for the interface.
 
 :::note
 

--- a/versioned_docs/version-v1.1/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/harvester-configuration.md
@@ -360,9 +360,7 @@ install:
 
 #### Definition
 
-Configure network interfaces for the host machine. Each key-value pair
-represents a network interface. The key name becomes the network name, and
-the values are configurations for each network. Valid configuration fields are:
+Configure network interfaces for the host machine. Valid configuration fields are:
 
 - `method`: Method to assign an IP to this network. The following are supported:
     - `static`: Manually assign an IP and gateway.
@@ -377,7 +375,7 @@ the values are configurations for each network. Valid configuration fields are:
     - `mode: balance-tlb`
     - `miimon: 100`
 - `mtu`: The MTU for the interface.
-- `vlan_id`: The VLAN ID for the interface
+- `vlan_id`: The VLAN ID for the interface.
 
 :::note
 


### PR DESCRIPTION
Resolves [Issue #3496](https://github.com/harvester/harvester/issues/3496)

Small change - Remove the following statement, it is no longer true as of v.1.1. Users can configure network interfaces for the host machine via install.management_interface. 
- "Each key-value pair represents a network interface. The key name becomes the network name, and the values are configurations for each network."
- This is done with install.networks in <v.1.1.