### PR TITLE
Update canonical links for Overview page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,11 @@ keywords:
   - Harvester Intro
 Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+</head>
+
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 ## Harvester Architecture

--- a/versioned_docs/version-v0.3/index.md
+++ b/versioned_docs/version-v0.3/index.md
@@ -11,6 +11,10 @@ keywords:
 Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+</head>
+
 Harvester is an open-source [hyper-converged infrastructure](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) (HCI) software built on Kubernetes. It is an open alternative to using a proprietary HCI stack that incorporates the design and ethos of [Cloud Native Computing](https://en.wikipedia.org/wiki/Cloud_native_computing).
 
 ![harvester-ui](./assets/dashboard.png)

--- a/versioned_docs/version-v1.0/index.md
+++ b/versioned_docs/version-v1.0/index.md
@@ -12,6 +12,10 @@ keywords:
 Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+</head>
+
 Harvester is an open-source [hyper-converged infrastructure](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) (HCI) software built on Kubernetes. It is an open alternative to using a proprietary HCI stack that incorporates the design and ethos of [Cloud Native Computing](https://en.wikipedia.org/wiki/Cloud_native_computing).
 
 ![harvester-ui](/img/v1.0/dashboard.png)

--- a/versioned_docs/version-v1.1/index.md
+++ b/versioned_docs/version-v1.1/index.md
@@ -12,6 +12,11 @@ keywords:
   - Harvester Intro
 Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+</head>
+
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 ## Harvester Architecture


### PR DESCRIPTION
**Note:** Tracking adding canonical links for v1.2 via https://github.com/harvester/docs/issues/446. Wait to merge until https://github.com/harvester/docs/pull/434 is merged.

Updated canonical links for Overview page (v0.3-v1.2) to point latest version of docs: https://docs.harvesterhci.io/v1.2/