### PR TITLE
Fix image positions for the volume section

### DIFF
--- a/docs/volume/clone-volume.md
+++ b/docs/volume/clone-volume.md
@@ -14,10 +14,11 @@ Description: Clone volume from the Volume page.
 After creating a volume, you can clone the volume by following the steps below:
 
 1. Click the `⋮` button and select the `Clone` option.
-1. Select `clone volume data`
+
+    ![clone-volume-1](/img/v1.2/volume/clone-volume-1.png)
+
+1. Select `clone volume data`.
 1. Configure the `Name` of the new volume and click `Create`.
 1. (Optional) A cloned volume can be added to a VM using `Add Existing Volume`.
 
-![clone-volume-1](/img/v1.2/volume/clone-volume-1.png)
-
-![clone-volume-2](/img/v1.2/volume/clone-volume-2.png)
+    ![clone-volume-2](/img/v1.2/volume/clone-volume-2.png)

--- a/docs/volume/export-volume.md
+++ b/docs/volume/export-volume.md
@@ -14,11 +14,12 @@ Description: Export volume to image from the Volume page.
 You can select and export an existing volume to an image by following the steps below:
 
 1. Click the `⋮` button and select the `Export Image` option.
+
+    ![export-volume-to-image-1](/img/v1.2/volume/export-volume-to-image-1.png)
+
 1. Select the `Namespace` of the new image.
 1. Configure the `Name` of the new image.
 1. Select an existing `StorageClass`.
 1. (Optional) You can download the exported image from the `Images` page by clicking the `⋮` button and selecting the `Download` option.
 
-![export-volume-to-image-1](/img/v1.2/volume/export-volume-to-image-1.png)
-
-![export-volume-to-image-2](/img/v1.2/volume/export-volume-to-image-2.png)
+    ![export-volume-to-image-2](/img/v1.2/volume/export-volume-to-image-2.png)

--- a/docs/volume/volume-snapshots.md
+++ b/docs/volume/volume-snapshots.md
@@ -23,22 +23,30 @@ A recurring snapshot is currently not supported and is tracked via [harvester/ha
 After creating a volume, you can create volume snapshots by following the steps below:
 
 1. Click the `⋮` button and select the `Take Snapshot` option.
+
+    ![create-volume-snapshot-1](/img/v1.2/volume/create-volume-snapshot-1.png)
+
 1. Configure the `Name` of the new image and click `Create`.
 
-![create-volume-snapshot-1](/img/v1.2/volume/create-volume-snapshot-1.png)
-![create-volume-snapshot-2](/img/v1.2/volume/create-volume-snapshot-2.png)
+    ![create-volume-snapshot-2](/img/v1.2/volume/create-volume-snapshot-2.png)
 
 ## Restore a New Volume using Volume Snapshot
 
 After creating a volume snapshot, you can restore a new volume using the volume snapshot by following the steps below:
 
 1. Go to the `Backup & Snapshot > Volume Snapshots` page or the `Snapshots` tab in each `Volumes` Detail page.
-1. Click the `⋮` button and select the `Restore` option.
-1. Specify the `Name` of the new Volume.
-1. If the source volume is not an image volume, you can also select a different `StorageClass`.
-1. Click `Create`.
 
-![restore-volume-snapshot-1](/img/v1.2/volume/restore-volume-snapshot-1.png)
-![restore-volume-snapshot-2](/img/v1.2/volume/restore-volume-snapshot-2.png)
-![restore-volume-snapshot-3](/img/v1.2/volume/restore-volume-snapshot-3.png)
-![restore-volume-snapshot-4](/img/v1.2/volume/restore-volume-snapshot-4.png)
+    ![restore-volume-snapshot-1](/img/v1.2/volume/restore-volume-snapshot-1.png)
+
+1. Click the `⋮` button and select the `Restore` option.
+
+    ![restore-volume-snapshot-2](/img/v1.2/volume/restore-volume-snapshot-2.png)
+
+1. Specify the `Name` of the new Volume.
+    ![restore-volume-snapshot-3](/img/v1.2/volume/restore-volume-snapshot-3.png)
+
+1. If the source volume is not an image volume, you can also select a different `StorageClass`.
+
+    ![restore-volume-snapshot-4](/img/v1.2/volume/restore-volume-snapshot-4.png)
+
+1. Click `Create`.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/volume/clone-volume.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/volume/clone-volume.md
@@ -10,10 +10,11 @@ Description: 通过 Volume 页面克隆卷。
 创建卷后，你可以按照以下步骤克隆卷：
 
 1. 单击 `⋮` 按钮并选择 `Clone` 选项。
+
+   ![clone-volume-1](/img/v1.2/volume/clone-volume-1.png)
+
 1. 选择 `clone volume data`。
 1. 配置新卷的 `Name`，然后单击 `Create`。
 1. （可选）你可以使用 `Add Existing Volume` 将克隆的卷添加到 VM。
 
-![clone-volume-1](/img/v1.2/volume/clone-volume-1.png)
-
-![clone-volume-2](/img/v1.2/volume/clone-volume-2.png)
+   ![clone-volume-2](/img/v1.2/volume/clone-volume-2.png)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/volume/export-volume.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/volume/export-volume.md
@@ -10,11 +10,12 @@ Description: 通过 Volume 页面将卷导出到镜像。
 你可以按照以下步骤选择现有卷并将其导出到镜像：
 
 1. 单击 `⋮` 按钮并选择 `Export Image` 选项。
+
+   ![export-volume-to-image-1](/img/v1.2/volume/export-volume-to-image-1.png)
+
 1. 选择新镜像的 `Namespace`。
 1. 配置新镜像的 `Name`。
 1. 选择现有的 `StorageClass`。
 1. （可选）你可以通过 `Images` 页面下载导出的镜像，方法是单击 `⋮` 按钮并选择 `Download` 选项。
 
-![export-volume-to-image-1](/img/v1.2/volume/export-volume-to-image-1.png)
-
-![export-volume-to-image-2](/img/v1.2/volume/export-volume-to-image-2.png)
+   ![export-volume-to-image-2](/img/v1.2/volume/export-volume-to-image-2.png)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/volume/volume-snapshots.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/volume/volume-snapshots.md
@@ -19,22 +19,30 @@ Description: 通过 Volume 页面获取卷快照。
 创建卷后，你可以按照以下步骤创建卷快照：
 
 1. 单击 `⋮` 按钮并选择 `Take Snapshot` 选项。
+
+   ![create-volume-snapshot-1](/img/v1.2/volume/create-volume-snapshot-1.png)
+
 1. 配置新镜像的 `Name`，然后单击 `Create`。
 
-![create-volume-snapshot-1](/img/v1.2/volume/create-volume-snapshot-1.png)
-![create-volume-snapshot-2](/img/v1.2/volume/create-volume-snapshot-2.png)
+   ![create-volume-snapshot-2](/img/v1.2/volume/create-volume-snapshot-2.png)
 
 ## 使用卷快照来还原新卷
 
 创建卷快照后，你可以按照以下步骤使用卷快照来还原新卷：
 
 1. 转到 `Backup & Snapshot > Volume Snapshots` 页面，或每个 `Volumes` 详细信息页面中的 `Snapshots` 选项卡。
-1. 单击 `⋮` 按钮并选择 `Restore` 选项。
-1. 指定新卷的 `Name`。
-1. 如果源卷不是镜像卷，你也可以选择不同的 `StorageClass`。
-1. 单击 `Create`。
 
-![restore-volume-snapshot-1](/img/v1.2/volume/restore-volume-snapshot-1.png)
-![restore-volume-snapshot-2](/img/v1.2/volume/restore-volume-snapshot-2.png)
-![restore-volume-snapshot-3](/img/v1.2/volume/restore-volume-snapshot-3.png)
-![restore-volume-snapshot-4](/img/v1.2/volume/restore-volume-snapshot-4.png)
+   ![restore-volume-snapshot-1](/img/v1.2/volume/restore-volume-snapshot-1.png)
+
+1. 单击 `⋮` 按钮并选择 `Restore` 选项。
+
+   ![restore-volume-snapshot-2](/img/v1.2/volume/restore-volume-snapshot-2.png)
+
+1. 指定新卷的 `Name`。
+   ![restore-volume-snapshot-3](/img/v1.2/volume/restore-volume-snapshot-3.png)
+
+1. 如果源卷不是镜像卷，你也可以选择不同的 `StorageClass`。
+
+   ![restore-volume-snapshot-4](/img/v1.2/volume/restore-volume-snapshot-4.png)
+
+1. 单击 `Create`。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/volume/clone-volume.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/volume/clone-volume.md
@@ -10,10 +10,11 @@ Description: 通过 Volume 页面克隆卷。
 创建卷后，你可以按照以下步骤克隆卷：
 
 1. 单击 `⋮` 按钮并选择 `Clone` 选项。
+
+   ![clone-volume-1](/img/v1.1/volume/clone-volume-1.png)
+
 1. 选择 `clone volume data`。
 1. 配置新卷的 `Name`，然后单击 `Create`。
 1. （可选）你可以使用 `Add Existing Volume` 将克隆的卷添加到 VM。
 
-![clone-volume-1](/img/v1.1/volume/clone-volume-1.png)
-
-![clone-volume-2](/img/v1.1/volume/clone-volume-2.png)
+   ![clone-volume-2](/img/v1.1/volume/clone-volume-2.png)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/volume/export-volume.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/volume/export-volume.md
@@ -10,11 +10,12 @@ Description: 通过 Volume 页面将卷导出到镜像。
 你可以按照以下步骤选择现有卷并将其导出到镜像：
 
 1. 单击 `⋮` 按钮并选择 `Export Image` 选项。
+
+   ![export-volume-to-image-1](/img/v1.1/volume/export-volume-to-image-1.png)
+
 1. 选择新镜像的 `Namespace`。
 1. 配置新镜像的 `Name`。
 1. 选择现有的 `StorageClass`。
 1. （可选）你可以通过 `Images` 页面下载导出的镜像，方法是单击 `⋮` 按钮并选择 `Download` 选项。
 
-![export-volume-to-image-1](/img/v1.1/volume/export-volume-to-image-1.png)
-
-![export-volume-to-image-2](/img/v1.1/volume/export-volume-to-image-2.png)
+   ![export-volume-to-image-2](/img/v1.1/volume/export-volume-to-image-2.png)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/volume/volume-snapshots.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/volume/volume-snapshots.md
@@ -19,22 +19,31 @@ Description: 通过 Volume 页面获取卷快照。
 创建卷后，你可以按照以下步骤创建卷快照：
 
 1. 单击 `⋮` 按钮并选择 `Take Snapshot` 选项。
+
+   ![create-volume-snapshot-1](/img/v1.1/volume/create-volume-snapshot-1.png)
+
 1. 配置新镜像的 `Name`，然后单击 `Create`。
 
-![create-volume-snapshot-1](/img/v1.1/volume/create-volume-snapshot-1.png)
-![create-volume-snapshot-2](/img/v1.1/volume/create-volume-snapshot-2.png)
+   ![create-volume-snapshot-2](/img/v1.1/volume/create-volume-snapshot-2.png)
 
 ## 使用卷快照来还原新卷
 
 创建卷快照后，你可以按照以下步骤使用卷快照来还原新卷：
 
 1. 转到 `Backup & Snapshot > Volume Snapshots` 页面，或每个 `Volumes` 详细信息页面中的 `Snapshots` 选项卡。
-1. 单击 `⋮` 按钮并选择 `Restore` 选项。
-1. 指定新卷的 `Name`。
-1. 如果源卷不是镜像卷，你也可以选择不同的 `StorageClass`。
-1. 单击 `Create`。
 
-![restore-volume-snapshot-1](/img/v1.1/volume/restore-volume-snapshot-1.png)
-![restore-volume-snapshot-2](/img/v1.1/volume/restore-volume-snapshot-2.png)
-![restore-volume-snapshot-3](/img/v1.1/volume/restore-volume-snapshot-3.png)
-![restore-volume-snapshot-4](/img/v1.1/volume/restore-volume-snapshot-4.png)
+   ![restore-volume-snapshot-1](/img/v1.1/volume/restore-volume-snapshot-1.png)
+
+1. 单击 `⋮` 按钮并选择 `Restore` 选项。
+
+   ![restore-volume-snapshot-2](/img/v1.1/volume/restore-volume-snapshot-2.png)
+
+1. 指定新卷的 `Name`。
+
+   ![restore-volume-snapshot-3](/img/v1.1/volume/restore-volume-snapshot-3.png)
+
+1. 如果源卷不是镜像卷，你也可以选择不同的 `StorageClass`。
+
+   ![restore-volume-snapshot-4](/img/v1.1/volume/restore-volume-snapshot-4.png)
+
+1. 单击 `Create`。

--- a/versioned_docs/version-v1.1/volume/clone-volume.md
+++ b/versioned_docs/version-v1.1/volume/clone-volume.md
@@ -14,10 +14,11 @@ Description: Clone volume from the Volume page.
 After creating a volume, you can clone the volume by following the steps below:
 
 1. Click the `⋮` button and select the `Clone` option.
-1. Select `clone volume data`
+
+    ![clone-volume-1](/img/v1.1/volume/clone-volume-1.png)
+
+1. Select `clone volume data`.
 1. Configure the `Name` of the new volume and click `Create`.
 1. (Optional) A cloned volume can be added to a VM using `Add Existing Volume`.
 
-![clone-volume-1](/img/v1.1/volume/clone-volume-1.png)
-
-![clone-volume-2](/img/v1.1/volume/clone-volume-2.png)
+    ![clone-volume-2](/img/v1.1/volume/clone-volume-2.png)

--- a/versioned_docs/version-v1.1/volume/export-volume.md
+++ b/versioned_docs/version-v1.1/volume/export-volume.md
@@ -14,11 +14,12 @@ Description: Export volume to image from the Volume page.
 You can select and export an existing volume to an image by following the steps below:
 
 1. Click the `⋮` button and select the `Export Image` option.
+
+    ![export-volume-to-image-1](/img/v1.1/volume/export-volume-to-image-1.png)
+
 1. Select the `Namespace` of the new image.
 1. Configure the `Name` of the new image.
 1. Select an existing `StorageClass`.
 1. (Optional) You can download the exported image from the `Images` page by clicking the `⋮` button and selecting the `Download` option.
 
-![export-volume-to-image-1](/img/v1.1/volume/export-volume-to-image-1.png)
-
-![export-volume-to-image-2](/img/v1.1/volume/export-volume-to-image-2.png)
+    ![export-volume-to-image-2](/img/v1.1/volume/export-volume-to-image-2.png)

--- a/versioned_docs/version-v1.1/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.1/volume/volume-snapshots.md
@@ -23,22 +23,31 @@ A recurring snapshot is currently not supported and is tracked via [harvester/ha
 After creating a volume, you can create volume snapshots by following the steps below:
 
 1. Click the `⋮` button and select the `Take Snapshot` option.
+
+    ![create-volume-snapshot-1](/img/v1.1/volume/create-volume-snapshot-1.png)
+
 1. Configure the `Name` of the new image and click `Create`.
 
-![create-volume-snapshot-1](/img/v1.1/volume/create-volume-snapshot-1.png)
-![create-volume-snapshot-2](/img/v1.1/volume/create-volume-snapshot-2.png)
+    ![create-volume-snapshot-2](/img/v1.1/volume/create-volume-snapshot-2.png)
 
 ## Restore a New Volume using Volume Snapshot
 
 After creating a volume snapshot, you can restore a new volume using the volume snapshot by following the steps below:
 
 1. Go to the `Backup & Snapshot > Volume Snapshots` page or the `Snapshots` tab in each `Volumes` Detail page.
-1. Click the `⋮` button and select the `Restore` option.
-1. Specify the `Name` of the new Volume.
-1. If the source volume is not an image volume, you can also select a different `StorageClass`.
-1. Click `Create`.
 
-![restore-volume-snapshot-1](/img/v1.1/volume/restore-volume-snapshot-1.png)
-![restore-volume-snapshot-2](/img/v1.1/volume/restore-volume-snapshot-2.png)
-![restore-volume-snapshot-3](/img/v1.1/volume/restore-volume-snapshot-3.png)
-![restore-volume-snapshot-4](/img/v1.1/volume/restore-volume-snapshot-4.png)
+    ![restore-volume-snapshot-1](/img/v1.1/volume/restore-volume-snapshot-1.png)
+
+1. Click the `⋮` button and select the `Restore` option.
+
+    ![restore-volume-snapshot-2](/img/v1.1/volume/restore-volume-snapshot-2.png)
+
+1. Specify the `Name` of the new Volume.
+
+    ![restore-volume-snapshot-3](/img/v1.1/volume/restore-volume-snapshot-3.png)
+
+1. If the source volume is not an image volume, you can also select a different `StorageClass`.
+
+    ![restore-volume-snapshot-4](/img/v1.1/volume/restore-volume-snapshot-4.png)
+
+1. Click `Create`.


### PR DESCRIPTION
Put step-related images right behind the corresponding step to avoid piling up the images.