### PR TITLE
Update canonical links for Upload Image page

### DIFF
--- a/docs/upload-image.md
+++ b/docs/upload-image.md
@@ -12,6 +12,10 @@ keywords:
 Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+</head>
+
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 
 ### Upload Images via URL

--- a/versioned_docs/version-v0.3/upload-image.md
+++ b/versioned_docs/version-v0.3/upload-image.md
@@ -11,6 +11,10 @@ keywords:
 Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+</head>
+
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 
 ### Upload Images via URL

--- a/versioned_docs/version-v1.0/upload-image.md
+++ b/versioned_docs/version-v1.0/upload-image.md
@@ -11,6 +11,10 @@ keywords:
 Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+</head>
+
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 
 ### Upload Images via URL

--- a/versioned_docs/version-v1.1/upload-image.md
+++ b/versioned_docs/version-v1.1/upload-image.md
@@ -12,6 +12,10 @@ keywords:
 Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+</head>
+
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 
 ### Upload Images via URL


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Upload Images page (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/