### PR TITLE
doc: Update Harvester Addon Config Info

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -75,10 +75,21 @@ install:
   vip_mode: dhcp
   force_mbr: false
   addons:
-    rancher-monitoring:
-      enabled: true
-    rancher-logging:
+    harvester_vm_import_controller:
       enabled: false
+      values_content: ""
+    harvester_pcidevices_controller:
+      enabled: false
+      values_content: ""
+    rancher_monitoring:
+      enabled: true
+      values_content: ""
+    rancher_logging:
+      enabled: false
+      values_content: ""
+    harvester_seeder:
+      enabled: false
+      values_content: ""
 system_settings:
   auto-disk-provision-paths: ""
 ```
@@ -293,7 +304,7 @@ The password for the default user, `rancher`. By default, there is no password f
 If you set a password at runtime it will be reset on the next boot. The
 value of the password can be clear text or an encrypted form. The easiest way to get this encrypted
 form is to change your password on a Linux system and copy the value of the second field from
-`/etc/shadow`. You can also encrypt a password using OpenSSL. For the encryption algorithms 
+`/etc/shadow`. You can also encrypt a password using OpenSSL. For the encryption algorithms
 supported by Harvester, please refer to the table below.
 
 | Algorithm | Command | Support |
@@ -566,18 +577,19 @@ Default: The addons are disabled.
 ```yaml
 install:
   addons:
-    rancher-monitoring:
+    rancher_monitoring:
       enabled: true
-    rancher-logging:
+    rancher_logging:
       enabled: false
 ```
 
-Harvester v1.2.0 ships with four addons:
+Harvester v1.2.0 ships with five addons:
 
-- harvester-vm-import-controller
-- harvester-pcidevices-controller
+- vm-import-controller (chartName: `harvester-vm-import-controller`)
+- pcidevices-controller (chartName: `harvester-pcidevices-controller`)
 - rancher-monitoring
 - rancher-logging
+- harvester-seeder (experimental)
 
 ### `install.harvester.storage_class.replica_count`
 


### PR DESCRIPTION
Super willing to iterate and update this as needed but wanted to push up a slight change :smile: 

Given that there is a distinction between UI "naming" and Helm Chart naming:
![Screenshot from 2023-07-26 11-36-32](https://github.com/harvester/docs/assets/5370752/61e609a1-cc28-4860-8578-391f14308834)
![Screenshot from 2023-07-26 11-32-52](https://github.com/harvester/docs/assets/5370752/86b34211-be82-47c6-b451-f597e82efbb1)

And that in order for the configuration to work, if serving remotely as a configuration, the syntax in the YAML will need to change shifting from `-` (hypens) to `_` (underscores).

Additionally, sharing out to docs about `values_content` as a property on the addon.

This PR updates the way the user is informed of:
- proper YAML configuration for enablement
- the distinction between "chart name"/"chartname" (helm chart name) and what the user would see through the Web UI (if enabling through WebUI/harvester-dashboard, instead of kubectl edits)
- additionally providing the `valuescontent` property as a configuration element 

Newer PR from: https://github.com/harvester/docs/pull/368