### PR TITLE
Add canonical links for /advanced

### DIFF
--- a/docs/advanced/addons.md
+++ b/docs/advanced/addons.md
@@ -4,6 +4,10 @@ sidebar_label: Addons
 title: "Addons"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+</head>
+
 _Available as of v1.1.0_
 
 Beginning with v1.1.0, Harvester will make optional functionality available as Addons.

--- a/docs/advanced/pcidevices.md
+++ b/docs/advanced/pcidevices.md
@@ -4,6 +4,10 @@ sidebar_label: PCI Devices
 title: "PCI Devices (Experimental)"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/pcidevices"/>
+</head>
+
 _Available as of v1.1.0_
 
 A `PCIDevice` in Harvester represents a host device with a PCI address. 

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -4,6 +4,10 @@ sidebar_label: Settings
 title: "Settings"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+</head>
+
 This page contains a list of advanced settings which can be used in Harvester.
 You can modify the custom resource `settings.harvesterhci.io` from the Dashboard UI or with the `kubectl` command.
 

--- a/docs/advanced/storageclass.md
+++ b/docs/advanced/storageclass.md
@@ -4,6 +4,10 @@ sidebar_label: StorageClass
 title: "StorageClass"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+</head>
+
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.
 
 ## Creating a StorageClass

--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -4,6 +4,10 @@ sidebar_label: Storage Network
 title: "Storage Network"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+</head>
+
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.
 
 For more informations, please refer [Longhorn Storage Network](https://longhorn.io/docs/1.3.2/advanced-resources/deploy/storage-network/)

--- a/docs/advanced/vmimport.md
+++ b/docs/advanced/vmimport.md
@@ -4,6 +4,10 @@ sidebar_label: VM Import
 title: "VM Import"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vmimport"/>
+</head>
+
 _Available as of v1.1.0_
 
 Beginning with v1.1.0, users can import their virtual machines from VMWare and OpenStack into Harvester.

--- a/versioned_docs/version-v1.1/advanced/addons.md
+++ b/versioned_docs/version-v1.1/advanced/addons.md
@@ -4,6 +4,10 @@ sidebar_label: Addons
 title: "Addons"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+</head>
+
 _Available as of v1.1.0_
 
 Beginning with v1.1.0, Harvester will make optional functionality available as Addons.

--- a/versioned_docs/version-v1.1/advanced/pcidevices.md
+++ b/versioned_docs/version-v1.1/advanced/pcidevices.md
@@ -4,6 +4,10 @@ sidebar_label: PCI Devices
 title: "PCI Devices (Experimental)"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/pcidevices"/>
+</head>
+
 _Available as of v1.1.0_
 
 A `PCIDevice` in Harvester represents a host device with a PCI address. 

--- a/versioned_docs/version-v1.1/advanced/settings.md
+++ b/versioned_docs/version-v1.1/advanced/settings.md
@@ -4,6 +4,10 @@ sidebar_label: Settings
 title: "Settings"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+</head>
+
 This page contains a list of advanced settings which can be used in Harvester.
 You can modify the custom resource `settings.harvesterhci.io` from the Dashboard UI or with the `kubectl` command.
 

--- a/versioned_docs/version-v1.1/advanced/storageclass.md
+++ b/versioned_docs/version-v1.1/advanced/storageclass.md
@@ -4,6 +4,10 @@ sidebar_label: StorageClass
 title: "StorageClass"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+</head>
+
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.
 
 ## Creating a StorageClass

--- a/versioned_docs/version-v1.1/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.1/advanced/storagenetwork.md
@@ -4,6 +4,10 @@ sidebar_label: Storage Network
 title: "Storage Network"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+</head>
+
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.
 
 For more informations, please refer [Longhorn Storage Network](https://longhorn.io/docs/1.3.2/advanced-resources/deploy/storage-network/)

--- a/versioned_docs/version-v1.1/advanced/vmimport.md
+++ b/versioned_docs/version-v1.1/advanced/vmimport.md
@@ -4,6 +4,10 @@ sidebar_label: VM Import
 title: "VM Import"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vmimport"/>
+</head>
+
 _Available as of v1.1.0_
 
 Beginning with v1.1.0, users can import their virtual machines from VMWare and OpenStack into Harvester.


### PR DESCRIPTION
Adding canonical links to /advanced section pages in Harvester.

Tied to https://github.com/harvester/docs/issues/341