### PR TITLE
Add v1.2.1 upgrade docs

### DIFF
--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -22,7 +22,7 @@ The following table shows the upgrade path of all supported versions.
 
 | Upgrade from version | Supported new version(s) |
 |----------------------|--------------------------|
-| [v1.1.2](./v1-1-2-to-v1-2-0.md) | v1.2.0        |
+| [v1.1.2/v1.2.0](./v1-2-0-to-v1-2-1.md) | v1.2.1              |
 | [v1.1.0, v1.1.1](./v1-1-to-v1-1-2.md) | v1.1.2        |
 | [v1.0.3](./v1-0-3-to-v1-1-1.md) | v1.1.0, v1.1.1 (v1.1.1 is recommended)        |
 | [v1.0.2](./previous-releases/v1-0-2-to-v1-0-3.md) | v1.0.3        |

--- a/docs/upgrade/previous-releases/_category_.json
+++ b/docs/upgrade/previous-releases/_category_.json
@@ -1,4 +1,4 @@
 {
-    "position": 5,
+    "position": 6,
     "label": "Previous Releases"
 }

--- a/docs/upgrade/troubleshooting.md
+++ b/docs/upgrade/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 sidebar_label: Troubleshooting
 title: "Troubleshooting"
 ---

--- a/docs/upgrade/v1-0-3-to-v1-1-1.md
+++ b/docs/upgrade/v1-0-3-to-v1-1-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Upgrade from v1.0.3/v1.1.0 to v1.1.1
 title: "Upgrade from v1.0.3/v1.1.0 to v1.1.1"
 ---

--- a/docs/upgrade/v1-1-2-to-v1-2-0.md
+++ b/docs/upgrade/v1-1-2-to-v1-2-0.md
@@ -1,12 +1,21 @@
 ---
-sidebar_position: 2
-sidebar_label: Upgrade from v1.1.2 to v1.2.0
-title: "Upgrade from v1.1.2 to v1.2.0"
+sidebar_position: 3
+sidebar_label: Upgrade from v1.1.2 to v1.2.0 (not recommended)
+title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
+
+:::caution
+
+Due to the known issues found v1.2.0:
+- [An Upgrade is stuck in the Post-draining state](#9-an-upgrade-is-stuck-in-the-post-draining-state)
+- [An upgrade is stuck in the Upgrading System Service state due to the customer provided SSL certificate without IP SAN error in fleet-agent](#10-an-upgrade-is-stuck-in-the-upgrading-system-service-state-due-to-the-customer-provided-ssl-certificate-without-ip-san-error-in-fleet-agent)
+
+We don't recommend upgrading to v1.2.0. Please upgrade your v1.1.x cluster to v1.2.1.
+:::
 
 
 ## General information
@@ -410,6 +419,12 @@ Harvester does not package the `registry.suse.com/harvester-beta/vmdp:latest` im
 
 ### 9. An Upgrade is stuck in the Post-draining state
 
+:::note
+
+This known issue is fixed in v1.2.1.
+
+:::
+
 The node might be stuck in the OS upgrade process if you encounter the **Post-draining** state, as shown below.
 
 ![](/img/v1.2/upgrade/known_issues/stuck-in-post-draining.png)
@@ -488,6 +503,12 @@ After performing the steps above, you should pass post-draining with the next re
 ---
 
 ### 10. An upgrade is stuck in the Upgrading System Service state due to the `customer provided SSL certificate without IP SAN` error in `fleet-agent`
+
+:::note
+
+This known issue is fixed in v1.2.1.
+
+:::
 
 If an upgrade is stuck in an **Upgrading System Service** state for an extended period, follow these steps to investigate this issue:
 

--- a/docs/upgrade/v1-1-to-v1-1-2.md
+++ b/docs/upgrade/v1-1-to-v1-1-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Upgrade from v1.1.0/v1.1.1 to v1.1.2
 title: "Upgrade from v1.1.0/v1.1.1 to v1.1.2"
 ---

--- a/docs/upgrade/v1-2-0-to-v1-2-1.md
+++ b/docs/upgrade/v1-2-0-to-v1-2-1.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 2
+sidebar_label: Upgrade from v1.1.2/v1.2.0 to v1.2.1
+title: "Upgrade from v1.1.2/v1.2.0 to v1.2.1"
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-2-0-to-v1-2-1"/>
+</head>
+
+
+## Important changes to this version
+
+Harvester `v1.2.1` fixes upgrade known issues found in `v1.2.0`, we suggest upgrading `v1.1.2` and `v1.2.0` clusters to `v1.2.1`. The known issues found in `v1.2.0` are:
+- [An Upgrade is stuck in the Post-draining state](./v1-1-2-to-v1-2-0.md#9-an-upgrade-is-stuck-in-the-post-draining-state)
+- [An upgrade is stuck in the Upgrading System Service state due to the customer provided SSL certificate without IP SAN error in fleet-agent](./v1-1-2-to-v1-2-0.md#10-an-upgrade-is-stuck-in-the-upgrading-system-service-state-due-to-the-customer-provided-ssl-certificate-without-ip-san-error-in-fleet-agent)
+
+
+For clusters already upgraded to v1.2.0, please refer to the [release note](https://github.com/harvester/harvester/releases/tag/v1.2.1) for new changes.
+
+## General information
+
+:::tip
+
+Before you start an upgrade, you can run the pre-check script to make sure the cluster is in a stable state. For more details, please visit this [URL](https://github.com/harvester/upgrade-helpers/tree/main/pre-check/v1.1.x) for the script.
+:::
+
+Once there is an upgradable version, the Harvester GUI Dashboard page will show an upgrade button. For more details, please refer to [start an upgrade](./automatic.md#start-an-upgrade).
+
+For the air-gap env upgrade, please refer to [prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
+
+
+## Known issues
+
+Please check v1.2.0 [known issues](./v1-1-2-to-v1-2-0.md#known-issues).

--- a/versioned_docs/version-v1.2/upgrade/automatic.md
+++ b/versioned_docs/version-v1.2/upgrade/automatic.md
@@ -22,7 +22,7 @@ The following table shows the upgrade path of all supported versions.
 
 | Upgrade from version | Supported new version(s) |
 |----------------------|--------------------------|
-| [v1.1.2](./v1-1-2-to-v1-2-0.md) | v1.2.0        |
+| [v1.1.2/v1.2.0](./v1-2-0-to-v1-2-1.md) | v1.2.1              |
 | [v1.1.0, v1.1.1](./v1-1-to-v1-1-2.md) | v1.1.2        |
 | [v1.0.3](./v1-0-3-to-v1-1-1.md) | v1.1.0, v1.1.1 (v1.1.1 is recommended)        |
 | [v1.0.2](./previous-releases/v1-0-2-to-v1-0-3.md) | v1.0.3        |

--- a/versioned_docs/version-v1.2/upgrade/previous-releases/_category_.json
+++ b/versioned_docs/version-v1.2/upgrade/previous-releases/_category_.json
@@ -1,4 +1,4 @@
 {
-    "position": 5,
+    "position": 6,
     "label": "Previous Releases"
 }

--- a/versioned_docs/version-v1.2/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.2/upgrade/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 sidebar_label: Troubleshooting
 title: "Troubleshooting"
 ---

--- a/versioned_docs/version-v1.2/upgrade/v1-0-3-to-v1-1-1.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-0-3-to-v1-1-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Upgrade from v1.0.3/v1.1.0 to v1.1.1
 title: "Upgrade from v1.0.3/v1.1.0 to v1.1.1"
 ---

--- a/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
@@ -1,12 +1,21 @@
 ---
-sidebar_position: 2
-sidebar_label: Upgrade from v1.1.2 to v1.2.0
-title: "Upgrade from v1.1.2 to v1.2.0"
+sidebar_position: 3
+sidebar_label: Upgrade from v1.1.2 to v1.2.0 (not recommended)
+title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
+
+:::caution
+
+Due to the known issues found v1.2.0:
+- [An Upgrade is stuck in the Post-draining state](#9-an-upgrade-is-stuck-in-the-post-draining-state)
+- [An upgrade is stuck in the Upgrading System Service state due to the customer provided SSL certificate without IP SAN error in fleet-agent](#10-an-upgrade-is-stuck-in-the-upgrading-system-service-state-due-to-the-customer-provided-ssl-certificate-without-ip-san-error-in-fleet-agent)
+
+We don't recommend upgrading to v1.2.0. Please upgrade your v1.1.x cluster to v1.2.1.
+:::
 
 
 ## General information
@@ -330,7 +339,7 @@ If you notice the upgrade is stuck in the **Upgrading System Service** state for
 
 ---
 
-### 7. An upgrade is stuck in the `Upgrading System Service` state
+### 7. Upgrade stuck in the `Upgrading System Service` state
 
 If an upgrade is stuck in an `Upgrading System Service` state for an extended period, some system services' certificates may have expired. To investigate and resolve this issue, follow these steps:
 
@@ -410,6 +419,12 @@ Harvester does not package the `registry.suse.com/harvester-beta/vmdp:latest` im
 
 ### 9. An Upgrade is stuck in the Post-draining state
 
+:::note
+
+This known issue is fixed in v1.2.1.
+
+:::
+
 The node might be stuck in the OS upgrade process if you encounter the **Post-draining** state, as shown below.
 
 ![](/img/v1.2/upgrade/known_issues/stuck-in-post-draining.png)
@@ -488,6 +503,12 @@ After performing the steps above, you should pass post-draining with the next re
 ---
 
 ### 10. An upgrade is stuck in the Upgrading System Service state due to the `customer provided SSL certificate without IP SAN` error in `fleet-agent`
+
+:::note
+
+This known issue is fixed in v1.2.1.
+
+:::
 
 If an upgrade is stuck in an **Upgrading System Service** state for an extended period, follow these steps to investigate this issue:
 

--- a/versioned_docs/version-v1.2/upgrade/v1-1-to-v1-1-2.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-1-to-v1-1-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Upgrade from v1.1.0/v1.1.1 to v1.1.2
 title: "Upgrade from v1.1.0/v1.1.1 to v1.1.2"
 ---

--- a/versioned_docs/version-v1.2/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-2-0-to-v1-2-1.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 2
+sidebar_label: Upgrade from v1.1.2/v1.2.0 to v1.2.1
+title: "Upgrade from v1.1.2/v1.2.0 to v1.2.1"
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-2-0-to-v1-2-1"/>
+</head>
+
+
+## Important changes to this version
+
+Harvester `v1.2.1` fixes upgrade known issues found in `v1.2.0`, we suggest upgrading `v1.1.2` and `v1.2.0` clusters to `v1.2.1`. The known issues found in `v1.2.0` are:
+- [An Upgrade is stuck in the Post-draining state](./v1-1-2-to-v1-2-0.md#9-an-upgrade-is-stuck-in-the-post-draining-state)
+- [An upgrade is stuck in the Upgrading System Service state due to the customer provided SSL certificate without IP SAN error in fleet-agent](./v1-1-2-to-v1-2-0.md#10-an-upgrade-is-stuck-in-the-upgrading-system-service-state-due-to-the-customer-provided-ssl-certificate-without-ip-san-error-in-fleet-agent)
+
+
+For clusters already upgraded to v1.2.0, please refer to the [release note](https://github.com/harvester/harvester/releases/tag/v1.2.1) for new changes.
+
+## General information
+
+:::tip
+
+Before you start an upgrade, you can run the pre-check script to make sure the cluster is in a stable state. For more details, please visit this [URL](https://github.com/harvester/upgrade-helpers/tree/main/pre-check/v1.1.x) for the script.
+:::
+
+Once there is an upgradable version, the Harvester GUI Dashboard page will show an upgrade button. For more details, please refer to [start an upgrade](./automatic.md#start-an-upgrade).
+
+For the air-gap env upgrade, please refer to [prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
+
+
+## Known issues
+
+Please check v1.2.0 [known issues](./v1-1-2-to-v1-2-0.md#known-issues).


### PR DESCRIPTION
Add v1.2.1 upgrade docs:
- Add v1.2.1 pages.
- Add notes describing some v1.2.0 known issues that are already fixed in v1.2.1.