### PR TITLE
Update broken link settings for CI to pass

### DIFF
--- a/docs/advanced/rancher-vcluster.md
+++ b/docs/advanced/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher vcluster (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/dev/advanced/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/rancher-vcluster"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/advanced/rancher-vcluster.md
+++ b/docs/advanced/rancher-vcluster.md
@@ -44,7 +44,7 @@ Once the addon is deployed, Rancher can take a few minutes to become available.
 
 You can then access Rancher via the hostname DNS record that you provided.
 
-See [Rancher Integration](../rancher/virtualization-management) for more information.
+See [Rancher Integration](../rancher/virtualization-management.md) for more information.
 
 :::note Disabling rancher-vcluster
 

--- a/docs/advanced/seeder.md
+++ b/docs/advanced/seeder.md
@@ -5,7 +5,7 @@ title: "Seeder"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/dev/advanced/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/seeder"/>
 </head>
 _Available as of v1.2.0_
 

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -230,7 +230,7 @@ _Available as of v1.2.0_
 
 This setting allows you to configure NTP servers for time synchronization on the Harvester nodes.
 
-Using this setting, you can define NTP servers during [installation](../install/harvester-configuration#osntp_servers) or update NTP servers after installation.
+Using this setting, you can define NTP servers during [installation](../install/harvester-configuration.md#osntp_servers) or update NTP servers after installation.
 
 :::caution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ The Harvester architecture consists of cutting-edge open-source technologies:
 ## Harvester Features
 
 Harvester is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features of Harvester include:
-- **Easy to get started.** Since Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the [ISO image](https://github.com/harvester/harvester/releases) or automatically install it using [iPXE](https://docs.harvesterhci.io/dev/install/pxe-boot-install) scripts.
+- **Easy to get started.** Since Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the [ISO image](https://github.com/harvester/harvester/releases) or automatically install it using [iPXE](./install/pxe-boot-install.md) scripts.
 - **VM lifecycle management.** Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 - **VM live migration.** Move a VM to a different host or node with zero downtime.
 - **VM backup, snapshot, and restore.** Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.

--- a/docs/install/update-harvester-configuration.md
+++ b/docs/install/update-harvester-configuration.md
@@ -26,7 +26,7 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 ### Runtime change
 
-1. Log in to a Harvester node and become root. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-into-a-harvester-node) for more details.
+1. Log in to a Harvester node and become root. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-in-to-a-harvester-node) for more details.
 1. Edit `/etc/sysconfig/network/config` and update the following line. Use a space to separate DNS server addresses if there are multiple servers.
 
     ```
@@ -71,7 +71,7 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 ### Runtime change
 
-1. Log in to a Harvester node and become root. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-into-a-harvester-node) for more details.
+1. Log in to a Harvester node and become root. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-in-to-a-harvester-node) for more details.
 1. Edit `/etc/systemd/timesyncd.conf` and specify NTP servers in the `NTP=` setting:
 
     ```
@@ -128,7 +128,7 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 ### Runtime change
 
-1. Log in to a Harvester node as user `rancher`. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-into-a-harvester-node) for more details.
+1. Log in to a Harvester node as user `rancher`. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-in-to-a-harvester-node) for more details.
 1. Edit `/home/rancher/.ssh/authorized_keys` to add or remove keys.
 
 ### Configuration persistence
@@ -156,7 +156,7 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 ### Runtime change
 
-1. Log in to a Harvester node as user `rancher`. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-into-a-harvester-node) for more details.
+1. Log in to a Harvester node as user `rancher`. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-in-to-a-harvester-node) for more details.
 1. To reset the password for the user `rancher`, run the command `passwd`. 
 
 ### Configuration persistence
@@ -176,7 +176,7 @@ You can update the slave interfaces of Harvester's management bonding interface 
 
 ### Runtime change
 
-1. Log in to a Harvester node and become root. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-into-a-harvester-node) for more details.
+1. Log in to a Harvester node and become root. See [how to log into a Harvester node](../troubleshooting/os.md#how-to-log-in-to-a-harvester-node) for more details.
 1. Identify the interface names with the following command:
 
     ```

--- a/docs/rancher/cloud-provider.md
+++ b/docs/rancher/cloud-provider.md
@@ -192,7 +192,7 @@ Harvester's built-in load balancer offers both **DHCP** and **Pool** modes, and 
 
 - **DCHP:** A DHCP server is required. The Harvester load balancer will request an IP address from the DHCP server.
 
-- **Pool:** An [IP pool](/networking/ippool.md) must be configured first. The Harvester load balancer controller will allocate an IP for the load balancer service following [the IP pool selection policy](/networking/ippool.md/#selection-policy).
+- **Pool:** An [IP pool](../networking/ippool.md) must be configured first. The Harvester load balancer controller will allocate an IP for the load balancer service following [the IP pool selection policy](../networking/ippool.md#selection-policy).
 
 - **Share IP:** When creating a new load balancer service, you can re-utilize an existing load balancer service IP. The new service is referred to as a secondary service, while the currently chosen service is the primary one. To specify the primary service in the secondary service, you can add the annotation `cloudprovider.harvesterhci.io/primary-service: $primary-service-name`.  However, there are two known limitations:
   - Services that share the same IP address can't use the same port.

--- a/docs/rancher/csi-driver.md
+++ b/docs/rancher/csi-driver.md
@@ -221,7 +221,7 @@ Follow these steps to set up **RBAC** for error message visibility:
 ### Deploying
 Now you can create a new StorageClass that you intend to use in your guest Kubernetes cluster.
 
-1. For administrators, you can create a desired [StorageClass](https://docs.harvesterhci.io/dev/advanced/storageclass) (e.g., named **replica-2**) in your bare-metal Harvester cluster.
+1. For administrators, you can create a desired [StorageClass](../advanced/storageclass.md) (e.g., named **replica-2**) in your bare-metal Harvester cluster.
 
     ![](/img/v1.2/rancher/sc-replica-2.png)
 

--- a/docs/rancher/node/k3s-cluster.md
+++ b/docs/rancher/node/k3s-cluster.md
@@ -17,7 +17,7 @@ You can now provision K3s Kubernetes clusters on top of the Harvester cluster in
 - Harvester K3s node driver is in **Tech Preview**.
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
 - Harvester node driver only supports cloud images.
-- For the port requirements of the guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](install/requirements.md#inbound-rules-for-k3s-or-rkerke2-clusters).
+- For the port requirements of the guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 
 :::
 

--- a/docs/rancher/node/rke1-cluster.md
+++ b/docs/rancher/node/rke1-cluster.md
@@ -18,7 +18,7 @@ RKE1 and RKE2 have several slight behavioral differences. Refer to the [differen
 
 - VLAN network is required for Harvester node driver.
 - Harvester node driver only supports cloud images.
-- For port requirements of guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](install/requirements.md#inbound-rules-for-k3s-or-rkerke2-clusters).
+- For port requirements of guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 
 :::
 

--- a/docs/rancher/node/rke2-cluster.md
+++ b/docs/rancher/node/rke2-cluster.md
@@ -16,7 +16,7 @@ You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster i
 
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
 - Harvester node driver only supports cloud images.
-- For the port requirements of the guest clusters deployed within Harvester, please refer to the doc [here](install/requirements.md#inbound-rules-for-k3s-or-rkerke2-clusters).
+- For the port requirements of the guest clusters deployed within Harvester, please refer to the doc [here](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 - For RKE2 with Harvester cloud provider support matrix, please refer to the website [here](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/).
 
 :::

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -22,7 +22,7 @@ Users can import and manage multiple Harvester clusters using the Rancher [Virtu
 
 For a comprehensive overview of the support matrix, please refer to the [Harvester & Rancher Support Matrix](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/).
 
-For the network requirements, please refer to the doc [here](install/requirements.md#network-requirements).
+For the network requirements, please refer to the doc [here](../install/requirements.md#network-requirements).
 
 <div class="text-center">
 <iframe width="950" height="475" src="https://www.youtube.com/embed/fyxDm3HVwWI" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -37,7 +37,7 @@ default via 10.10.0.10 dev mgmt-br proto dhcp        <-- Does a default route ex
 ## Modifying cluster token on agent nodes
 
 When an agent node fails to join the cluster, it can be related to the cluster token not being identical to the server node token.
-In order to confirm the issue, connect to your agent node (i.e. with [SSH](./os.md#how-to-log-into-a-harvester-node) and check the `rancherd` service log with the following command:
+In order to confirm the issue, connect to your agent node (i.e. with [SSH](./os.md#how-to-log-in-to-a-harvester-node) and check the `rancherd` service log with the following command:
 
 ```shell
 $ sudo journalctl -b -u rancherd

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ const config = {
   tagline: "The open source hyperconverged infrastructure (HCI) solution for a cloud native world",
   url: "https://docs.harvesterhci.io",
   baseUrl: "/",
-  onBrokenLinks: "throw",
+  onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
   organizationName: "harvester",

--- a/i18n/zh/docusaurus-plugin-content-docs/current/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/index.md
@@ -32,7 +32,7 @@ Harvester 架构由尖端的开源技术组成：
 ## Harvester 功能
 
 Harvester 是一个企业就绪、易于使用的基础设施平台，它使用本地、直接连接的存储而不是复杂的外部 SAN。它使用 Kubernetes API 作为跨容器和虚拟机工作负载的统一自动化语言。Harvester 的一些主要功能包括：
-- **易于上手**。由于 Harvester 作为可启动的设备镜像提供，因此你可以使用 [ISO 镜像](https://github.com/harvester/harvester/releases)将其直接安装在裸机服务器上，也可以使用 [iPXE](https://docs.harvesterhci.io/dev/install/pxe-boot-install) 脚本进行自动安装。
+- **易于上手**。由于 Harvester 作为可启动的设备镜像提供，因此你可以使用 [ISO 镜像](https://github.com/harvester/harvester/releases)将其直接安装在裸机服务器上，也可以使用 [iPXE](./install/pxe-boot-install.md) 脚本进行自动安装。
 - **虚拟机生命周期管理**。轻松创建、编辑、克隆和删除虚拟机，包括 SSH-Key 注入、cloud-init 配置、以及图形和串行端口控制台。
 - **VM 热迁移**。将虚拟机迁移到不同的主机或节点，没有停机时间。
 - **虚拟机备份、快照和恢复**。从 NFS、S3 服务器或 NAS 设备备份你的虚拟机，然后使用备份来恢复故障的虚拟机，或在其他集群上创建新的虚拟机。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/rancher/csi-driver.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/rancher/csi-driver.md
@@ -217,7 +217,7 @@ Harvester CSI Driver 提供了一个标准的 CSI 接口，供 Harvester 中所�
 
 ### 部署
 
-1. 创建一个要在 Guest K8s 集群中使用的新 StorageClass。你可以参考 [StorageClasses](https://docs.harvesterhci.io/dev/advanced/storageclass) 了解更多详情。
+1. 创建一个要在 Guest K8s 集群中使用的新 StorageClass。你可以参考 [StorageClasses](../advanced/storageclass.md) 了解更多详情。
 
    如下图所示，新建一个名为 **replica-2** 的 StorageClass。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/index.md
@@ -32,7 +32,7 @@ Harvester 架构由尖端的开源技术组成：
 ## Harvester 功能
 
 Harvester 是一个企业就绪、易于使用的基础设施平台，它使用本地、直接连接的存储而不是复杂的外部 SAN。它使用 Kubernetes API 作为跨容器和虚拟机工作负载的统一自动化语言。Harvester 的一些主要功能包括：
-- **易于上手**。由于 Harvester 作为可启动的设备镜像提供，因此你可以使用 [ISO 镜像](https://github.com/harvester/harvester/releases)将其直接安装在裸机服务器上，也可以使用 [iPXE](https://docs.harvesterhci.io/dev/install/pxe-boot-install) 脚本进行自动安装。
+- **易于上手**。由于 Harvester 作为可启动的设备镜像提供，因此你可以使用 [ISO 镜像](https://github.com/harvester/harvester/releases)将其直接安装在裸机服务器上，也可以使用 [iPXE](./install/pxe-boot-install.md) 脚本进行自动安装。
 - **虚拟机生命周期管理**。轻松创建、编辑、克隆和删除虚拟机，包括 SSH-Key 注入、cloud-init 配置、以及图形和串行端口控制台。
 - **VM 热迁移**。将虚拟机迁移到不同的主机或节点，没有停机时间。
 - **虚拟机备份、快照和恢复**。从 NFS、S3 服务器或 NAS 设备备份你的虚拟机，然后使用备份来恢复故障的虚拟机，或在其他集群上创建新的虚拟机。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/rancher/csi-driver.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/rancher/csi-driver.md
@@ -217,7 +217,7 @@ Harvester CSI Driver 提供了一个标准的 CSI 接口，供 Harvester 中所�
 
 ### 部署
 
-1. 创建一个要在 Guest K8s 集群中使用的新 StorageClass。你可以参考 [StorageClasses](https://docs.harvesterhci.io/dev/advanced/storageclass) 了解更多详情。
+1. 创建一个要在 Guest K8s 集群中使用的新 StorageClass。你可以参考 [StorageClasses](../advanced/storageclass.md) 了解更多详情。
 
    如下图所示，新建一个名为 **replica-2** 的 StorageClass。
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remark-cli": "^11.0.0",
-    "remark-lint-no-dead-urls": "^1.1.0"
+    "remark-lint-no-dead-urls": "^1.1.0",
+    "remark-validate-links": "^12.1.1"
   },
   "browserslist": {
     "production": [
@@ -45,12 +46,6 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"
-    ]
-  },
-  "remarkConfig": {
-    "plugins": [
-      "remark-validate-links",
-      "remark-lint-no-dead-urls"
     ]
   }
 }

--- a/versioned_docs/version-v1.1/index.md
+++ b/versioned_docs/version-v1.1/index.md
@@ -28,7 +28,7 @@ The Harvester architecture consists of cutting-edge open-source technologies:
 ## Harvester Features
 
 Harvester is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features of Harvester include:
-- **Easy to get started.** Since Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the [ISO image](https://github.com/harvester/harvester/releases) or automatically install it using [iPXE](https://docs.harvesterhci.io/dev/install/pxe-boot-install) scripts.
+- **Easy to get started.** Since Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the [ISO image](https://github.com/harvester/harvester/releases) or automatically install it using [iPXE](./install/pxe-boot-install.md) scripts.
 - **VM lifecycle management.** Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 - **VM live migration.** Move a VM to a different host or node with zero downtime.
 - **VM backup, snapshot, and restore.** Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.

--- a/versioned_docs/version-v1.1/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.1/rancher/csi-driver.md
@@ -223,7 +223,7 @@ Make sure the `serviceaccount name` and `namespace` are the same as your cloud p
 
 ### Deploying
 
-1. Create a new StorageClass that you would like to use in your guest k8s cluster. You can refer to the [StorageClasses](https://docs.harvesterhci.io/dev/advanced/storageclass) for more details.
+1. Create a new StorageClass that you would like to use in your guest k8s cluster. You can refer to the [StorageClasses](../advanced/storageclass.md) for more details.
 
     As show in the following figure, create a new StorageClass named **replica-2**.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,6 +5668,11 @@ github-slugger@^1.4.0:
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.5.0.tgz#17891bbc73232051474d68bd867a34625c955f7d"
   integrity sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==
 
+github-slugger@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -6063,6 +6068,13 @@ hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+hosted-git-info@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-6.1.1.tgz#629442c7889a69c05de604d52996b74fe6f26d58"
+  integrity sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==
+  dependencies:
+    lru-cache "^7.5.1"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -6847,6 +6859,11 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
+levenshtein-edit-distance@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz#895baf478cce8b5c1a0d27e45d7c1d978a661e49"
+  integrity sha512-gpgBvPn7IFIAL32f0o6Nsh2g+5uOvkt4eK9epTfgE4YVxBxwVhJ/p1888lMm/u8mXdu1ETLSi6zeEmkBI+0F3w==
+
 lilconfig@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
@@ -6999,6 +7016,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.5.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
 "lru-cache@^9.1.1 || ^10.0.0":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
@@ -7128,7 +7150,7 @@ mdast-util-to-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
   integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
-mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
+mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0, mdast-util-to-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
   integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
@@ -8585,6 +8607,13 @@ property-information@^6.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.2.0.tgz#b74f522c31c097b5149e3c3cb8d7f3defd986a1d"
   integrity sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==
 
+propose@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/propose/-/propose-0.0.5.tgz#48a065d9ec7d4c8667f4050b15c4a2d85dbca56b"
+  integrity sha512-Jary1vb+ap2DIwOGfyiadcK4x1Iu3pzpkDBy8tljFPmQvnc9ES3m1PMZOMiWOG50cfoAyYNtGeBzrp+Rlh4G9A==
+  dependencies:
+    levenshtein-edit-distance "^1.0.0"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -9211,6 +9240,23 @@ remark-stringify@^10.0.0:
     "@types/mdast" "^3.0.0"
     mdast-util-to-markdown "^1.0.0"
     unified "^10.0.0"
+
+remark-validate-links@^12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/remark-validate-links/-/remark-validate-links-12.1.1.tgz#8c2060d547cdb5872bd443f8ce62e5a897ef8195"
+  integrity sha512-nk/CkcZ3u8QntoMCqZ+JzUzFub36E+mNFMMbYqqN+yQViUHbRLqirCG1qOI4E38RyKZ8abjFUv0JGB7skKa41A==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    github-slugger "^2.0.0"
+    hosted-git-info "^6.0.0"
+    mdast-util-to-string "^3.2.0"
+    propose "0.0.5"
+    to-vfile "^7.0.0"
+    trough "^2.0.0"
+    unified "^10.0.0"
+    unified-engine "^10.0.1"
+    unist-util-visit "^4.0.0"
+    vfile "^5.0.0"
 
 remark@^14.0.0:
   version "14.0.3"
@@ -10265,7 +10311,7 @@ unified-args@^10.0.0:
     text-table "^0.2.0"
     unified-engine "^10.0.0"
 
-unified-engine@^10.0.0:
+unified-engine@^10.0.0, unified-engine@^10.0.1:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-10.1.0.tgz#6899f00d1f53ee9af94f7abd0ec21242aae3f56c"
   integrity sha512-5+JDIs4hqKfHnJcVCxTid1yBoI/++FfF/1PFdSMpaftZZZY+qg2JFruRbf7PaIwa9KgLotXQV3gSjtY0IdcFGQ==


### PR DESCRIPTION
This PR:

1. Fixes broken links found in the existing docs.
2. Changed `dev` to `v1.2` in v1.2-related links.
3. Adds back the `remark-validate-links` plugin that was accidentally deleted in #388.
4. Sets `onBrokenLinks` to `warn` to avoid CI failure caused by the update time gap between the CN and EN docs during documentation development.
5. Use relative links rather than URLs.
6. Tweaks the remark config to better facilitate local link checks.

## Related issues

Fixes #415