### PR TITLE
Add Rancher Home link and refactor navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,19 +83,12 @@ const config = {
       items: [
         {
           type: 'docsVersionDropdown',
-          position: 'right',
+          position: 'left',
           dropdownActiveClassDisabled: true,
         },
         {
           type: "localeDropdown",
           position: "right",
-        },
-        {
-          type: 'doc',
-          docId: 'index',
-          position: "right",
-          label: "Docs",
-          className: "navbar__docs",
         },
         {
           href: "https://www.suse.com/c/?s=harvester",
@@ -108,6 +101,11 @@ const config = {
           position: "right",
           label: "Knowledge Base",
           className: "navbar__kb",
+        },
+        {
+          href: 'https://www.rancher.com',
+          label: 'Rancher Home',
+          position: 'right',
         },
         {
           href: "https://github.com/harvester/harvester",

--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -5,7 +5,7 @@
   },
   "theme.ErrorPageContent.tryAgain": {
     "message": "重试",
-    "description": "The label of the button to try again when the page crashed"
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.NotFound.title": {
     "message": "找不到页面",

--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -1,8 +1,4 @@
 {
-  "item.label.Docs": {
-    "message": "文档",
-    "description": "Navbar item with label Docs"
-  },
   "item.label.Blog": {
     "message": "博文",
     "description": "Navbar item with label Blog"
@@ -14,5 +10,13 @@
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"
+  },
+  "logo.alt": {
+    "message": "Harvester Logo",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Rancher Home": {
+    "message": "Rancher 主页",
+    "description": "Navbar item with label Rancher Home"
   }
 }


### PR DESCRIPTION
This PR:

1. Adds a home link to the navbar (fixes #339)
2. Moves the version switch to the left
3. Removes the **Docs** link as it's redundant on our site (works the same as the harvester logo in the upper-left corner)

**Screenshot**:
<img width="1916" alt="image" src="https://github.com/harvester/docs/assets/63201949/852ac113-e87b-4531-927f-292b2e997db9">