### PR TITLE
Update banner for v1.1 and v1.2

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,9 +46,11 @@ const config = {
             },
             "v1.1": {
               path: "v1.1",
+              banner: `none`
             },
             "v1.0": {
               path: "v1.0",
+              banner: `unmaintained`
             }
           }
         },


### PR DESCRIPTION
- Removes banner for v1.1

<img width="774" alt="Screenshot 2023-09-08 at 8 56 13 AM" src="https://github.com/harvester/docs/assets/83089978/2cdb750d-76c5-4f07-9e4f-ad69a63fdfc7">
