### PR TITLE
Update canonical links for VM Management section

### DIFF
--- a/docs/vm/access-to-the-vm.md
+++ b/docs/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ Description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/docs/vm/backup-restore.md
+++ b/docs/vm/backup-restore.md
@@ -12,7 +12,7 @@ Description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/docs/vm/clone-vm.md
+++ b/docs/vm/clone-vm.md
@@ -12,7 +12,7 @@ Description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/vm/create-vm.md
+++ b/docs/vm/create-vm.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Create a Virtual Machine
 title: "Create a Virtual Machine"
@@ -15,7 +14,7 @@ Description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/docs/vm/create-windows-vm.md
+++ b/docs/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ Description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/docs/vm/edit-vm.md
+++ b/docs/vm/edit-vm.md
@@ -14,7 +14,7 @@ Description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/docs/vm/hotplug-volume.md
+++ b/docs/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ Description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/docs/vm/live-migration.md
+++ b/docs/vm/live-migration.md
@@ -12,7 +12,7 @@ Description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/docs/vm/resource-overcommit.md
+++ b/docs/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ Description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v0.3/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v0.3/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ Description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v0.3/vm/backup-restore.md
+++ b/versioned_docs/version-v0.3/vm/backup-restore.md
@@ -12,7 +12,7 @@ Description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/backup-restore"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/vm/create-vm.md
+++ b/versioned_docs/version-v0.3/vm/create-vm.md
@@ -12,7 +12,7 @@ Description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v0.3/vm/hotplug-volume.md
+++ b/versioned_docs/version-v0.3/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ Description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v0.3/vm/live-migration.md
+++ b/versioned_docs/version-v0.3/vm/live-migration.md
@@ -12,7 +12,7 @@ Description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.0/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.0/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ Description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/access-to-the-vm"/>
 </head>
 
 

--- a/versioned_docs/version-v1.0/vm/backup-restore.md
+++ b/versioned_docs/version-v1.0/vm/backup-restore.md
@@ -12,7 +12,7 @@ Description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/backup-restore"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.0/vm/create-vm.md
+++ b/versioned_docs/version-v1.0/vm/create-vm.md
@@ -14,7 +14,7 @@ Description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.0/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.0/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ Description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/create-windows-vm"/>
 </head>
 
 

--- a/versioned_docs/version-v1.0/vm/edit-vm.md
+++ b/versioned_docs/version-v1.0/vm/edit-vm.md
@@ -14,7 +14,7 @@ Description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.0/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.0/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ Description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.0/vm/live-migration.md
+++ b/versioned_docs/version-v1.0/vm/live-migration.md
@@ -12,7 +12,7 @@ Description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.0/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.0/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ Description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../settings/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.1/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.1/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ Description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.1/vm/backup-restore.md
+++ b/versioned_docs/version-v1.1/vm/backup-restore.md
@@ -12,7 +12,7 @@ Description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.1/vm/clone-vm.md
+++ b/versioned_docs/version-v1.1/vm/clone-vm.md
@@ -12,7 +12,7 @@ Description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/vm/create-vm.md
+++ b/versioned_docs/version-v1.1/vm/create-vm.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Create a Virtual Machine
 title: "Create a Virtual Machine"
@@ -15,7 +14,7 @@ Description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.1/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.1/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ Description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.1/vm/edit-vm.md
+++ b/versioned_docs/version-v1.1/vm/edit-vm.md
@@ -14,7 +14,7 @@ Description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.1/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.1/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ Description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.1/vm/live-migration.md
+++ b/versioned_docs/version-v1.1/vm/live-migration.md
@@ -12,7 +12,7 @@ Description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.1/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.1/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ Description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for VM Management section (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Remove Index ID for create-vm.md page