### PR TITLE
Add shadows to images via custom.css

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -164,3 +164,11 @@ a.btn.navbar__github::before {
 .navbar__link > svg {
   display: none !important;
 }
+
+/* Add shadows to docs images */ 
+.img_ev3q {
+  box-shadow: 10px 10px 25px rgb(100, 100, 100);
+  -moz-box-shadow: 10px 10px 25px rgb(100, 100, 100);
+  -webkit-box-shadow: 10px 10px 25px rgb(100, 100, 100);
+  -khtml-box-shadow: 10px 10px 25px rgb(100, 100, 100);
+}


### PR DESCRIPTION
### **Summary**
- Added shadows to images via src/css/custom.css. Any CSS included here will be global.
- To avoid setting a shadow to the logo, the style is based on the class ID (img_ev3q) which is set by Docusaurus when building the docs. The class ID is constant across the builds.
- Referencing https://github.com/rancher-sandbox/docs.rancherdesktop.io/pull/140