### PR TITLE
Update canonical link for airgap.md page

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -10,6 +10,10 @@ keywords:
 - HTTP proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/airgap"/>
+</head>
+
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.
 
 The Harvester ISO image contains all the packages to make it work in an air gapped environment.

--- a/versioned_docs/version-v1.0/airgap.md
+++ b/versioned_docs/version-v1.0/airgap.md
@@ -9,6 +9,10 @@ keywords:
 - HTTP proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/airgap"/>
+</head>
+
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.
 
 The Harvester ISO image contains all the packages to make it work in an air gapped environment.

--- a/versioned_docs/version-v1.1/airgap.md
+++ b/versioned_docs/version-v1.1/airgap.md
@@ -10,6 +10,10 @@ keywords:
 - HTTP proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/airgap"/>
+</head>
+
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.
 
 The Harvester ISO image contains all the packages to make it work in an air gapped environment.


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Air Gapped Environment page (v1.0-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/