### PR TITLE
Update canonical links for Host Management page

### DIFF
--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -5,6 +5,10 @@ sidebar_label: Host Management
 title: "Host Management"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+</head>
+
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 
 :::note

--- a/versioned_docs/version-v0.3/host/host.md
+++ b/versioned_docs/version-v0.3/host/host.md
@@ -4,6 +4,10 @@ sidebar_label: Host Management
 title: "Host Management"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+</head>
+
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are more than three nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 
 :::note

--- a/versioned_docs/version-v1.0/host/host.md
+++ b/versioned_docs/version-v1.0/host/host.md
@@ -4,6 +4,10 @@ sidebar_label: Host Management
 title: "Host Management"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+</head>
+
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 
 :::note

--- a/versioned_docs/version-v1.1/host/host.md
+++ b/versioned_docs/version-v1.1/host/host.md
@@ -5,6 +5,10 @@ sidebar_label: Host Management
 title: "Host Management"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+</head>
+
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 
 :::note


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Host Management page (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/