### PR TITLE
Change wording for network requirements from recommendation to required

### DIFF
--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -16,14 +16,14 @@ As an HCI solution on bare metal servers, there are minimum node hardware and ne
 
 Harvester nodes have the following hardware requirements and recommendations for installation and testing.
 
-| Type             | Requirements and Recommendations                                                                                                                                                                                        |
-|:-----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CPU              | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum for testing; 16-core or above recommended for production                                                            |
-| Memory           | 32 GB minimum for testing; 64 GB or above recommended for production                                                                                                                                                               |
-| Disk Capacity    | 250 GB minimum for testing; 500 GB or above recommended for production                                                                                                                                  |
-| Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for Etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd) |
-| Network Card     | 1 Gbps Ethernet minimum for testing, 10Gbps Ethernet recommended for production                                                                                                                       |
-| Network Switch   | Trunking of ports required for VLAN support                                                                                                                                                           |
+| Type             | Requirements and Recommendations                                                                                                          |
+|:-----------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| CPU              | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum for testing; 16-core or above required for production |
+| Memory           | 32 GB minimum for testing; 64 GB or above required for production                                                                         |
+| Disk Capacity    | 250 GB minimum for testing; 500 GB or above required for production                                                                       |
+| Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for etcd](https://www.suse.com/support/kb/doc/?id=000020100)                                  |
+| Network Card     | 1 Gbps Ethernet minimum for testing, 10 Gbps Ethernet minimum required for production                                                     |
+| Network Switch   | Trunking of ports required for VLAN support                                                                                               |
 
 :::note
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/install/requirements.md
@@ -18,7 +18,7 @@ Harvester 是运行在裸机服务器上的 HCI 解决方案，要正常运行�
 | CPU | 仅支持 x86_64。需要硬件辅助虚拟化。8 核（至少）用于测试；生产中推荐使用 16 核或以上 |
 | 内存 | 32 GB（至少）用于测试；生产中推荐使用 64 GB 或以上 |
 | 磁盘容量 | 250 GB（至少）用于测试；生产中推荐使用 500 GB 或以上 |
-| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前 3 个节点）必须[对 etcd 而言足够快](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd)。 |
+| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前 3 个节点）必须[对 etcd 而言足够快](https://www.suse.com/support/kb/doc/?id=000020100)。 |
 | 网卡 | 1 Gbps 以太网（至少）用于测试；生产中建议使用 10 Gbps 或以上的以太网 |
 | 网络交换机 | VLAN 支持所需的端口中继。 |
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.0/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.0/index.md
@@ -51,7 +51,7 @@ Harvester 支持在裸机服务器上实施 HCI。Harvester 使用本地、直�
 | CPU | 仅支持 x86_64。需要硬件辅助虚拟化。最少需要 8 核处理器，建议使用 16 核处理器。 |
 | 内存 | 32 GB（至少），建议使用 64 GB 或以上的内存。 |
 | 磁盘容量 | 140 GB（至少）用于测试，建议在生产中使用 500 GB 或以上的磁盘。 |
-| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前三个节点）必须[对 etcd 而言足够快](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd)。 |
+| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前三个节点）必须[对 etcd 而言足够快](https://www.suse.com/support/kb/doc/?id=000020100)。 |
 | 网卡 | 1 Gbps 以太网（至少）用于测试，建议在生产中使用 10 Gbps 或以上的以太网。 |
 | 网络交换机 | VLAN 支持所需的端口中继。 |
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.0/install/requirements.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.0/install/requirements.md
@@ -17,7 +17,7 @@ Harvester 是裸机服务器上的 HCI 解决方案，以下是 Harvester 安装
 | CPU | 仅支持 x86_64。需要硬件辅助虚拟化。最少需要 8 核处理器，建议使用 16 核处理器。 |
 | 内存 | 32 GB（至少）。建议使用 64 GB 或以上的内存。 |
 | 磁盘容量 | 140 GB（至少）用于测试，建议在生产中使用 500 GB 或以上的磁盘。 |
-| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前 3 个节点）必须[对 etcd 而言足够快](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd)。 |
+| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前 3 个节点）必须[对 etcd 而言足够快](https://www.suse.com/support/kb/doc/?id=000020100)。 |
 | 网卡 | 1 Gbps 以太网（至少）用于测试；生产中建议使用 10 Gbps 或以上的以太网 |
 | 网络交换机 | VLAN 支持所需的端口中继。 |
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/install/requirements.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/install/requirements.md
@@ -18,7 +18,7 @@ Harvester 是运行在裸机服务器上的 HCI 解决方案，要正常运行�
 | CPU | 仅支持 x86_64。需要硬件辅助虚拟化。8 核（至少）用于测试；生产中推荐使用 16 核或以上 |
 | 内存 | 32 GB（至少）用于测试；生产中推荐使用 64 GB 或以上 |
 | 磁盘容量 | 200 GB（至少）用于测试；生产中推荐使用 500 GB 或以上 |
-| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前 3 个节点）必须[对 etcd 而言足够快](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd)。 |
+| 磁盘性能 | 每个磁盘 5,000+ 随机 IOPS (SSD/NVMe)。管理节点（前 3 个节点）必须[对 etcd 而言足够快](https://www.suse.com/support/kb/doc/?id=000020100)。 |
 | 网卡 | 1 Gbps 以太网（至少）用于测试；生产中建议使用 10 Gbps 或以上的以太网 |
 | 网络交换机 | VLAN 支持所需的端口中继。 |
 

--- a/versioned_docs/version-v1.0/index.md
+++ b/versioned_docs/version-v1.0/index.md
@@ -51,7 +51,7 @@ To get the Harvester server up and running, the following minimum hardware is re
 | CPU | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum; 16-core or above preferred                                                                                            |
 | Memory | 32 GB minimum; 64 GB or above preferred                                                                                                                                                                    |
 | Disk Capacity | 140 GB minimum for testing; 500 GB or above preferred for production                                                                                                                                       |
-| Disk Performance | 5,000+ random IOPS per disk (SSD/NVMe). Management nodes (first three nodes) must be [fast enough for etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd) |
+| Disk Performance | 5,000+ random IOPS per disk (SSD/NVMe). Management nodes (first three nodes) must be [fast enough for etcd](https://www.suse.com/support/kb/doc/?id=000020100) |
 | Network Card | 1 Gbps Ethernet minimum for testing; 10Gbps Ethernet recommended for production                                                                                                                            |
 | Network Switch | Trunking of ports required for VLAN support                                                                                                                                                                |
 

--- a/versioned_docs/version-v1.0/install/requirements.md
+++ b/versioned_docs/version-v1.0/install/requirements.md
@@ -21,7 +21,7 @@ To get the Harvester server up and running the following minimum hardware is req
 | CPU              | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum; 16-core or above preferred                                                                                       |
 | Memory           | 32 GB minimum, 64 GB or above preferred                                                                                                                                                               |
 | Disk Capacity    | 140 GB minimum for testing, 500 GB or above preferred for production                                                                                                                                  |
-| Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for Etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd) |
+| Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for etcd](https://www.suse.com/support/kb/doc/?id=000020100) |
 | Network Card     | 1 Gbps Ethernet minimum for testing, 10Gbps Ethernet recommended for production                                                                                                                       |
 | Network Switch   | Trunking of ports required for VLAN support                                                                                                                                                           |
   

--- a/versioned_docs/version-v1.1/install/requirements.md
+++ b/versioned_docs/version-v1.1/install/requirements.md
@@ -22,7 +22,7 @@ Harvester nodes have the following hardware requirements and recommendations for
 | Memory           | 32 GB minimum for testing; 64 GB or above recommended for production                                                                                                                                                               |
 | Disk Capacity    | 200 GB minimum for testing; 500 GB or above recommended for production                                                                                                                                  |
 | Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for Etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd) |
-| Network Card     | 1 Gbps Ethernet minimum for testing, 10Gbps Ethernet recommended for production                                                                                                                       |
+| Network Card     | 1 Gbps Ethernet minimum for testing, 10Gbps Ethernet minimum required for production                                                                                                                       |
 | Network Switch   | Trunking of ports required for VLAN support                                                                                                                                                           |
 
 :::note

--- a/versioned_docs/version-v1.1/install/requirements.md
+++ b/versioned_docs/version-v1.1/install/requirements.md
@@ -16,14 +16,14 @@ As an HCI solution on bare metal servers, there are minimum node hardware and ne
 
 Harvester nodes have the following hardware requirements and recommendations for installation and testing.
 
-| Type             | Requirements and Recommendations                                                                                                                                                                                        |
-|:-----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CPU              | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum for testing; 16-core or above recommended for production                                                            |
-| Memory           | 32 GB minimum for testing; 64 GB or above recommended for production                                                                                                                                                               |
-| Disk Capacity    | 200 GB minimum for testing; 500 GB or above recommended for production                                                                                                                                  |
-| Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for Etcd](https://www.ibm.com/cloud/blog/using-fio-to-tell-whether-your-storage-is-fast-enough-for-etcd) |
-| Network Card     | 1 Gbps Ethernet minimum for testing, 10Gbps Ethernet minimum required for production                                                                                                                       |
-| Network Switch   | Trunking of ports required for VLAN support                                                                                                                                                           |
+| Type             | Requirements and Recommendations                                                                                                          |
+|:-----------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| CPU              | x86_64 only. Hardware-assisted virtualization is required. 8-core processor minimum for testing; 16-core or above required for production |
+| Memory           | 32 GB minimum for testing; 64 GB or above required for production                                                                         |
+| Disk Capacity    | 200 GB minimum for testing; 500 GB or above required for production                                                                       |
+| Disk Performance | 5,000+ random IOPS per disk(SSD/NVMe). Management nodes (first 3 nodes) must be [fast enough for etcd](https://www.suse.com/support/kb/doc/?id=000020100)                                  |
+| Network Card     | 1 Gbps Ethernet minimum for testing, 10 Gbps Ethernet minimum required for production                                                     |
+| Network Switch   | Trunking of ports required for VLAN support                                                                                               |
 
 :::note
 


### PR DESCRIPTION
For VM migration, for storage replication and for VM access in production scenarios / scenarios under load - 1 GB will not be sufficient at all. Basically with 1 GB the VM migration will not complete if the VM is under load and the automatic and working VM migration will also be required for Harvester upgrades while VMs are up and running.

So we really should change "10 G recommended" to "10 G required".