### PR TITLE
Convert URLs to relative paths

### DIFF
--- a/docs/upgrade/v1-0-3-to-v1-1-1.md
+++ b/docs/upgrade/v1-0-3-to-v1-1-1.md
@@ -89,7 +89,7 @@ An upgrade is stuck, as shown in the screenshot below:
 
 ### 5. Additional certificates disappear after an upgrade
 
-After upgrading from v1.0.3, the file `/etc/pki/trust/anchors/additional-ca.pem` configured via the [`additional-ca` setting](https://docs.harvesterhci.io/v1.1/advanced/settings#additional-ca) disappears.
+After upgrading from v1.0.3, the file `/etc/pki/trust/anchors/additional-ca.pem` configured via the [`additional-ca` setting](../advanced/settings.md#additional-ca) disappears.
 
 To fix this, the user needs to access the Settings page (Harvester GUI, `Advanced -> Settings`): 
 - Edit the `additional-ca` setting. Back up the current value first, clear the current value, and click `Save`.

--- a/docs/vm/live-migration.md
+++ b/docs/vm/live-migration.md
@@ -34,7 +34,7 @@ Live migration means moving a virtual machine to a different host without downti
 
 ![](/img/v1.2/vm/migrate-action.png)
 
-When you have [node scheduling rules](https://docs.harvesterhci.io/v1.1/vm/create-windows-vm/#node-scheduling-tab) configured for a VM, you must ensure that the target nodes you are migrating to meet the VM's runtime requirements. The list of nodes you get to search and select from will be generated based on:
+When you have [node scheduling rules](./create-windows-vm.md#node-scheduling-tab) configured for a VM, you must ensure that the target nodes you are migrating to meet the VM's runtime requirements. The list of nodes you get to search and select from will be generated based on:
 - VM scheduling rules.
 - Possibly node rules from the network configuration.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/advanced/storageclass.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/advanced/storageclass.md
@@ -102,13 +102,13 @@ StorageClass 动态创建的卷将具有在类的 `reclaimPolicy` 字段中指�
 
 #### 推荐做法
 
-首先，在 `Host` 页面添加你的 HDD，然后根据需要添加磁盘标签，例如 `HDD` 或 `ColdStorage`。有关如何添加其他磁盘和磁盘标签的更多信息，请参阅[多磁盘管理](https://docs.harvesterhci.io/v1.1/host/#multi-disk-management)。
+首先，在 `Host` 页面添加你的 HDD，然后根据需要添加磁盘标签，例如 `HDD` 或 `ColdStorage`。有关如何添加其他磁盘和磁盘标签的更多信息，请参阅[多磁盘管理](../host/host.md#多磁盘管理)。
 
 ![](/img/v1.2/storageclass/add_hdd_on_host_page.png)
 
 ![](/img/v1.2/storageclass/add_tags.png)
 
-然后，为 HDD 创建一个新的 `StorageClass`（使用上面的磁盘标签）。对于容量大但性能慢的硬盘，你可以减少副本数量来提高性能。有关详细信息，请参阅 [storageclass](https://docs.harvesterhci.io/v1.1/advanced/storageclass)。
+然后，为 HDD 创建一个新的 `StorageClass`（使用上面的磁盘标签）。对于容量大但性能慢的硬盘，你可以减少副本数量来提高性能。
 
 ![](/img/v1.2/storageclass/create_hdd_storageclass.png)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/upgrade/v1-0-3-to-v1-1-1.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/upgrade/v1-0-3-to-v1-1-1.md
@@ -83,7 +83,7 @@ node3   Ready,SchedulingDisabled   control-plane,etcd,master   20d   v1.24.7+rke
 
 ### 5. 其他受信 CA 证书在更新后遗失
 
-从 v1.0.3 升级后，通过 [`additional-ca`](https://docs.harvesterhci.io/v1.1/advanced/settings#additional-ca) 设置配置的 `/etc/pki/trust/anchors/additional-ca.pem` 文件消失了。
+从 v1.0.3 升级后，通过 [`additional-ca`](../advanced/settings.md#additional-ca) 设置配置的 `/etc/pki/trust/anchors/additional-ca.pem` 文件消失了。
 
 要解决此问题，用户需要访问 Settings 页面（Harvester GUI > `Advanced > Settings`）：
 - 编辑 `additional-ca` 设置。先备份当前值，清除当前值，点击 `Save`。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/vm/live-migration.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/vm/live-migration.md
@@ -30,7 +30,7 @@ Description: 热迁移（也称为实时迁移，动态迁移）指的是在不�
 
 ![](/img/v1.2/vm/migrate-action.png)
 
-为虚拟机配置[节点调度规则](https://docs.harvesterhci.io/v1.1/vm/create-windows-vm/#node-scheduling-tab)时，你必须确保要迁移的目标节点满足虚拟机的运行时要求。可以搜索和选择的节点是基于以下内容生成的：
+为虚拟机配置[节点调度规则](./create-windows-vm.md#节点调度选项卡)时，你必须确保要迁移的目标节点满足虚拟机的运行时要求。可以搜索和选择的节点是基于以下内容生成的：
 - 虚拟机调度规则。
 - 可能来自网络配置的节点规则。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/advanced/storageclass.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/advanced/storageclass.md
@@ -102,13 +102,13 @@ StorageClass 动态创建的卷将具有在类的 `reclaimPolicy` 字段中指�
 
 #### 推荐做法
 
-首先，在 `Host` 页面添加你的 HDD，然后根据需要添加磁盘标签，例如 `HDD` 或 `ColdStorage`。有关如何添加其他磁盘和磁盘标签的更多信息，请参阅[多磁盘管理](https://docs.harvesterhci.io/v1.1/host/#multi-disk-management)。
+首先，在 `Host` 页面添加你的 HDD，然后根据需要添加磁盘标签，例如 `HDD` 或 `ColdStorage`。有关如何添加其他磁盘和磁盘标签的更多信息，请参阅[多磁盘管理](../host/host.md#多磁盘管理)。
 
 ![](/img/v1.1/storageclass/add_hdd_on_host_page.png)
 
 ![](/img/v1.1/storageclass/add_tags.png)
 
-然后，为 HDD 创建一个新的 `StorageClass`（使用上面的磁盘标签）。对于容量大但性能慢的硬盘，你可以减少副本数量来提高性能。有关详细信息，请参阅 [storageclass](https://docs.harvesterhci.io/v1.1/advanced/storageclass)。
+然后，为 HDD 创建一个新的 `StorageClass`（使用上面的磁盘标签）。对于容量大但性能慢的硬盘，你可以减少副本数量来提高性能。
 
 ![](/img/v1.1/storageclass/create_hdd_storageclass.png)
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/upgrade/v1-0-3-to-v1-1-1.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/upgrade/v1-0-3-to-v1-1-1.md
@@ -83,7 +83,7 @@ node3   Ready,SchedulingDisabled   control-plane,etcd,master   20d   v1.24.7+rke
 
 ### 5. 其他受信 CA 证书在更新后遗失
 
-从 v1.0.3 升级后，通过 [`additional-ca`](https://docs.harvesterhci.io/v1.1/advanced/settings#additional-ca) 设置配置的 `/etc/pki/trust/anchors/additional-ca.pem` 文件消失了。
+从 v1.0.3 升级后，通过 [`additional-ca`](../advanced/settings.md#additional-ca) 设置配置的 `/etc/pki/trust/anchors/additional-ca.pem` 文件消失了。
 
 要解决此问题，用户需要访问 Settings 页面（Harvester GUI > `Advanced > Settings`）：
 - 编辑 `additional-ca` 设置。先备份当前值，清除当前值，点击 `Save`。

--- a/versioned_docs/version-v1.0/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.0/rancher/node/k3s-cluster.md
@@ -15,7 +15,7 @@ You can now provision K3s Kubernetes clusters on top of the Harvester cluster in
 :::note
 
 - Harvester K3s node driver is in tech preview.
-- [VLAN network](https://docs.harvesterhci.io/v1.0/networking/harvester-network/#create-a-vlan-network) is required for Harvester node driver.
+- [VLAN network](../../networking/harvester-network.md#create-a-vlan-network) is required for Harvester node driver.
 
 :::
 

--- a/versioned_docs/version-v1.1/advanced/storageclass.md
+++ b/versioned_docs/version-v1.1/advanced/storageclass.md
@@ -106,13 +106,13 @@ HDD is not recommended for guest RKE2 clusters or VMs with good performance disk
 
 #### Recommended Practice
 
-First, add your HDD on the `Host` page and specify the disk tags as needed, such as`HDD` or `ColdStorage`. For more information on how to add extra disks and disk tags, see [Multi-disk Management](https://docs.harvesterhci.io/v1.1/host/#multi-disk-management) for details.
+First, add your HDD on the `Host` page and specify the disk tags as needed, such as`HDD` or `ColdStorage`. For more information on how to add extra disks and disk tags, see [Multi-disk Management](../host/host.md#multi-disk-management) for details.
 
 ![](/img/v1.1/storageclass/add_hdd_on_host_page.png)
 
 ![](/img/v1.1/storageclass/add_tags.png)
 
-Then, create a new `StorageClass` for the HDD (use the above disk tags). For hard drives with large capacity but slow performance, the number of replicas can be reduced to improve performance. For details, see [storageclass](https://docs.harvesterhci.io/v1.1/advanced/storageclass) for details.
+Then, create a new `StorageClass` for the HDD (use the above disk tags). For hard drives with large capacity but slow performance, the number of replicas can be reduced to improve performance.
 
 ![](/img/v1.1/storageclass/create_hdd_storageclass.png)
 

--- a/versioned_docs/version-v1.1/upgrade/v1-0-3-to-v1-1-1.md
+++ b/versioned_docs/version-v1.1/upgrade/v1-0-3-to-v1-1-1.md
@@ -89,7 +89,7 @@ An upgrade is stuck, as shown in the screenshot below:
 
 ### 5. Additional certificates disappear after an upgrade
 
-After upgrading from v1.0.3, the file `/etc/pki/trust/anchors/additional-ca.pem` configured via the [`additional-ca` setting](https://docs.harvesterhci.io/v1.1/advanced/settings#additional-ca) disappears.
+After upgrading from v1.0.3, the file `/etc/pki/trust/anchors/additional-ca.pem` configured via the [`additional-ca` setting](../advanced/settings.md#additional-ca) disappears.
 
 To fix this, the user needs to access the Settings page (Harvester GUI, `Advanced -> Settings`): 
 - Edit the `additional-ca` setting. Back up the current value first, clear the current value, and click `Save`.


### PR DESCRIPTION
Converts URLs to relative paths so that the links can point to the right version of docs

We should avoid using URLs in the docs:
- The URLs were added when we developed the v1.1 docs, and the docs were then reused in v1.2. These URLs pointing to v1.1 do not apply to v1.2 docs.
- Using relative paths makes sure that the links always point to the corresponding doc of the desired version.