### PR TITLE
Update canonical links for Troubleshooting section

### DIFF
--- a/docs/troubleshooting/harvester.md
+++ b/docs/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -1,12 +1,11 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Installation
 title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/docs/troubleshooting/monitoring.md
+++ b/docs/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v0.3/troubleshooting/harvester.md
+++ b/versioned_docs/version-v0.3/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/harvester"/>
 </head>
 
 ## Generate a Support Bundle

--- a/versioned_docs/version-v0.3/troubleshooting/installation.md
+++ b/versioned_docs/version-v0.3/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v0.3/troubleshooting/installation.md
+++ b/versioned_docs/version-v0.3/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v0.3/troubleshooting/os.md
+++ b/versioned_docs/version-v0.3/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [cOS toolkit](https://github.com/rancher-sandbox/cOS-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.0/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.0/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/harvester"/>
 </head>
 
 ## Generate a support bundle

--- a/versioned_docs/version-v1.0/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.0/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.0/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.0/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.0/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.0/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.0/troubleshooting/os.md
+++ b/versioned_docs/version-v1.0/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [cOS toolkit](https://github.com/rancher-sandbox/cOS-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.1/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.1/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.1/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.1/troubleshooting/installation.md
@@ -1,12 +1,11 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Installation
 title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.1/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.1/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.1/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.1/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.1/troubleshooting/os.md
+++ b/versioned_docs/version-v1.1/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [cOS toolkit](https://github.com/rancher-sandbox/cOS-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for Troubleshooting section (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Remove Index ID for installation.md page