### PR TITLE
Update canonical links for Volume Management section

### DIFF
--- a/docs/volume/clone-volume.md
+++ b/docs/volume/clone-volume.md
@@ -8,7 +8,7 @@ Description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Create a Volume
 title: "Create a Volume"
@@ -9,7 +8,7 @@ Description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/create-volume"/>
 </head>
 
 ## Create an Empty Volume

--- a/docs/volume/edit-volume.md
+++ b/docs/volume/edit-volume.md
@@ -8,7 +8,7 @@ Description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/docs/volume/export-volume.md
+++ b/docs/volume/export-volume.md
@@ -8,7 +8,7 @@ Description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/docs/volume/volume-snapshots.md
+++ b/docs/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 Description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.1/volume/clone-volume.md
+++ b/versioned_docs/version-v1.1/volume/clone-volume.md
@@ -8,7 +8,7 @@ Description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/clone-volume"/>
 </head>
 
 After creating a volume, you can clone the volume by following the steps below:

--- a/versioned_docs/version-v1.1/volume/create-volume.md
+++ b/versioned_docs/version-v1.1/volume/create-volume.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Create a Volume
 title: "Create a Volume"
@@ -9,7 +8,7 @@ Description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/create-volume"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.1/volume/edit-volume.md
+++ b/versioned_docs/version-v1.1/volume/edit-volume.md
@@ -8,7 +8,7 @@ Description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.1/volume/export-volume.md
+++ b/versioned_docs/version-v1.1/volume/export-volume.md
@@ -8,7 +8,7 @@ Description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.1/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.1/volume/volume-snapshots.md
@@ -9,7 +9,7 @@ Description: Take a snapshot for a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for Volume Management section (v1.1-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Remove Index ID for create-volume.md page