### PR TITLE
Use "v1.2" for v1.2 doc URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,7 +42,7 @@ const config = {
           versions: {
             current: {
               label: 'v1.2-dev',
-              path: 'dev',
+              path: 'v1.2',
             },
             "v1.1": {
               path: "v1.1",


### PR DESCRIPTION
Use `v1.2` in v1.2 doc URLs instead of `dev` so that we can use the correct URLs in the Release Notes and the Dashboard.