### PR TITLE
Update canonical links for Upgrade section

### DIFF
--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -1,5 +1,5 @@
 ---
-id: index
+id: upgrading-harvester
 sidebar_position: 1
 sidebar_label: Upgrading Harvester
 title: "Upgrading Harvester"
@@ -13,7 +13,7 @@ Description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/upgrading-harvester"/>
 </head>
 
 ## Upgrade support matrix

--- a/docs/upgrade/troubleshooting.md
+++ b/docs/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/docs/upgrade/v1-0-3-to-v1-1-1.md
+++ b/docs/upgrade/v1-0-3-to-v1-1-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.0.3/v1.1.0 to v1.1.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/v1-0-3-to-v1-1-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-0-3-to-v1-1-1"/>
 </head>
 
 

--- a/docs/upgrade/v1-1-to-v1-1-2.md
+++ b/docs/upgrade/v1-1-to-v1-1-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.0/v1.1.1 to v1.1.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/v1-1-to-v1-1-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-1-to-v1-1-2"/>
 </head>
 
 :::danger

--- a/versioned_docs/version-v0.3/upgrade.md
+++ b/versioned_docs/version-v0.3/upgrade.md
@@ -1,4 +1,5 @@
 ---
+id: upgrading-harvester
 sidebar_position: 4
 sidebar_label: Upgrading Harvester
 title: "Upgrading Harvester"
@@ -10,6 +11,10 @@ keywords:
   - Harvester Upgrade
 Description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/upgrading-harvester"/>
+</head>
 
 :::note
 

--- a/versioned_docs/version-v1.0/upgrade/automatic.md
+++ b/versioned_docs/version-v1.0/upgrade/automatic.md
@@ -1,4 +1,5 @@
 ---
+id: upgrading-harvester
 sidebar_position: 1
 sidebar_label: Upgrading Harvester
 title: "Upgrading Harvester"
@@ -12,7 +13,7 @@ Description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/upgrading-harvester"/>
 </head>
 
 ## Upgrade support matrix

--- a/versioned_docs/version-v1.0/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.0/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.1/upgrade/automatic.md
+++ b/versioned_docs/version-v1.1/upgrade/automatic.md
@@ -1,5 +1,5 @@
 ---
-id: index
+id: upgrading-harvester
 sidebar_position: 1
 sidebar_label: Upgrading Harvester
 title: "Upgrading Harvester"
@@ -13,7 +13,7 @@ Description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/upgrading-harvester"/>
 </head>
 
 ## Upgrade support matrix

--- a/versioned_docs/version-v1.1/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.1/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.1/upgrade/v1-0-3-to-v1-1-1.md
+++ b/versioned_docs/version-v1.1/upgrade/v1-0-3-to-v1-1-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.0.3/v1.1.0 to v1.1.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/v1-0-3-to-v1-1-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-0-3-to-v1-1-1"/>
 </head>
 
 

--- a/versioned_docs/version-v1.1/upgrade/v1-1-to-v1-1-2.md
+++ b/versioned_docs/version-v1.1/upgrade/v1-1-to-v1-1-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.0/v1.1.1 to v1.1.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/v1-1-to-v1-1-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-1-to-v1-1-2"/>
 </head>
 
 :::danger


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for Upgrade section (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Change page ID for automatic.md to upgrading-harvester