### PR TITLE
Add information about support for single-node clusters

### DIFF
--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -1,0 +1,21 @@
+# Single-Node Clusters
+
+Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).
+
+Single-node clusters support most Harvester features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
+- No high availability: Errors and updates that require rebooting of the node cause downtime to running VMs.
+- No fault tolerance: There is no automatic provision of failover to another node.
+- No multi-replica support: Only 1 replica is created for each volume in Longhorn.
+- No live-migration and zero-downtime support during upgrades
+
+## Prerequisites/Requirements
+
+Before you begin deploying your single-node cluster, ensure that the following requirements are fulfilled/addressed.
+
+- Hardware: [Use server-class hardware](https://docs.harvesterhci.io/v1.2/install/requirements#hardware-requirements) with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
+- Network: [Configure ports](https://docs.harvesterhci.io/v1.2/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
+- StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.3/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only 1 replica is created for each volume in Longhorn.
+
+    :::info important
+    The default StorageClass "harvester-longhorn" has a replica count value of "3" for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
+    :::

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -9,7 +9,7 @@ Description: Support for deployment of single-node clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters">
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters">
 </head>
 
 Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -12,7 +12,7 @@ Description: Support for deployment of single-node clusters
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters"/>
 </head>
 
-Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).
+As of Harvester release v1.2.0, single-node clusters are supported for implementations that require minimal initial deployment resources or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).
 
 Single-node clusters support most Harvester features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
 

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -3,18 +3,18 @@
 Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).
 
 Single-node clusters support most Harvester features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
+
 - No high availability: Errors and updates that require rebooting of the node cause downtime to running VMs.
-- No fault tolerance: There is no automatic provision of failover to another node.
-- No multi-replica support: Only 1 replica is created for each volume in Longhorn.
-- No live-migration and zero-downtime support during upgrades
+- No multi-replica support: Only one replica is created for each volume in Longhorn.
+- No live migration and zero-downtime support during upgrades
 
 ## Prerequisites/Requirements
 
 Before you begin deploying your single-node cluster, ensure that the following requirements are fulfilled/addressed.
 
-- Hardware: [Use server-class hardware](https://docs.harvesterhci.io/v1.2/install/requirements#hardware-requirements) with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
-- Network: [Configure ports](https://docs.harvesterhci.io/v1.2/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
-- StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.3/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only 1 replica is created for each volume in Longhorn.
+- Hardware: [Use server-class hardware](https://docs.harvesterhci.io/v1.3/install/requirements#hardware-requirements) with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
+- Network: [Configure ports](https://docs.harvesterhci.io/v1.3/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
+- StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.3/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only one replica is created for each volume in Longhorn.
 
     :::info important
     The default StorageClass "harvester-longhorn" has a replica count value of "3" for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -18,7 +18,7 @@ Single-node clusters support most Harvester features, including the creation of 
 
 - No high availability: Errors and updates that require rebooting of the node cause downtime to running VMs.
 - No multi-replica support: Only one replica is created for each volume in Longhorn.
-- No live migration and zero-downtime support during upgrades
+- No live migration and zero-downtime support during upgrades.
 
 ## Prerequisites/Requirements
 

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -20,7 +20,7 @@ Single-node clusters support most Harvester features, including the creation of 
 - No multi-replica support: Only one replica is created for each volume in Longhorn.
 - No live migration and zero-downtime support during upgrades.
 
-## Prerequisites/Requirements
+## Prerequisites
 
 Before you begin deploying your single-node cluster, ensure that the following requirements are addressed.
 
@@ -29,5 +29,5 @@ Before you begin deploying your single-node cluster, ensure that the following r
 - StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.3/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only one replica is created for each volume in Longhorn.
 
     :::info important
-    The default StorageClass "harvester-longhorn" has a replica count value of "3" for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
+    The default StorageClass `harvester-longhorn` has a replica count value of `3` for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
     :::

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -22,7 +22,7 @@ Single-node clusters support most Harvester features, including the creation of 
 
 ## Prerequisites/Requirements
 
-Before you begin deploying your single-node cluster, ensure that the following requirements are fulfilled/addressed.
+Before you begin deploying your single-node cluster, ensure that the following requirements are addressed.
 
 - Hardware: [Use server-class hardware](https://docs.harvesterhci.io/v1.3/install/requirements#hardware-requirements) with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
 - Network: [Configure ports](https://docs.harvesterhci.io/v1.3/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -28,6 +28,6 @@ Before you begin deploying your single-node cluster, ensure that the following r
 - Network: [Configure ports](https://docs.harvesterhci.io/v1.3/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
 - StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.3/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only one replica is created for each volume in Longhorn.
 
-    :::info important
-    The default StorageClass `harvester-longhorn` has a replica count value of `3` for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
-    :::
+  :::info important
+  The default StorageClass `harvester-longhorn` has a replica count value of `3` for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
+  :::

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -1,4 +1,16 @@
-# Single-Node Clusters
+---
+id: singlenodeclusters
+sidebar_position: 7
+sidebar_label: Single-Node Clusters
+title: "Single-Node Clusters"
+keywords:
+- Single Node
+Description: Support for deployment of single-node clusters
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters">
+</head>
 
 Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).
 

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -9,7 +9,7 @@ Description: Support for deployment of single-node clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters">
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters"/>
 </head>
 
 Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -12,7 +12,11 @@ Description: Outline the Harvester installation requirements
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
 </head>
 
-As an HCI solution on bare metal servers, there are minimum node hardware and network requirements to install and run Harvester.
+As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.
+
+A three-node cluster is required to fully realize the multi-node features of Harvester. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
+
+Certain versions of Harvester support the deployment of [single-node clusters](https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters). Such clusters do not support high availability, multiple replicas, and live migration.
 
 ## Hardware Requirements
 
@@ -27,15 +31,9 @@ Harvester nodes have the following hardware requirements and recommendations for
 | Network Card     | 1 Gbps Ethernet minimum for testing; 10Gbps Ethernet required for production                                                                                                                       |
 | Network Switch   | Trunking of ports required for VLAN support                                                                                                                                                           |
 
-:::info
-
-A three-node cluster is required to realize the multi-node features of Harvester fully.
-
-- The first node always defaults to be a management node of the cluster.
-- When there are three or more nodes, the two other nodes added first are automatically promoted to management nodes to form a high availability (HA) cluster.
-- We recommend server-class hardware for the best results. Laptops and nested virtualization are not officially supported.
-- The `product_uuid` fetched from `/sys/class/dmi/id/product_uuid` in Linux must be unique in each node. Otherwise, features like VM live migration will be affected. For more information, refer to [#4025](https://github.com/harvester/harvester/issues/4025).
-
+:::info important
+- Use server-class hardware to achieve the best results. Laptops and nested virtualization are not supported.
+- Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see [Issue #4025](https://github.com/harvester/harvester/issues/4025).
 :::
 
 ## Network Requirements

--- a/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
@@ -1,0 +1,21 @@
+# Single-Node Clusters
+
+Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).
+
+Single-node clusters support most Harvester features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
+- No high availability: Errors and updates that require rebooting of the node cause downtime to running VMs.
+- No fault tolerance: There is no automatic provision of failover to another node.
+- No multi-replica support: Only 1 replica is created for each volume in Longhorn.
+- No live-migration and zero-downtime support during upgrades
+
+## Prerequisites/Requirements
+
+Before you begin deploying your single-node cluster, ensure that the following requirements are fulfilled/addressed.
+
+- Hardware: [Use server-class hardware](https://docs.harvesterhci.io/v1.2/install/requirements#hardware-requirements) with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
+- Network: [Configure ports](https://docs.harvesterhci.io/v1.2/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
+- StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.3/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only 1 replica is created for each volume in Longhorn.
+
+    :::info important
+    The default StorageClass "harvester-longhorn" has a replica count value of "3" for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
+    :::

--- a/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
@@ -12,21 +12,22 @@ Description: Support for deployment of single-node clusters
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters"/>
 </head>
 
-Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.2/install/index), [USB](https://docs.harvesterhci.io/v1.2/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.2/install/pxe-boot-install)).
+As of Harvester release v1.2.0, single-node clusters are supported for implementations that require minimal initial deployment resources or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.2/install/index), [USB](https://docs.harvesterhci.io/v1.2/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.2/install/pxe-boot-install)).
 
 Single-node clusters support most Harvester features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
+
 - No high availability: Errors and updates that require rebooting of the node cause downtime to running VMs.
 - No multi-replica support: Only one replica is created for each volume in Longhorn.
-- No live migration and zero-downtime support during upgrades
+- No live migration and zero-downtime support during upgrades.
 
-## Prerequisites/Requirements
+## Prerequisites
 
-Before you begin deploying your single-node cluster, ensure that the following requirements are fulfilled/addressed.
+Before you begin deploying your single-node cluster, ensure that the following requirements are addressed.
 
 - Hardware: [Use server-class hardware](https://docs.harvesterhci.io/v1.2/install/requirements#hardware-requirements) with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
 - Network: [Configure ports](https://docs.harvesterhci.io/v1.2/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
 - StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.2/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only one replica is created for each volume in Longhorn.
 
     :::info important
-    The default StorageClass "harvester-longhorn" has a replica count value of "3" for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
+    The default StorageClass `harvester-longhorn` has a replica count value of `3` for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
     :::

--- a/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
@@ -1,4 +1,16 @@
-# Single-Node Clusters
+---
+id: singlenodeclusters
+sidebar_position: 7
+sidebar_label: Single-Node Clusters
+title: "Single-Node Clusters"
+keywords:
+- Single Node
+Description: Support for deployment of single-node clusters
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters">
+</head>
 
 Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.2/install/index), [USB](https://docs.harvesterhci.io/v1.2/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.2/install/pxe-boot-install)).
 

--- a/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
@@ -1,12 +1,11 @@
 # Single-Node Clusters
 
-Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).
+Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.2/install/index), [USB](https://docs.harvesterhci.io/v1.2/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.2/install/pxe-boot-install)).
 
 Single-node clusters support most Harvester features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
 - No high availability: Errors and updates that require rebooting of the node cause downtime to running VMs.
-- No fault tolerance: There is no automatic provision of failover to another node.
-- No multi-replica support: Only 1 replica is created for each volume in Longhorn.
-- No live-migration and zero-downtime support during upgrades
+- No multi-replica support: Only one replica is created for each volume in Longhorn.
+- No live migration and zero-downtime support during upgrades
 
 ## Prerequisites/Requirements
 
@@ -14,7 +13,7 @@ Before you begin deploying your single-node cluster, ensure that the following r
 
 - Hardware: [Use server-class hardware](https://docs.harvesterhci.io/v1.2/install/requirements#hardware-requirements) with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
 - Network: [Configure ports](https://docs.harvesterhci.io/v1.2/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
-- StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.3/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only 1 replica is created for each volume in Longhorn.
+- StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.2/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only one replica is created for each volume in Longhorn.
 
     :::info important
     The default StorageClass "harvester-longhorn" has a replica count value of "3" for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.

--- a/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
@@ -9,7 +9,7 @@ Description: Support for deployment of single-node clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters">
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters"/>
 </head>
 
 Beginning with v1.2.0, Harvester is supporting single-node clusters for implementations that require minimal initial deployment resources and/or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.2/install/index), [USB](https://docs.harvesterhci.io/v1.2/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.2/install/pxe-boot-install)).

--- a/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
@@ -28,6 +28,6 @@ Before you begin deploying your single-node cluster, ensure that the following r
 - Network: [Configure ports](https://docs.harvesterhci.io/v1.2/install/requirements#port-requirements-for-harvester-nodes) based on the type of traffic to be transmitted among VMs.
 - StorageClass: [Create a new default StorageClass](https://docs.harvesterhci.io/v1.2/advanced/storageclass#creating-a-storageclass) with the **Number of Replicas** parameter set to "1". This ensures that only one replica is created for each volume in Longhorn.
 
-    :::info important
-    The default StorageClass `harvester-longhorn` has a replica count value of `3` for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
-    :::
+  :::info important
+  The default StorageClass `harvester-longhorn` has a replica count value of `3` for high availability. If you use this StorageClass to create volumes for your single-node cluster, Longhorn is unable to create the configured number of replicas. This results in volumes being marked as "Degraded" on the Longhorn UI.
+  :::

--- a/versioned_docs/version-v1.2/install/requirements.md
+++ b/versioned_docs/version-v1.2/install/requirements.md
@@ -12,7 +12,11 @@ Description: Outline the Harvester installation requirements
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
 </head>
 
-As an HCI solution on bare metal servers, there are minimum node hardware and network requirements to install and run Harvester.
+As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.
+
+A three-node cluster is required to fully realize the multi-node features of Harvester. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
+
+Certain versions of Harvester support the deployment of [single-node clusters](https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters). Such clusters do not support high availability, multiple replicas, and live migration.
 
 ## Hardware Requirements
 
@@ -27,15 +31,9 @@ Harvester nodes have the following hardware requirements and recommendations for
 | Network Card     | 1 Gbps Ethernet minimum for testing; 10Gbps Ethernet required for production                                                                                                                       |
 | Network Switch   | Trunking of ports required for VLAN support                                                                                                                                                           |
 
-:::info
-
-A three-node cluster is required to realize the multi-node features of Harvester fully.
-
-- The first node always defaults to be a management node of the cluster.
-- When there are three or more nodes, the two other nodes added first are automatically promoted to management nodes to form a high availability (HA) cluster.
-- We recommend server-class hardware for the best results. Laptops and nested virtualization are not officially supported.
-- The `product_uuid` fetched from `/sys/class/dmi/id/product_uuid` in Linux must be unique in each node. Otherwise, features like VM live migration will be affected. For more information, refer to [#4025](https://github.com/harvester/harvester/issues/4025).
-
+:::info important
+- Use server-class hardware to achieve the best results. Laptops and nested virtualization are not supported.
+- Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see [Issue #4025](https://github.com/harvester/harvester/issues/4025).
 :::
 
 ## Network Requirements


### PR DESCRIPTION
Related Jira issue: SURE-7147

Scope: 
- "Installation" > "Hardware and Network Requirements": I reorganized existing cluster-related information and added a paragraph about single-node clusters.
- "Advanced" > "Single-Node Clusters": I added a file that contains information such as limitations and prerequisites. I plan to add content as I explore the link between Harvester and Longhorn (e.g., monitoring volumes).