### PR TITLE
Add summary for restart vm after force delete vm

### DIFF
--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -397,6 +397,10 @@ This setting allows you to force reschedule VMs when a node is unavailable. When
 
 Default: `{"enable":true, "period":300}`
 
+:::note
+When a host is unavailable or is powered off, the VM only reboots and does not migrate.
+:::
+
 #### Example
 
 ```json

--- a/versioned_docs/version-v1.1/advanced/settings.md
+++ b/versioned_docs/version-v1.1/advanced/settings.md
@@ -397,6 +397,10 @@ This setting allows you to force reschedule VMs when a node is unavailable. When
 
 Default: `{"enable":true, "period":300}`
 
+:::note
+When a host is unavailable or is powered off, the VM only reboots and does not migrate.
+:::
+
 #### Example
 
 ```json


### PR DESCRIPTION
**Related issue:**
https://github.com/harvester/harvester/issues/4049#issuecomment-1589360702

Maintenance mode has indicated in the documentation as a migration of VMs when enabled, and we only need to replenish for the vm-force-reset-policy setting.