### PR TITLE
Add canonical links for /volume

### DIFF
--- a/docs/volume/clone-volume.md
+++ b/docs/volume/clone-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Clone volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+</head>
+
 After creating a volume, you can clone the volume by following the steps below:
 
 1. Click the `⋮` button and select the `Clone` option.

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Create a volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+</head>
+
 ## Create an Empty Volume
 
 ### Header Section

--- a/docs/volume/edit-volume.md
+++ b/docs/volume/edit-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Edit volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+</head>
+
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.
 
 ## Expand a Volume

--- a/docs/volume/export-volume.md
+++ b/docs/volume/export-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Export volume to image from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+</head>
+
 You can select and export an existing volume to an image by following the steps below:
 
 1. Click the `⋮` button and select the `Export Image` option.

--- a/docs/volume/volume-snapshots.md
+++ b/docs/volume/volume-snapshots.md
@@ -8,6 +8,10 @@ keywords:
 Description: Take a snapshot for a volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+</head>
+
 ## Create Volume Snapshots
 
 :::note

--- a/versioned_docs/version-v1.1/volume/clone-volume.md
+++ b/versioned_docs/version-v1.1/volume/clone-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Clone volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+</head>
+
 After creating a volume, you can clone the volume by following the steps below:
 
 1. Click the `⋮` button and select the `Clone` option.

--- a/versioned_docs/version-v1.1/volume/create-volume.md
+++ b/versioned_docs/version-v1.1/volume/create-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Create a volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+</head>
+
 ## Create an Empty Volume
 
 ### Header Section

--- a/versioned_docs/version-v1.1/volume/edit-volume.md
+++ b/versioned_docs/version-v1.1/volume/edit-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Edit volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+</head>
+
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.
 
 ## Expand a Volume

--- a/versioned_docs/version-v1.1/volume/export-volume.md
+++ b/versioned_docs/version-v1.1/volume/export-volume.md
@@ -7,6 +7,10 @@ keywords:
 Description: Export volume to image from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+</head>
+
 You can select and export an existing volume to an image by following the steps below:
 
 1. Click the `⋮` button and select the `Export Image` option.

--- a/versioned_docs/version-v1.1/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.1/volume/volume-snapshots.md
@@ -8,6 +8,10 @@ keywords:
 Description: Take a snapshot for a volume from the Volume page.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+</head>
+
 ## Create Volume Snapshots
 
 :::note


### PR DESCRIPTION
Adding canonical links to /volume section pages in Harvester.

Tied to https://github.com/harvester/docs/issues/341