### PR TITLE
Restructure and add note to "Create a VM Network"

### DIFF
--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -69,7 +69,7 @@ The [Harvester network-controller](https://github.com/harvester/harvester-networ
 
     ![](/img/v1.2/networking/create-network-manual.png)
 
-    :::important
+    :::info important
     Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
     :::
 

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -69,7 +69,9 @@ The [Harvester network-controller](https://github.com/harvester/harvester-networ
 
     ![](/img/v1.2/networking/create-network-manual.png)
 
-    > **Important**: Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
+    :::important
+    Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
+    :::
 
 ### Create a VM with VLAN Network
 You can now create a new VM using the VLAN network configured above:

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -39,22 +39,37 @@ Since the management network is built-in and doesn't require extra operations, y
 
 The [Harvester network-controller](https://github.com/harvester/harvester-network-controller) leverages the [multus](https://github.com/k8snetworkplumbingwg/multus-cni) and [bridge](https://www.cni.dev/plugins/current/main/bridge/) CNI plugins to implement its customized L2 bridge VLAN network. It helps to connect your VMs to the host network interface and can be accessed from internal and external networks using the physical switch.
 
-### How to use VLAN network
+### Create a VM Network
 
-To create a new VLAN network, go to the **Networks > VM Networks** page and click the **Create** button.
+1. Go to **Networks** > **VM Networks**. 
 
-1. Specify the name, select the type `L2VlanNetwork`, input the VLAN ID and select the cluster network.
+1. Select **Create**. 
+
+1. Configure the following settings: 
+
+    - Namespace 
+    - Name 
+    - Description (optional) 
+
+1. On the **Basics** tab, configure the following settings: 
+
+    - Type: Select **L2VlanNetwork**.
+    - Vlan ID 
+    - Cluster Network 
 
     ![](/img/v1.2/networking/create-vlan-network.png)
 
-1. Configure a route to allow the hosts to connect to the VLAN network using IPv4 addresses. The CIDR and gateway of the VLAN network are mandatory parameters for the route configuration.  You can configure the route by choosing one of the following options:
-    - Auto(DHCP): the Harvester network controller will get the CIDR and gateway values from the DHCP server using the DHCP protocol. Optionally, you can specify the DHCP server address.
+1. On the Route tab, select an option and then specify the related IPv4 addresses.
+
+    - Auto(DHCP): The Harvester network controller retrieves the CIDR and gateway addresses from the DHCP server. You can specify the DHCP server address. 
 
     ![](/img/v1.2/networking/create-network-auto.png)
 
-    - Manual: You need to specify the CIDR and gateway values manually.
+    - Manual: Specify the CIDR and gateway addresses. 
 
     ![](/img/v1.2/networking/create-network-manual.png)
+
+    > **Important**: Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
 
 ### Create a VM with VLAN Network
 You can now create a new VM using the VLAN network configured above:

--- a/versioned_docs/version-v1.1/networking/harvester-network.md
+++ b/versioned_docs/version-v1.1/networking/harvester-network.md
@@ -69,7 +69,7 @@ The [Harvester network-controller](https://github.com/harvester/harvester-networ
 
     ![](/img/v1.2/networking/create-network-manual.png)
 
-    :::important
+    :::info important
     Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
     :::
 

--- a/versioned_docs/version-v1.1/networking/harvester-network.md
+++ b/versioned_docs/version-v1.1/networking/harvester-network.md
@@ -39,22 +39,39 @@ Since the management network is built-in and doesn't require extra operations, y
 
 The [Harvester network-controller](https://github.com/harvester/harvester-network-controller) leverages the [multus](https://github.com/k8snetworkplumbingwg/multus-cni) and [bridge](https://www.cni.dev/plugins/current/main/bridge/) CNI plugins to implement its customized L2 bridge VLAN network. It helps to connect your VMs to the host network interface and can be accessed from internal and external networks using the physical switch.
 
-### How to use VLAN network
+### Create a VM Network
 
-To create a new VLAN network, go to the **Networks > VM Networks** page and click the **Create** button.
+1. Go to **Networks** > **VM Networks**. 
 
-1. Specify the name, select the type `L2VlanNetwork`, input the VLAN ID and select the cluster network.
+1. Select **Create**. 
 
-    ![](/img/v1.1/networking/create-vlan-network.png)
+1. Configure the following settings: 
 
-1. Configure a route to allow the hosts to connect to the VLAN network using IPv4 addresses. The CIDR and gateway of the VLAN network are mandatory parameters for the route configuration.  You can configure the route by choosing one of the following options:
-    - Auto(DHCP): the Harvester network controller will get the CIDR and gateway values from the DHCP server using the DHCP protocol. Optionally, you can specify the DHCP server address.
+    - Namespace 
+    - Name 
+    - Description (optional) 
 
-    ![](/img/v1.1/networking/create-network-auto.png)
+1. On the **Basics** tab, configure the following settings: 
 
-    - Manual: You need to specify the CIDR and gateway values manually.
+    - Type: Select **L2VlanNetwork**.
+    - Vlan ID 
+    - Cluster Network 
 
-    ![](/img/v1.1/networking/create-network-manual.png)
+    ![](/img/v1.2/networking/create-vlan-network.png)
+
+1. On the Route tab, select an option and then specify the related IPv4 addresses.
+
+    - Auto(DHCP): The Harvester network controller retrieves the CIDR and gateway addresses from the DHCP server. You can specify the DHCP server address. 
+
+    ![](/img/v1.2/networking/create-network-auto.png)
+
+    - Manual: Specify the CIDR and gateway addresses. 
+
+    ![](/img/v1.2/networking/create-network-manual.png)
+
+    :::important
+    Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
+    :::
 
 ### Create a VM with VLAN Network
 You can now create a new VM using the VLAN network configured above:

--- a/versioned_docs/version-v1.2/networking/harvester-network.md
+++ b/versioned_docs/version-v1.2/networking/harvester-network.md
@@ -69,7 +69,7 @@ The [Harvester network-controller](https://github.com/harvester/harvester-networ
 
     ![](/img/v1.2/networking/create-network-manual.png)
 
-    :::important
+    :::info important
     Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
     :::
 

--- a/versioned_docs/version-v1.2/networking/harvester-network.md
+++ b/versioned_docs/version-v1.2/networking/harvester-network.md
@@ -39,22 +39,39 @@ Since the management network is built-in and doesn't require extra operations, y
 
 The [Harvester network-controller](https://github.com/harvester/harvester-network-controller) leverages the [multus](https://github.com/k8snetworkplumbingwg/multus-cni) and [bridge](https://www.cni.dev/plugins/current/main/bridge/) CNI plugins to implement its customized L2 bridge VLAN network. It helps to connect your VMs to the host network interface and can be accessed from internal and external networks using the physical switch.
 
-### How to use VLAN network
+### Create a VM Network
 
-To create a new VLAN network, go to the **Networks > VM Networks** page and click the **Create** button.
+1. Go to **Networks** > **VM Networks**. 
 
-1. Specify the name, select the type `L2VlanNetwork`, input the VLAN ID and select the cluster network.
+1. Select **Create**. 
+
+1. Configure the following settings: 
+
+    - Namespace 
+    - Name 
+    - Description (optional) 
+
+1. On the **Basics** tab, configure the following settings: 
+
+    - Type: Select **L2VlanNetwork**.
+    - Vlan ID 
+    - Cluster Network 
 
     ![](/img/v1.2/networking/create-vlan-network.png)
 
-1. Configure a route to allow the hosts to connect to the VLAN network using IPv4 addresses. The CIDR and gateway of the VLAN network are mandatory parameters for the route configuration.  You can configure the route by choosing one of the following options:
-    - Auto(DHCP): the Harvester network controller will get the CIDR and gateway values from the DHCP server using the DHCP protocol. Optionally, you can specify the DHCP server address.
+1. On the Route tab, select an option and then specify the related IPv4 addresses.
+
+    - Auto(DHCP): The Harvester network controller retrieves the CIDR and gateway addresses from the DHCP server. You can specify the DHCP server address. 
 
     ![](/img/v1.2/networking/create-network-auto.png)
 
-    - Manual: You need to specify the CIDR and gateway values manually.
+    - Manual: Specify the CIDR and gateway addresses. 
 
     ![](/img/v1.2/networking/create-network-manual.png)
+
+    :::important
+    Harvester uses the information to verify that all nodes can access the VM network you are creating. If that is the case, the *Network connectivity* column on the **VM Networks** screen indicates that the network is active. Otherwise, the screen indicates that an error has occurred.
+    :::
 
 ### Create a VM with VLAN Network
 You can now create a new VM using the VLAN network configured above:


### PR DESCRIPTION
I added a note to address user confusion surrounding required information on the "Route" tab (Networks > VM Networks).

I also restructured the procedural information to match what I wrote for the PoC Guide. Moving forward, procedural steps (especially those involving settings) will be structured in this manner for better UX. 