### PR TITLE
Mention the Helm installation method for CSI driver

### DIFF
--- a/docs/rancher/csi-driver.md
+++ b/docs/rancher/csi-driver.md
@@ -121,6 +121,16 @@ Perform the following steps to deploy the Harvester CSI driver manually:
 
     ![](/img/v1.2/rancher/donot_change_cloud_config_path.png)
 
+:::note
+
+If you prefer not to install the Harvester CSI driver using Rancher
+(**Apps** > **Charts**), you can use [Helm](https://helm.sh) instead.
+The Harvester CSI driver is [packaged as a Helm chart](
+https://github.com/harvester/charts/tree/master/charts/harvester-csi-driver).
+For more information, see https://charts.harvesterhci.io.
+
+:::
+
 By following the above steps, you should be able to see those CSI driver pods are up and running on the `kube-system` namespace, and you can verify it by provisioning a new PVC using the default StorageClass `harvester` on your RKE2 cluster.
 
 ### Deploying with Harvester K3s node driver

--- a/versioned_docs/version-v1.0/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.0/rancher/csi-driver.md
@@ -126,6 +126,16 @@ If you want to change the cloud-provider-config path, you should update the clou
 
   ![](/img/v1.0/rancher/donot_change_cloud_config_path.png)
 
+:::note
+
+If you prefer not to install the Harvester CSI driver using Rancher
+(**Apps** > **Charts**), you can use [Helm](https://helm.sh) instead.
+The Harvester CSI driver is [packaged as a Helm chart](
+https://github.com/harvester/charts/tree/master/charts/harvester-csi-driver).
+For more information, see https://charts.harvesterhci.io.
+
+:::
+
 By following the above steps, you should be able to see those CSI driver pods are up and running, and you can verify it by provisioning a new PVC using the default storageClass `harvester.`.
 
 ### Deploying with Harvester K3s Node Driver

--- a/versioned_docs/version-v1.1/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.1/rancher/csi-driver.md
@@ -127,6 +127,16 @@ Perform the following steps to deploy the Harvester CSI Driver manually:
 
     ![](/img/v1.1/rancher/donot_change_cloud_config_path.png)
 
+:::note
+
+If you prefer not to install the Harvester CSI driver using Rancher
+(**Apps** > **Charts**), you can use [Helm](https://helm.sh) instead.
+The Harvester CSI driver is [packaged as a Helm chart](
+https://github.com/harvester/charts/tree/master/charts/harvester-csi-driver).
+For more information, see https://charts.harvesterhci.io.
+
+:::
+
 By following the above steps, you should be able to see those CSI driver pods are up and running, and you can verify it by provisioning a new PVC using the default storageClass `harvester.`.
 
 ### Deploying with Harvester K3s Node Driver

--- a/versioned_docs/version-v1.2/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.2/rancher/csi-driver.md
@@ -121,6 +121,16 @@ Perform the following steps to deploy the Harvester CSI driver manually:
 
     ![](/img/v1.2/rancher/donot_change_cloud_config_path.png)
 
+:::note
+
+If you prefer not to install the Harvester CSI driver using Rancher
+(**Apps** > **Charts**), you can use [Helm](https://helm.sh) instead.
+The Harvester CSI driver is [packaged as a Helm chart](
+https://github.com/harvester/charts/tree/master/charts/harvester-csi-driver).
+For more information, see https://charts.harvesterhci.io.
+
+:::
+
 By following the above steps, you should be able to see those CSI driver pods are up and running on the `kube-system` namespace, and you can verify it by provisioning a new PVC using the default StorageClass `harvester` on your RKE2 cluster.
 
 ### Deploying with Harvester K3s node driver


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The Harvester documentation doesn't mention the Helm install method for installing the harvester-csi-driver onto a guest cluster for operators who are not using Rancher or who choose to not use the Rancher marketplace.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add a note to the Harvester CSI Driver pages in the "manual install" sections.

**Related Issue:** https://github.com/harvester/harvester/issues/4446
