### PR TITLE
Update canonical links for Harvester Terraform Provider page

### DIFF
--- a/docs/terraform/terraform-provider.md
+++ b/docs/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v0.3/terraform/terraform-provider.md
+++ b/versioned_docs/version-v0.3/terraform/terraform-provider.md
@@ -5,7 +5,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
 </head>
 
 ## Requirements

--- a/versioned_docs/version-v1.0/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.0/terraform/terraform-provider.md
@@ -5,7 +5,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
 </head>
 
 ## Requirements

--- a/versioned_docs/version-v1.1/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.1/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Harvester Terraform Provider page (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/