### PR TITLE
Update canonical links for Monitoring page

### DIFF
--- a/docs/monitoring/harvester-monitoring.md
+++ b/docs/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v0.3/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v0.3/monitoring/harvester-monitoring.md
@@ -4,7 +4,7 @@ sidebar_label: Monitoring
 title: "Monitoring"
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.0/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.0/monitoring/harvester-monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.1/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.1/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v0.3.0_


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Monitoring page (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/