### PR TITLE
Update multi CSI driver related docs

### DIFF
--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -135,7 +135,7 @@ If you set a username and password for a private registry, the system will autom
 
 _Available as of v1.2.0_
 
-This setting allows you to install a Container Storage Interface (CSI) in your Harvester cluster to support and use external storage as the VM's non-system data partition and leverage different drivers.
+If you install third-party CSI drivers in the Harvester cluster, you must configure some necessary information through this setting before using **Backup/Snapshot** related features.
 
 Default:
 ```
@@ -150,8 +150,6 @@ Default:
 1. Add the provisioner for the newly added CSI driver.
 1. Configure **Volume Snapshot Class Name**, which refers to the name of the `VolumeSnapshotClass` used to create volume snapshots or VM snapshots.
 1. Configure **Backup Volume Snapshot Class Name**, which refers to the name of the `VolumeSnapshotClass` used to create VM backups.
-
-Select the desired StorageClass when creating an empty volume or adding a new empty volume to a virtual machine.
 
 ## `default-vm-termination-grace-period-seconds`
 

--- a/docs/advanced/storageclass.md
+++ b/docs/advanced/storageclass.md
@@ -93,25 +93,21 @@ The `volumeBindingMode` field controls when volume binding and dynamic provision
 
 ## Multi Container Storage Interface support
 
-Harvester now supports installing a Container Storage Interface (CSI) in your Harvester cluster to support and use external storage as the VM's non-system data partition. For example, choose an existing storage provider (e.g., Dell PowerFlex) to create a data volume in Harvester. Leverage different drivers for specific purposes, such as performance optimization or integration with existing internal storage providers.
+Harvester now supports installing a Container Storage Interface (CSI) in your Harvester cluster to support and use external storage as the VM's non-system data disks. Leverage different drivers for specific purposes, such as performance optimization or integration with existing in-house storage providers.
 
 :::note
 
-The system partition of the VM can still use Longhorn. Before v1.2.0, Harvester only supports the use of Longhorn to store virtual machine data, and does not support the use of external storage to store VM data.
+The provisioner of the VM image still uses Longhorn. Before v1.2.0, Harvester only supports using Longhorn to store virtual machine data and does not support using external storage to store VM data.
 
 :::
 
-You must first manually install your CSI driver. Then create a new StorageClass and edit the `csi-driver-config` setting.
+Administrators can enable this feature through the following steps:
+1. Set the [`os.persistent_state_paths`](../install/harvester-configuration.md#ospersistent_state_paths) and [`os.after_install_chroot_commands`](../install/harvester-configuration.md#osafter_install_chroot_commands) settings before creating the Harvester cluster for the specific CSI driver needs.
+2. Install the CSI driver to the Harvester cluster manually after creating the Harvester cluster.
+3. Edit the [`csi-driver-config`](../advanced/settings.md#csi-driver-config) setting.
+4. Create a new StorageClass that uses the CSI driver.
 
-### Header Section
-
-- **Name**: Name of the StorageClass
-- **Description** (optional): Description of the StorageClass.
-- **Provisioner**: Select a provisioner.
-
-### Parameters
-
-Edit the [`csi-driver-config`](../advanced/settings.md#csi-driver-config) setting to add the provisioner for the newly added CSI driver.
+After performing these steps, you must select the desired StorageClass when creating an empty volume or adding a new empty volume to a virtual machine.
 
 ## Appendix - Use Case
 


### PR DESCRIPTION
**Related issues**
https://github.com/harvester/harvester/issues/4420

Summarize CSI driver related informations to section `Multi Container Storage Interface support`  in the `StorageClass` page.

I'll create a new PR to harvester/harvesterhci.io to add KB article for Rook Ceph CSI Driver [KB: Using Rook Ceph storage in Harvester](https://github.com/harvester/harvesterhci.io/pull/41)
After Rook Ceph CSI Driver KB and the [KB article for NetApp Trident CSI Driver](https://github.com/harvester/harvesterhci.io/pull/38) merged
I'll create another new PR to add these KB links to the harvester/docs