### PR TITLE
Update canonical links for Installation section

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -12,7 +12,7 @@ Description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 2
 sidebar_label: ISO Installation
 title: "ISO Installation"
@@ -13,7 +12,7 @@ Description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/iso-install"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/docs/install/management-address.md
+++ b/docs/install/management-address.md
@@ -8,7 +8,7 @@ Description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ Description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -9,7 +9,7 @@ Description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements to install and run Harvester.

--- a/docs/install/update-harvester-configuration.md
+++ b/docs/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ Description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/docs/install/usb-install.md
+++ b/docs/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v0.3/install/harvester-configuration.md
+++ b/versioned_docs/version-v0.3/install/harvester-configuration.md
@@ -12,7 +12,7 @@ Description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v0.3/install/iso-install.md
+++ b/versioned_docs/version-v0.3/install/iso-install.md
@@ -12,7 +12,7 @@ Description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/iso-install"/>
 </head>
 
 To get the Harvester ISO, download it from the [Github releases.](https://github.com/harvester/harvester/releases)

--- a/versioned_docs/version-v0.3/install/management-address.md
+++ b/versioned_docs/version-v0.3/install/management-address.md
@@ -8,7 +8,7 @@ Description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address. Users can see the management address on the console dashboard after installation.

--- a/versioned_docs/version-v0.3/install/pxe-boot-install.md
+++ b/versioned_docs/version-v0.3/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ Description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v0.3/install/usb-install.md
+++ b/versioned_docs/version-v0.3/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.0/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.0/install/harvester-configuration.md
@@ -12,7 +12,7 @@ Description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.0/install/iso-install.md
+++ b/versioned_docs/version-v1.0/install/iso-install.md
@@ -12,7 +12,7 @@ Description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/iso-install"/>
 </head>
 
 To get the Harvester ISO image, download it from the [Github releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.0/install/management-address.md
+++ b/versioned_docs/version-v1.0/install/management-address.md
@@ -8,7 +8,7 @@ Description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.0/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.0/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ Description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.0/install/requirements.md
+++ b/versioned_docs/version-v1.0/install/requirements.md
@@ -8,7 +8,7 @@ Description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, Harvester has some minimum requirements as outlined below.

--- a/versioned_docs/version-v1.0/install/usb-install.md
+++ b/versioned_docs/version-v1.0/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.1/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/harvester-configuration.md
@@ -12,7 +12,7 @@ Description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.1/install/iso-install.md
+++ b/versioned_docs/version-v1.1/install/iso-install.md
@@ -12,7 +12,7 @@ Description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/iso-install"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.1/install/management-address.md
+++ b/versioned_docs/version-v1.1/install/management-address.md
@@ -8,7 +8,7 @@ Description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.1/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.1/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ Description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.1/install/requirements.md
+++ b/versioned_docs/version-v1.1/install/requirements.md
@@ -9,7 +9,7 @@ Description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements to install and run Harvester.

--- a/versioned_docs/version-v1.1/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ Description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/versioned_docs/version-v1.1/install/usb-install.md
+++ b/versioned_docs/version-v1.1/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for Installation section (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Removed page ID for iso-install.md page 