### PR TITLE
Bump terraform-provider-harvester version to v0.6.2

### DIFF
--- a/docs/terraform/terraform-provider.md
+++ b/docs/terraform/terraform-provider.md
@@ -12,8 +12,9 @@ title: "Harvester Terraform Provider"
 
 | Harvester Version                                                    | Supported Terraform Provider Harvester                                                  | Supported Terraformer Harvester                                                            |
 |----------------------------------------------------------------------|-----------------------------------------------------------------------------------------| ------------------------------------------------------------------------------------------ |
-| [v1.1.1](https://github.com/harvester/harvester/releases/tag/v1.1.1) | [v0.6.1](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.1) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
-| [v1.1.0](https://github.com/harvester/harvester/releases/tag/v1.1.0) | [v0.6.1](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.1) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
+| [v1.1.2](https://github.com/harvester/harvester/releases/tag/v1.1.2) | [v0.6.2](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.2) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
+| [v1.1.1](https://github.com/harvester/harvester/releases/tag/v1.1.1) | [v0.6.2](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.2) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
+| [v1.1.0](https://github.com/harvester/harvester/releases/tag/v1.1.0) | [v0.6.2](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.2) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
 | [v1.0.3](https://github.com/harvester/harvester/releases/tag/v1.0.3) | [v0.5.4](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.5.4) | [v1.0.1-harvester](https://github.com/harvester/terraformer/releases/tag/v1.0.1-harvester) |
 
 ## Requirements

--- a/versioned_docs/version-v1.1/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.1/terraform/terraform-provider.md
@@ -12,8 +12,9 @@ title: "Harvester Terraform Provider"
 
 | Harvester Version                                                    | Supported Terraform Provider Harvester                                                  | Supported Terraformer Harvester                                                            |
 |----------------------------------------------------------------------|-----------------------------------------------------------------------------------------| ------------------------------------------------------------------------------------------ |
-| [v1.1.1](https://github.com/harvester/harvester/releases/tag/v1.1.1) | [v0.6.1](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.1) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
-| [v1.1.0](https://github.com/harvester/harvester/releases/tag/v1.1.0) | [v0.6.1](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.1) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
+| [v1.1.2](https://github.com/harvester/harvester/releases/tag/v1.1.2) | [v0.6.2](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.2) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
+| [v1.1.1](https://github.com/harvester/harvester/releases/tag/v1.1.1) | [v0.6.2](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.2) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
+| [v1.1.0](https://github.com/harvester/harvester/releases/tag/v1.1.0) | [v0.6.2](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.2) | [v1.1.0-harvester](https://github.com/harvester/terraformer/releases/tag/v1.1.0-harvester) |
 | [v1.0.3](https://github.com/harvester/harvester/releases/tag/v1.0.3) | [v0.5.4](https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.5.4) | [v1.0.1-harvester](https://github.com/harvester/terraformer/releases/tag/v1.0.1-harvester) |
 
 ## Requirements


### PR DESCRIPTION
- Bump terraform-provider-harvester version to v0.6.2
- Add missing Harvester version v1.1.2