### PR TITLE
Update canonical links for Networking section

### DIFF
--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Cluster Network
 title: "Cluster Network"
@@ -12,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/clusternetwork"/>
 </head>
 
 ## Concepts

--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/index"/>
 </head>
 
 ## Concepts

--- a/docs/networking/deep-dive.md
+++ b/docs/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/deep-dive"/>
 </head>
 
 The network topology below reveals how we implement the Harvester network.

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/docs/networking/ippool.md
+++ b/docs/networking/ippool.md
@@ -5,6 +5,11 @@ title: "IP Pool"
 keywords:
 - IP Pool
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/ippool"/>
+</head>
+
 _Available as of v1.2.0_
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).

--- a/docs/networking/loadbalancer.md
+++ b/docs/networking/loadbalancer.md
@@ -5,6 +5,11 @@ title: "Load Balancer"
 keywords:
 - Load Balancer
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/loadbalancer"/>
+</head>
+
 _Available as of v1.2.0_
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.

--- a/versioned_docs/version-v0.3/networking/harvester-network.md
+++ b/versioned_docs/version-v0.3/networking/harvester-network.md
@@ -12,7 +12,7 @@ Description: Harvester is built on Kubernetes, which uses CNI as an interface be
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/harvester-network"/>
 </head>
 
 Harvester is built on top of [Kubernetes](https://kubernetes.io/) and leverages its built-in [CNI](https://github.com/containernetworking/cni) mechanism to provide the interface between network providers and its VM networks. 

--- a/versioned_docs/version-v1.0/networking/harvester-network.md
+++ b/versioned_docs/version-v1.0/networking/harvester-network.md
@@ -12,7 +12,7 @@ Description: Harvester is built on Kubernetes, which uses CNI as an interface be
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/harvester-network"/>
 </head>
 
 Harvester is built on top of [Kubernetes](https://kubernetes.io/) and leverages its built-in [CNI](https://github.com/containernetworking/cni) mechanism to provide the interface between network providers and its VM networks. 

--- a/versioned_docs/version-v1.1/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.1/networking/clusternetwork.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Cluster Network
 title: "Cluster Network"
@@ -12,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/clusternetwork"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.1/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.1/networking/clusternetwork.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.1/networking/deep-dive.md
+++ b/versioned_docs/version-v1.1/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/deep-dive"/>
 </head>
 
 The network topology below reveals how we implement the Harvester network.

--- a/versioned_docs/version-v1.1/networking/harvester-network.md
+++ b/versioned_docs/version-v1.1/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of virtual networks for virtual machines (VMs), including:


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for Networking section (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Remove Index ID for clusternetwork.md page