### PR TITLE
Update canonical links for Rancher Integration section

### DIFF
--- a/docs/rancher/cloud-provider.md
+++ b/docs/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ Description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/docs/rancher/csi-driver.md
+++ b/docs/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a standard CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Rancher Integration
 title: "Rancher Integration"
@@ -13,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/docs/rancher/resource-quota.md
+++ b/docs/rancher/resource-quota.md
@@ -11,6 +11,10 @@ keywords:
 Description: ResourceQuota allows administrators to set resource limits per namespace, preventing excessive resource usage and ensuring the smooth operation of other namespaces when the quota is reached.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/resource-quota"/>
+</head>
+
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.
 
 In Harvester, ResourceQuota can define usage limits for the following resources:

--- a/docs/rancher/virtualization-management.md
+++ b/docs/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v0.3/rancher/cloud-provider.md
+++ b/versioned_docs/version-v0.3/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ Description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/rancher/csi-driver.md
+++ b/versioned_docs/version-v0.3/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/versioned_docs/version-v0.3/rancher/rancher-integration.md
+++ b/versioned_docs/version-v0.3/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/rancher/rancher-integration.md
+++ b/versioned_docs/version-v0.3/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/rancher/virtualization-management.md
+++ b/versioned_docs/version-v0.3/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
 </head>
 
 For Harvester v0.3.0 and above, virtualization management with the multi-cluster management feature will be supported using Rancher v2.6.x.

--- a/versioned_docs/version-v1.0/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.0/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ Description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and [cluster Persistent Storage](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.0/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.0/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
 </head>
 
 

--- a/versioned_docs/version-v1.0/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.0/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.0/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.0/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.0/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.0/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
 </head>
 
 For Harvester v0.3.0 and above, virtualization management with the multi-cluster management feature will be supported using Rancher v2.6 and above.

--- a/versioned_docs/version-v1.1/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.1/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ Description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.1/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.1/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a standard CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/versioned_docs/version-v1.1/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.1/rancher/rancher-integration.md
@@ -1,5 +1,4 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Rancher Integration
 title: "Rancher Integration"
@@ -13,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.1/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.1/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ Description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.1/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.1/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
 </head>
 
 For Harvester v0.3.0 and above, virtualization management with the multi-cluster management feature will be supported using Rancher v2.6 and above.


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for Rancher Integration section (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Remove Index ID for rancher-integration.md page