### PR TITLE
Update canonical links for Authentication page

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -12,6 +12,10 @@ keywords:
 Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+</head>
+
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 
 ![auth](/img/v1.2/install/first-time-login.png)

--- a/versioned_docs/version-v0.3/authentication.md
+++ b/versioned_docs/version-v0.3/authentication.md
@@ -11,6 +11,10 @@ keywords:
 Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+</head>
+
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 
 ![auth](./install/assets/first-time-login.png)

--- a/versioned_docs/version-v1.0/authentication.md
+++ b/versioned_docs/version-v1.0/authentication.md
@@ -11,6 +11,10 @@ keywords:
 Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+</head>
+
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 
 ![auth](/img/v1.0/install/first-time-login.png)

--- a/versioned_docs/version-v1.1/authentication.md
+++ b/versioned_docs/version-v1.1/authentication.md
@@ -12,6 +12,10 @@ keywords:
 Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+</head>
+
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 
 ![auth](/img/v1.1/install/first-time-login.png)


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Authentication section (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/