### PR TITLE
Update canonical links for FAQ page

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,6 +5,10 @@ sidebar_label: FAQ
 title: "FAQ"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+</head>
+
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 
 ### How can I ssh login to the Harvester node?

--- a/versioned_docs/version-v0.3/faq.md
+++ b/versioned_docs/version-v0.3/faq.md
@@ -4,6 +4,10 @@ sidebar_label: FAQ
 title: "FAQ"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+</head>
+
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 
 1. How can I ssh login to the Harvester node?

--- a/versioned_docs/version-v1.0/faq.md
+++ b/versioned_docs/version-v1.0/faq.md
@@ -4,6 +4,10 @@ sidebar_label: FAQ
 title: "FAQ"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+</head>
+
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 
 ### How can I ssh login to the Harvester node?

--- a/versioned_docs/version-v1.1/faq.md
+++ b/versioned_docs/version-v1.1/faq.md
@@ -5,6 +5,10 @@ sidebar_label: FAQ
 title: "FAQ"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+</head>
+
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 
 ### How can I ssh login to the Harvester node?


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for FAQ page (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/