### PR TITLE
Customize for banner  EOL product versions

### DIFF
--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -19,8 +19,8 @@ function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
       id="theme.docs.versions.unreleasedVersionLabel"
       description="The label used to tell the user that he's browsing an unreleased doc version"
       values={{
-        siteTitle: <b>Harvester</b>,
-        versionLabel: <b>{versionMetadata.label}</b>,
+        siteTitle: <b>Harvester</b>, // Made title bold
+        versionLabel: <b>{versionMetadata.label}</b>, // Made version label bold
       }}>
       {
         'This is unreleased documentation for {siteTitle} {versionLabel} version.'
@@ -28,6 +28,7 @@ function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
     </Translate>
   );
 }
+// Update UnmaintainedVersionLabel function to customize banner
 function UnmaintainedVersionLabel({siteTitle, versionMetadata}) {
   let url = "https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/";
   return (
@@ -36,9 +37,9 @@ function UnmaintainedVersionLabel({siteTitle, versionMetadata}) {
       id="theme.docs.versions.unmaintainedVersionLabel"
       description="The label used to tell the user that he's browsing an unmaintained doc version"
       values={{ 
-        siteTitle: <b>Harvester</b>,
-        versionLabel: <b>{versionMetadata.label}</b>,
-        matrix: <a href={url}><b>SUSE support matrix</b></a>,
+        siteTitle: <b>Harvester</b>, // Made title bold
+        versionLabel: <b>{versionMetadata.label}</b>, // Made version label bold
+        matrix: <a href={url}><b>SUSE support matrix</b></a>, // Add URL and make URL bold
       }}>
       {
         '{siteTitle} {versionLabel} is EOL and this documentation is no longer actively maintained. For more details, refer to the {matrix}.' 

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+} from '@docusaurus/plugin-content-docs/client';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/theme-common/internal';
+function UnreleasedVersionLabel({siteTitle, versionMetadata}) {
+  return (
+    <Translate
+      id="theme.docs.versions.unreleasedVersionLabel"
+      description="The label used to tell the user that he's browsing an unreleased doc version"
+      values={{
+        siteTitle: <b>Harvester</b>,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+      }
+    </Translate>
+  );
+}
+function UnmaintainedVersionLabel({siteTitle, versionMetadata}) {
+  let url = "https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/";
+  return (
+    <div>
+    <Translate
+      id="theme.docs.versions.unmaintainedVersionLabel"
+      description="The label used to tell the user that he's browsing an unmaintained doc version"
+      values={{ 
+        siteTitle: <b>Harvester</b>,
+        versionLabel: <b>{versionMetadata.label}</b>,
+        matrix: <a href={url}><b>SUSE support matrix</b></a>,
+      }}>
+      {
+        '{siteTitle} {versionLabel} is EOL and this documentation is no longer actively maintained. For more details, refer to the {matrix}.' 
+      }
+    </Translate></div>
+  );
+}
+const BannerLabelComponents = {
+  unreleased: UnreleasedVersionLabel,
+  unmaintained: UnmaintainedVersionLabel,
+};
+function BannerLabel(props) {
+  const BannerLabelComponent =
+    BannerLabelComponents[props.versionMetadata.banner];
+  return <BannerLabelComponent {...props} />;
+}
+function LatestVersionSuggestionLabel({versionLabel, to, onClick}) {
+  return (
+    <Translate
+      id="theme.docs.versions.latestVersionSuggestionLabel"
+      description="The label used to tell the user to check the latest version"
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to={to} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.latestVersionLinkLabel"
+                description="The label used for the latest version suggestion link label">
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}>
+      {
+        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+function DocVersionBannerEnabled({className, versionMetadata}) {
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const {pluginId} = useActivePlugin({failfast: true});
+  const getVersionMainDoc = (version) =>
+    version.docs.find((doc) => doc.id === version.mainDocId);
+  const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
+  const {latestDocSuggestion, latestVersionSuggestion} =
+    useDocVersionSuggestions(pluginId);
+  // Try to link to same doc in latest version (not always possible), falling
+  // back to main doc of latest version
+  const latestVersionSuggestedDoc =
+    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        'alert alert--warning margin-bottom--md',
+      )}
+      role="alert">
+      <div>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+      </div>
+      <div className="margin-top--md">
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </div>
+    </div>
+  );
+}
+export default function DocVersionBanner({className}) {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
Customize banner for EOL product versions.
- Banner message should mention product version is EOL and provide link to support matrix. 
- Resource: https://docusaurus.io/docs/next/swizzling#ejecting
- Resolves https://github.com/harvester/harvester/issues/3696 

