### PR TITLE
Update canonical links for Logging page

### DIFF
--- a/docs/logging/harvester-logging.md
+++ b/docs/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.1/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.1/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.1.0_


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Logging page (v1.1-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/