### PR TITLE
Update canonical links for Advanced section

### DIFF
--- a/docs/advanced/addons.md
+++ b/docs/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Addons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/addons"/>
 </head>
 
 Harvester makes optional functionality available as Addons.

--- a/docs/advanced/addons/pcidevices.md
+++ b/docs/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/advanced/addons/pcidevices.md
+++ b/docs/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/addons/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/advanced/addons/vmimport.md
+++ b/docs/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/vmimport"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/advanced/addons/vmimport.md
+++ b/docs/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/addons/vmimport"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -5,7 +5,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/index"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -1,12 +1,11 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Settings
 title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/settings"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/docs/advanced/storageclass.md
+++ b/docs/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/storageclass"/>
 </head>
 
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.

--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.

--- a/versioned_docs/version-v1.1/advanced/addons.md
+++ b/versioned_docs/version-v1.1/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Addons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/addons"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/advanced/pcidevices.md
+++ b/versioned_docs/version-v1.1/advanced/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/advanced/pcidevices.md
+++ b/versioned_docs/version-v1.1/advanced/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/addons/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/advanced/settings.md
+++ b/versioned_docs/version-v1.1/advanced/settings.md
@@ -5,7 +5,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/index"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.1/advanced/settings.md
+++ b/versioned_docs/version-v1.1/advanced/settings.md
@@ -1,12 +1,11 @@
 ---
-id: index
 sidebar_position: 1
 sidebar_label: Settings
 title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/settings"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.1/advanced/storageclass.md
+++ b/versioned_docs/version-v1.1/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/storageclass"/>
 </head>
 
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.

--- a/versioned_docs/version-v1.1/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.1/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.

--- a/versioned_docs/version-v1.1/advanced/vmimport.md
+++ b/versioned_docs/version-v1.1/advanced/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/vmimport"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/advanced/vmimport.md
+++ b/versioned_docs/version-v1.1/advanced/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/addons/vmimport"/>
 </head>
 
 _Available as of v1.1.0_


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

- Updated canonical links for Advanced section (v1.1-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/
- Remove Index ID for settings.md page