### PR TITLE
Add canonical links for /install

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -11,6 +11,10 @@ keywords:
 Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+</head>
+
 ## Configuration Example
 
 Harvester configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -11,6 +11,10 @@ keywords:
 Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+</head>
+
 ## Installation Steps
 To get the Harvester ISO image, download it from the [Github releases](https://github.com/harvester/harvester/releases) page.
 

--- a/docs/install/management-address.md
+++ b/docs/install/management-address.md
@@ -7,6 +7,10 @@ keywords:
 Description: The Harvester provides a virtual IP as the management address.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+</head>
+
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.
 
 :::note

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -14,6 +14,10 @@ keywords:
 Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+</head>
+
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 
 We recommend using [iPXE](https://ipxe.org/) to perform the network boot. It has more features than the traditional PXE Boot program and is likely available in modern NIC cards. If the iPXE firmware is not available for your NIC card, the iPXE firmware images can be loaded from the TFTP server first.

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -6,6 +6,10 @@ keywords:
 - Installation Requirements
 Description: Outline the Harvester installation requirements
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+</head>
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements to install and run Harvester.
 
 ## Hardware requirements

--- a/docs/install/update-harvester-configuration.md
+++ b/docs/install/update-harvester-configuration.md
@@ -8,6 +8,10 @@ keywords:
 Description: How to update Harvester configuration after installation
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+</head>
+
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 
 
 This page describes how to edit some of the most-requested Harvester configurations. To update a configuration, you must first update the runtime value in the system and then update configuration files to make the changes persistent between reboots. 

--- a/docs/install/usb-install.md
+++ b/docs/install/usb-install.md
@@ -4,6 +4,10 @@ sidebar_label: USB Installation
 title: "USB Installation"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+</head>
+
 ## Create a bootable USB flash drive
 
 There are a couple of ways to create a USB installation flash drive.

--- a/versioned_docs/version-v0.3/install/harvester-configuration.md
+++ b/versioned_docs/version-v0.3/install/harvester-configuration.md
@@ -11,6 +11,10 @@ keywords:
 Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+</head>
+
 ## Configuration Example
 
 Harvester configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:

--- a/versioned_docs/version-v0.3/install/iso-install.md
+++ b/versioned_docs/version-v0.3/install/iso-install.md
@@ -11,6 +11,10 @@ keywords:
 Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+</head>
+
 To get the Harvester ISO, download it from the [Github releases.](https://github.com/harvester/harvester/releases)
 
 During the installation you can either choose to form a new cluster, or join the node to an existing cluster.

--- a/versioned_docs/version-v0.3/install/management-address.md
+++ b/versioned_docs/version-v0.3/install/management-address.md
@@ -7,6 +7,10 @@ keywords:
 Description: The Harvester provides a virtual IP as the management address.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+</head>
+
 Harvester provides a fixed virtual IP (VIP) as the management address. Users can see the management address on the console dashboard after installation.
 
 ![](./assets/console-dashboard.png)

--- a/versioned_docs/version-v0.3/install/pxe-boot-install.md
+++ b/versioned_docs/version-v0.3/install/pxe-boot-install.md
@@ -14,6 +14,10 @@ keywords:
 Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+</head>
+
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 
 We recommend using [iPXE](https://ipxe.org/) to perform the network boot. It has more features than the traditional PXE Boot program and is likely available in modern NIC cards. If the iPXE firmware is not available for your NIC card, the iPXE firmware images can be loaded from the TFTP server first.

--- a/versioned_docs/version-v0.3/install/usb-install.md
+++ b/versioned_docs/version-v0.3/install/usb-install.md
@@ -4,6 +4,10 @@ sidebar_label: USB Installation
 title: "USB Installation"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+</head>
+
 ## Create a bootable USB flash drive
 
 There are a couple of ways to create a USB installation flash drive.

--- a/versioned_docs/version-v1.0/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.0/install/harvester-configuration.md
@@ -11,6 +11,10 @@ keywords:
 Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+</head>
+
 ## Configuration Example
 
 Harvester configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:

--- a/versioned_docs/version-v1.0/install/iso-install.md
+++ b/versioned_docs/version-v1.0/install/iso-install.md
@@ -11,6 +11,10 @@ keywords:
 Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+</head>
+
 To get the Harvester ISO image, download it from the [Github releases](https://github.com/harvester/harvester/releases) page.
 
 During the installation you can either choose to form a new cluster, or join the node to an existing cluster.

--- a/versioned_docs/version-v1.0/install/management-address.md
+++ b/versioned_docs/version-v1.0/install/management-address.md
@@ -7,6 +7,10 @@ keywords:
 Description: The Harvester provides a virtual IP as the management address.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+</head>
+
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.
 
 :::note

--- a/versioned_docs/version-v1.0/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.0/install/pxe-boot-install.md
@@ -14,6 +14,10 @@ keywords:
 Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+</head>
+
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 
 We recommend using [iPXE](https://ipxe.org/) to perform the network boot. It has more features than the traditional PXE Boot program and is likely available in modern NIC cards. If the iPXE firmware is not available for your NIC card, the iPXE firmware images can be loaded from the TFTP server first.

--- a/versioned_docs/version-v1.0/install/requirements.md
+++ b/versioned_docs/version-v1.0/install/requirements.md
@@ -7,6 +7,10 @@ keywords:
 Description: Outline the Harvester installation requirements
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+</head>
+
 As an HCI solution on bare metal servers, Harvester has some minimum requirements as outlined below.
 
 ## Hardware Requirements

--- a/versioned_docs/version-v1.0/install/usb-install.md
+++ b/versioned_docs/version-v1.0/install/usb-install.md
@@ -4,6 +4,10 @@ sidebar_label: USB Installation
 title: "USB Installation"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+</head>
+
 ## Create a bootable USB flash drive
 
 There are a couple of ways to create a USB installation flash drive.

--- a/versioned_docs/version-v1.1/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/harvester-configuration.md
@@ -11,6 +11,10 @@ keywords:
 Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+</head>
+
 ## Configuration Example
 
 Harvester configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:

--- a/versioned_docs/version-v1.1/install/iso-install.md
+++ b/versioned_docs/version-v1.1/install/iso-install.md
@@ -11,6 +11,10 @@ keywords:
 Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+</head>
+
 ## Installation Steps
 To get the Harvester ISO image, download it from the [Github releases](https://github.com/harvester/harvester/releases) page.
 

--- a/versioned_docs/version-v1.1/install/management-address.md
+++ b/versioned_docs/version-v1.1/install/management-address.md
@@ -7,6 +7,10 @@ keywords:
 Description: The Harvester provides a virtual IP as the management address.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+</head>
+
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.
 
 :::note

--- a/versioned_docs/version-v1.1/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.1/install/pxe-boot-install.md
@@ -14,6 +14,10 @@ keywords:
 Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+</head>
+
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 
 We recommend using [iPXE](https://ipxe.org/) to perform the network boot. It has more features than the traditional PXE Boot program and is likely available in modern NIC cards. If the iPXE firmware is not available for your NIC card, the iPXE firmware images can be loaded from the TFTP server first.

--- a/versioned_docs/version-v1.1/install/requirements.md
+++ b/versioned_docs/version-v1.1/install/requirements.md
@@ -6,6 +6,10 @@ keywords:
 - Installation Requirements
 Description: Outline the Harvester installation requirements
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+</head>
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements to install and run Harvester.
 
 ## Hardware requirements

--- a/versioned_docs/version-v1.1/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/update-harvester-configuration.md
@@ -8,6 +8,10 @@ keywords:
 Description: How to update Harvester configuration after installation
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+</head>
+
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 
 
 This page describes how to edit some of the most-requested Harvester configurations. To update a configuration, you must first update the runtime value in the system and then update configuration files to make the changes persistent between reboots. 

--- a/versioned_docs/version-v1.1/install/usb-install.md
+++ b/versioned_docs/version-v1.1/install/usb-install.md
@@ -4,6 +4,10 @@ sidebar_label: USB Installation
 title: "USB Installation"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+</head>
+
 ## Create a bootable USB flash drive
 
 There are a couple of ways to create a USB installation flash drive.


### PR DESCRIPTION
Adding canonical links to /install section pages in Harvester.

Tied to https://github.com/harvester/docs/issues/341