### PR TITLE
Update EOL banner for the zh locale

### DIFF
--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -140,7 +140,7 @@
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "此为 {siteTitle} {versionLabel} 版的文档，现已不再积极维护。",
+    "message": "{siteTitle} {versionLabel} 已 EOL，此文档已不再积极维护。有关更多信息，请前往 {matrix}。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
@@ -392,5 +392,13 @@
   "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
     "message": "关闭导航栏",
     "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "主导航",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "文档侧边栏",
+    "description": "The ARIA label for the sidebar navigation"
   }
 }


### PR DESCRIPTION
- Also added command-generated navbar translations
- Update banner description for EOL versions (see screenshots below)

<img width="780" alt="image" src="https://github.com/harvester/docs/assets/63201949/0fb680e5-ae7a-4f35-8e5f-6ad3e4b7bb0e">

<img width="790" alt="image" src="https://github.com/harvester/docs/assets/63201949/9635db85-0208-4663-b7f5-0dfa49d7cc19">
