### PR TITLE
Fix invalid 'Description' field in front matter

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Authentication
-Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
+description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Intro
-Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
+description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Configuration
-Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
+description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
 <head>

--- a/docs/install/install-binaries-mode.md
+++ b/docs/install/install-binaries-mode.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - ISO Installation
-Description: To get the Harvester ISO, download it from the GitHub releases. During the installation, you can choose to install the binaries only.
+description: To get the Harvester ISO, download it from the GitHub releases. During the installation, you can choose to install the binaries only.
 ---
 
 <head>

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - ISO Installation
-Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
+description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
 <head>

--- a/docs/install/management-address.md
+++ b/docs/install/management-address.md
@@ -4,7 +4,7 @@ sidebar_label: Management Address
 title: "Management Address"
 keywords:
   - VIP
-Description: The Harvester provides a virtual IP as the management address.
+description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -11,7 +11,7 @@ keywords:
   - Installing Harvester
   - Harvester Installation
   - PXE Boot Install
-Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
+description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
 <head>

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -5,7 +5,7 @@ sidebar_label: Hardware and Network Requirements
 title: "Hardware and Network Requirements"
 keywords:
 - Installation Requirements
-Description: Outline the Harvester installation requirements
+description: Outline the Harvester installation requirements
 ---
 
 <head>

--- a/docs/install/update-harvester-configuration.md
+++ b/docs/install/update-harvester-configuration.md
@@ -5,7 +5,7 @@ title: "Update Harvester Configuration After Installation"
 keywords:
   - Harvester configuration
   - Configuration
-Description: How to update Harvester configuration after installation
+description: How to update Harvester configuration after installation
 ---
 
 <head>

--- a/docs/rancher/cloud-provider.md
+++ b/docs/rancher/cloud-provider.md
@@ -10,7 +10,7 @@ keywords:
   - RKE2
   - rke2
   - Harvester Cloud Provider
-Description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
+description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
 ---
 
 <head>

--- a/docs/rancher/node/node-driver.md
+++ b/docs/rancher/node/node-driver.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Node Driver
-Description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
+description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
 ---
 
 <head>

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Rancher Integration
-Description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
+description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
 ---
 
 <head>

--- a/docs/rancher/resource-quota.md
+++ b/docs/rancher/resource-quota.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Resource Quota
-Description: ResourceQuota allows administrators to set resource limits per namespace, preventing excessive resource usage and ensuring the smooth operation of other namespaces when the quota is reached.
+description: ResourceQuota allows administrators to set resource limits per namespace, preventing excessive resource usage and ensuring the smooth operation of other namespaces when the quota is reached.
 ---
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Upgrade
-Description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
+description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
 ---
 
 <head>

--- a/docs/upload-image.md
+++ b/docs/upload-image.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Import Images
-Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
+description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/docs/vm/access-to-the-vm.md
+++ b/docs/vm/access-to-the-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Access to the VM
-Description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
+description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
 ---
 
 <head>

--- a/docs/vm/backup-restore.md
+++ b/docs/vm/backup-restore.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - VM Backup, Snapshot & Restore
-Description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM. VM Snapshot can work without Backup Target.
+description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM. VM Snapshot can work without Backup Target.
 ---
 
 <head>

--- a/docs/vm/clone-vm.md
+++ b/docs/vm/clone-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Clone VM
-Description: VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
+description: VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
 ---
 
 <head>

--- a/docs/vm/create-vm.md
+++ b/docs/vm/create-vm.md
@@ -11,7 +11,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a VM
-Description: Create one or more virtual machines from the Virtual Machines page.
+description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/docs/vm/create-windows-vm.md
+++ b/docs/vm/create-windows-vm.md
@@ -12,7 +12,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a Windows VM
-Description: Create one or more Windows virtual machines from the Virtual Machines page.
+description: Create one or more Windows virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/docs/vm/edit-vm.md
+++ b/docs/vm/edit-vm.md
@@ -10,7 +10,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Edit a VM
-Description: Edit Virtual Machines from the Harvester VM page.
+description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>

--- a/docs/vm/hotplug-volume.md
+++ b/docs/vm/hotplug-volume.md
@@ -6,7 +6,7 @@ keywords:
   - Harvester
   - Hot-plug
   - Volume
-Description: Adding hot-plug volumes to a running VM.
+description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>

--- a/docs/vm/live-migration.md
+++ b/docs/vm/live-migration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Live Migration
-Description: Live migration means moving a virtual machine to a different host without downtime.
+description: Live migration means moving a virtual machine to a different host without downtime.
 ---
 
 <head>

--- a/docs/vm/resource-overcommit.md
+++ b/docs/vm/resource-overcommit.md
@@ -7,7 +7,7 @@ keywords:
   - Overcommit
   - Overprovision
   - ballooning
-Description: Overcommit resources to a VM.
+description: Overcommit resources to a VM.
 ---
 
 <head>

--- a/docs/volume/clone-volume.md
+++ b/docs/volume/clone-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Clone a Volume
 title: "Clone a Volume"
 keywords:
 - Volume
-Description: Clone volume from the Volume page.
+description: Clone volume from the Volume page.
 ---
 
 <head>

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -5,7 +5,7 @@ sidebar_label: Create a Volume
 title: "Create a Volume"
 keywords:
 - Volume
-Description: Create a volume from the Volume page.
+description: Create a volume from the Volume page.
 ---
 
 <head>

--- a/docs/volume/edit-volume.md
+++ b/docs/volume/edit-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Edit a Volume
 title: "Edit a Volume"
 keywords:
 - Volume
-Description: Edit volume from the Volume page.
+description: Edit volume from the Volume page.
 ---
 
 <head>

--- a/docs/volume/export-volume.md
+++ b/docs/volume/export-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Export a Volume to Image
 title: "Export a Volume to Image"
 keywords:
 - Volume
-Description: Export volume to image from the Volume page.
+description: Export volume to image from the Volume page.
 ---
 
 <head>

--- a/docs/volume/volume-snapshots.md
+++ b/docs/volume/volume-snapshots.md
@@ -5,7 +5,7 @@ title: "Volume Snapshots"
 keywords:
 - Volume Snapshot
 - Volume Snapshots
-Description: Take a snapshot for a volume from the Volume page.
+description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>

--- a/versioned_docs/version-v0.3/authentication.md
+++ b/versioned_docs/version-v0.3/authentication.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Authentication
-Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
+description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v0.3/index.md
+++ b/versioned_docs/version-v0.3/index.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Intro
-Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
+description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
 
 Harvester is an open-source [hyper-converged infrastructure](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) (HCI) software built on Kubernetes. It is an open alternative to using a proprietary HCI stack that incorporates the design and ethos of [Cloud Native Computing](https://en.wikipedia.org/wiki/Cloud_native_computing).

--- a/versioned_docs/version-v0.3/install/harvester-configuration.md
+++ b/versioned_docs/version-v0.3/install/harvester-configuration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Configuration
-Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
+description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/install/iso-install.md
+++ b/versioned_docs/version-v0.3/install/iso-install.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - ISO Installation
-Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
+description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/install/management-address.md
+++ b/versioned_docs/version-v0.3/install/management-address.md
@@ -4,7 +4,7 @@ sidebar_label: Management Address
 title: "Management Address"
 keywords:
   - VIP
-Description: The Harvester provides a virtual IP as the management address.
+description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/install/pxe-boot-install.md
+++ b/versioned_docs/version-v0.3/install/pxe-boot-install.md
@@ -11,7 +11,7 @@ keywords:
   - Installing Harvester
   - Harvester Installation
   - PXE Boot Install
-Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
+description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/networking/harvester-network.md
+++ b/versioned_docs/version-v0.3/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Upgrade
-Description: Harvester is built on Kubernetes, which uses CNI as an interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the Harvester network to provide a user-friendly way to configure networks for VMs.
+description: Harvester is built on Kubernetes, which uses CNI as an interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the Harvester network to provide a user-friendly way to configure networks for VMs.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/rancher/cloud-provider.md
+++ b/versioned_docs/version-v0.3/rancher/cloud-provider.md
@@ -10,7 +10,7 @@ keywords:
   - RKE2
   - rke2
   - Harvester Cloud Provider
-Description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
+description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/rancher/node/node-driver.md
+++ b/versioned_docs/version-v0.3/rancher/node/node-driver.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Node Driver
-Description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
+description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v0.3/rancher/node/rke1-cluster.md
@@ -9,7 +9,7 @@ keywords:
   - rancher
   - Rancher Integration
   - RKE1
-Description: Users can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher v2.6.1+ using the built-in Harvester node driver.
+description: Users can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher v2.6.1+ using the built-in Harvester node driver.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v0.3/rancher/node/rke2-cluster.md
@@ -9,7 +9,7 @@ keywords:
   - rancher
   - Rancher Integration
   - RKE2
-Description: Users can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher v2.6.1+ using the built-in Harvester node driver.
+description: Users can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher v2.6.1+ using the built-in Harvester node driver.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/rancher/rancher-integration.md
+++ b/versioned_docs/version-v0.3/rancher/rancher-integration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Rancher Integration
-Description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
+description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/upgrade.md
+++ b/versioned_docs/version-v0.3/upgrade.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Upgrade
-Description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
+description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
 ---
 
 :::note

--- a/versioned_docs/version-v0.3/upload-image.md
+++ b/versioned_docs/version-v0.3/upload-image.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Import Images
-Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
+description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v0.3/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v0.3/vm/access-to-the-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Access to the VM
-Description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
+description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/vm/backup-restore.md
+++ b/versioned_docs/version-v0.3/vm/backup-restore.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - VM Backup & Restore
-Description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM.
+description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/vm/create-vm.md
+++ b/versioned_docs/version-v0.3/vm/create-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Create a VM
-Description: Create one or more virtual machines from the Virtual Machines page.
+description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/vm/hotplug-volume.md
+++ b/versioned_docs/version-v0.3/vm/hotplug-volume.md
@@ -6,7 +6,7 @@ keywords:
   - Harvester
   - Hot-plug
   - Volume
-Description: Adding hot-plug volumes to a running VM.
+description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>

--- a/versioned_docs/version-v0.3/vm/live-migration.md
+++ b/versioned_docs/version-v0.3/vm/live-migration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Live Migration
-Description: Live migration means moving a virtual machine to a different host without downtime.
+description: Live migration means moving a virtual machine to a different host without downtime.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/authentication.md
+++ b/versioned_docs/version-v1.0/authentication.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Authentication
-Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
+description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.0/index.md
+++ b/versioned_docs/version-v1.0/index.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Intro
-Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
+description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
 
 Harvester is an open-source [hyper-converged infrastructure](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) (HCI) software built on Kubernetes. It is an open alternative to using a proprietary HCI stack that incorporates the design and ethos of [Cloud Native Computing](https://en.wikipedia.org/wiki/Cloud_native_computing).

--- a/versioned_docs/version-v1.0/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.0/install/harvester-configuration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Configuration
-Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
+description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/install/iso-install.md
+++ b/versioned_docs/version-v1.0/install/iso-install.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - ISO Installation
-Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
+description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/install/management-address.md
+++ b/versioned_docs/version-v1.0/install/management-address.md
@@ -4,7 +4,7 @@ sidebar_label: Management Address
 title: "Management Address"
 keywords:
   - VIP
-Description: The Harvester provides a virtual IP as the management address.
+description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.0/install/pxe-boot-install.md
@@ -11,7 +11,7 @@ keywords:
   - Installing Harvester
   - Harvester Installation
   - PXE Boot Install
-Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
+description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/install/requirements.md
+++ b/versioned_docs/version-v1.0/install/requirements.md
@@ -4,7 +4,7 @@ sidebar_label: Requirements
 title: "Requirements"
 keywords:
 - Installation Requirements
-Description: Outline the Harvester installation requirements
+description: Outline the Harvester installation requirements
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/networking/best-practice/multiple-nics-non-vlan-aware-switch.md
+++ b/versioned_docs/version-v1.0/networking/best-practice/multiple-nics-non-vlan-aware-switch.md
@@ -11,7 +11,7 @@ keywords:
   - network
   - VLAN
   - vlan
-Description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
+description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
 ---
 
 In this best practice guide for "non VLAN-aware" switch, also known as "dummy" switch, we will introduce Harvester VLAN network and external switch configuration for common scenario.

--- a/versioned_docs/version-v1.0/networking/best-practice/multiple-nics-vlan-aware-switch.md
+++ b/versioned_docs/version-v1.0/networking/best-practice/multiple-nics-vlan-aware-switch.md
@@ -11,7 +11,7 @@ keywords:
   - network
   - VLAN
   - vlan
-Description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
+description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
 ---
 
 In this best practice guide on how to configure "VLAN-aware", we will introduce Harvester VLAN network and external switch configuration for common scenario.

--- a/versioned_docs/version-v1.0/networking/best-practice/overview.md
+++ b/versioned_docs/version-v1.0/networking/best-practice/overview.md
@@ -11,7 +11,7 @@ keywords:
   - network
   - VLAN
   - vlan
-Description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
+description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
 ---
 
 In a real production environment, we generally recommend that you have multiple NICs in your machine, one for node access and one for VM networking. If your machine has multiple NICs, please refer to [multiple NICs](multiple-nics-vlan-aware-switch.md) for best practices. Otherwise, please refer to [Single NIC](single-nic-vlan-aware-switch.md) best practice.

--- a/versioned_docs/version-v1.0/networking/best-practice/single-nic-non-vlan-aware-switch.md
+++ b/versioned_docs/version-v1.0/networking/best-practice/single-nic-non-vlan-aware-switch.md
@@ -11,7 +11,7 @@ keywords:
   - network
   - VLAN
   - vlan
-Description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
+description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
 ---
 
 In this best practice guide for "non VLAN-aware" switch, also known as "dummy" switch, we will introduce Harvester VLAN network and external switch configuration for common scenario.

--- a/versioned_docs/version-v1.0/networking/best-practice/single-nic-vlan-aware-switch.md
+++ b/versioned_docs/version-v1.0/networking/best-practice/single-nic-vlan-aware-switch.md
@@ -11,7 +11,7 @@ keywords:
   - network
   - VLAN
   - vlan
-Description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
+description: Harvester is built on top of Kubernetes, and uses the [CNI](https://github.com/containernetworking/cni) as the interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the network configuration in order to provide a user-friendly way to configure networks for VMs.
 ---
 
 In this best practice guide on how to configure "VLAN-aware", we will introduce Harvester VLAN network and external switch configuration for common scenario.

--- a/versioned_docs/version-v1.0/networking/harvester-network.md
+++ b/versioned_docs/version-v1.0/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Upgrade
-Description: Harvester is built on Kubernetes, which uses CNI as an interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the Harvester network to provide a user-friendly way to configure networks for VMs.
+description: Harvester is built on Kubernetes, which uses CNI as an interface between network providers and Kubernetes pod networking. Naturally, we implement the Harvester network based on CNI. Moreover, the Harvester UI integrates the Harvester network to provide a user-friendly way to configure networks for VMs.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.0/rancher/cloud-provider.md
@@ -10,7 +10,7 @@ keywords:
   - RKE2
   - rke2
   - Harvester Cloud Provider
-Description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
+description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.0/rancher/node/node-driver.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Node Driver
-Description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
+description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.0/rancher/rancher-integration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Rancher Integration
-Description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
+description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/upgrade/automatic.md
+++ b/versioned_docs/version-v1.0/upgrade/automatic.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Upgrade
-Description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
+description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/upload-image.md
+++ b/versioned_docs/version-v1.0/upload-image.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Import Images
-Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
+description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.0/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.0/vm/access-to-the-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Access to the VM
-Description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
+description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/vm/backup-restore.md
+++ b/versioned_docs/version-v1.0/vm/backup-restore.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - VM Backup & Restore
-Description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM.
+description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/vm/create-vm.md
+++ b/versioned_docs/version-v1.0/vm/create-vm.md
@@ -10,7 +10,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a VM
-Description: Create one or more virtual machines from the Virtual Machines page.
+description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.0/vm/create-windows-vm.md
@@ -12,7 +12,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a Windows VM
-Description: Create one or more Windows virtual machines from the Virtual Machines page.
+description: Create one or more Windows virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/vm/edit-vm.md
+++ b/versioned_docs/version-v1.0/vm/edit-vm.md
@@ -10,7 +10,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Edit a VM
-Description: Edit Virtual Machines from the Harvester VM page.
+description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.0/vm/hotplug-volume.md
@@ -6,7 +6,7 @@ keywords:
   - Harvester
   - Hot-plug
   - Volume
-Description: Adding hot-plug volumes to a running VM.
+description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/vm/live-migration.md
+++ b/versioned_docs/version-v1.0/vm/live-migration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Live Migration
-Description: Live migration means moving a virtual machine to a different host without downtime.
+description: Live migration means moving a virtual machine to a different host without downtime.
 ---
 
 <head>

--- a/versioned_docs/version-v1.0/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.0/vm/resource-overcommit.md
@@ -7,7 +7,7 @@ keywords:
   - Overcommit
   - Overprovision
   - ballooning
-Description: Overcommit resources to a VM.
+description: Overcommit resources to a VM.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/authentication.md
+++ b/versioned_docs/version-v1.1/authentication.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Authentication
-Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
+description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.1/index.md
+++ b/versioned_docs/version-v1.1/index.md
@@ -10,7 +10,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Intro
-Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
+description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 

--- a/versioned_docs/version-v1.1/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/harvester-configuration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Configuration
-Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
+description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/install/iso-install.md
+++ b/versioned_docs/version-v1.1/install/iso-install.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - ISO Installation
-Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
+description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/install/management-address.md
+++ b/versioned_docs/version-v1.1/install/management-address.md
@@ -4,7 +4,7 @@ sidebar_label: Management Address
 title: "Management Address"
 keywords:
   - VIP
-Description: The Harvester provides a virtual IP as the management address.
+description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.1/install/pxe-boot-install.md
@@ -11,7 +11,7 @@ keywords:
   - Installing Harvester
   - Harvester Installation
   - PXE Boot Install
-Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
+description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/install/requirements.md
+++ b/versioned_docs/version-v1.1/install/requirements.md
@@ -5,7 +5,7 @@ sidebar_label: Hardware and Network Requirements
 title: "Hardware and Network Requirements"
 keywords:
 - Installation Requirements
-Description: Outline the Harvester installation requirements
+description: Outline the Harvester installation requirements
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/update-harvester-configuration.md
@@ -5,7 +5,7 @@ title: "Update Harvester Configuration After Installation"
 keywords:
   - Harvester configuration
   - Configuration
-Description: How to update Harvester configuration after installation
+description: How to update Harvester configuration after installation
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.1/rancher/cloud-provider.md
@@ -10,7 +10,7 @@ keywords:
   - RKE2
   - rke2
   - Harvester Cloud Provider
-Description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
+description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.1/rancher/node/node-driver.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Node Driver
-Description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
+description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.1/rancher/rancher-integration.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Rancher Integration
-Description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
+description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/upgrade/automatic.md
+++ b/versioned_docs/version-v1.1/upgrade/automatic.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Upgrade
-Description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
+description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/upload-image.md
+++ b/versioned_docs/version-v1.1/upload-image.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Import Images
-Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
+description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.1/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.1/vm/access-to-the-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Access to the VM
-Description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
+description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/backup-restore.md
+++ b/versioned_docs/version-v1.1/vm/backup-restore.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - VM Backup, Snapshot & Restore
-Description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM. VM Snapshot can work without Backup Target.
+description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM. VM Snapshot can work without Backup Target.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/clone-vm.md
+++ b/versioned_docs/version-v1.1/vm/clone-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Clone VM
-Description: VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
+description: VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/create-vm.md
+++ b/versioned_docs/version-v1.1/vm/create-vm.md
@@ -11,7 +11,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a VM
-Description: Create one or more virtual machines from the Virtual Machines page.
+description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.1/vm/create-windows-vm.md
@@ -12,7 +12,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a Windows VM
-Description: Create one or more Windows virtual machines from the Virtual Machines page.
+description: Create one or more Windows virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/edit-vm.md
+++ b/versioned_docs/version-v1.1/vm/edit-vm.md
@@ -10,7 +10,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Edit a VM
-Description: Edit Virtual Machines from the Harvester VM page.
+description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.1/vm/hotplug-volume.md
@@ -6,7 +6,7 @@ keywords:
   - Harvester
   - Hot-plug
   - Volume
-Description: Adding hot-plug volumes to a running VM.
+description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/live-migration.md
+++ b/versioned_docs/version-v1.1/vm/live-migration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Live Migration
-Description: Live migration means moving a virtual machine to a different host without downtime.
+description: Live migration means moving a virtual machine to a different host without downtime.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.1/vm/resource-overcommit.md
@@ -7,7 +7,7 @@ keywords:
   - Overcommit
   - Overprovision
   - ballooning
-Description: Overcommit resources to a VM.
+description: Overcommit resources to a VM.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/volume/clone-volume.md
+++ b/versioned_docs/version-v1.1/volume/clone-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Clone a Volume
 title: "Clone a Volume"
 keywords:
 - Volume
-Description: Clone volume from the Volume page.
+description: Clone volume from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/volume/create-volume.md
+++ b/versioned_docs/version-v1.1/volume/create-volume.md
@@ -5,7 +5,7 @@ sidebar_label: Create a Volume
 title: "Create a Volume"
 keywords:
 - Volume
-Description: Create a volume from the Volume page.
+description: Create a volume from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/volume/edit-volume.md
+++ b/versioned_docs/version-v1.1/volume/edit-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Edit a Volume
 title: "Edit a Volume"
 keywords:
 - Volume
-Description: Edit volume from the Volume page.
+description: Edit volume from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/volume/export-volume.md
+++ b/versioned_docs/version-v1.1/volume/export-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Export a Volume to Image
 title: "Export a Volume to Image"
 keywords:
 - Volume
-Description: Export volume to image from the Volume page.
+description: Export volume to image from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.1/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.1/volume/volume-snapshots.md
@@ -5,7 +5,7 @@ title: "Volume Snapshots"
 keywords:
 - Volume Snapshot
 - Volume Snapshots
-Description: Take a snapshot for a volume from the Volume page.
+description: Take a snapshot for a volume from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/authentication.md
+++ b/versioned_docs/version-v1.2/authentication.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Authentication
-Description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
+description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.2/index.md
+++ b/versioned_docs/version-v1.2/index.md
@@ -10,7 +10,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Intro
-Description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
+description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 

--- a/versioned_docs/version-v1.2/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.2/install/harvester-configuration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Configuration
-Description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
+description: Harvester configuration file can be provided during manual or automatic installation to configure various settings.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.2/install/install-binaries-mode.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - ISO Installation
-Description: To get the Harvester ISO, download it from the GitHub releases. During the installation, you can choose to install the binaries only.
+description: To get the Harvester ISO, download it from the GitHub releases. During the installation, you can choose to install the binaries only.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/install/iso-install.md
+++ b/versioned_docs/version-v1.2/install/iso-install.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - ISO Installation
-Description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
+description: To get the Harvester ISO, download it from the Github releases. During the installation you can either choose to form a new cluster, or join the node to an existing cluster.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/install/management-address.md
+++ b/versioned_docs/version-v1.2/install/management-address.md
@@ -4,7 +4,7 @@ sidebar_label: Management Address
 title: "Management Address"
 keywords:
   - VIP
-Description: The Harvester provides a virtual IP as the management address.
+description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.2/install/pxe-boot-install.md
@@ -11,7 +11,7 @@ keywords:
   - Installing Harvester
   - Harvester Installation
   - PXE Boot Install
-Description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
+description: Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/install/requirements.md
+++ b/versioned_docs/version-v1.2/install/requirements.md
@@ -5,7 +5,7 @@ sidebar_label: Hardware and Network Requirements
 title: "Hardware and Network Requirements"
 keywords:
 - Installation Requirements
-Description: Outline the Harvester installation requirements
+description: Outline the Harvester installation requirements
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.2/install/update-harvester-configuration.md
@@ -5,7 +5,7 @@ title: "Update Harvester Configuration After Installation"
 keywords:
   - Harvester configuration
   - Configuration
-Description: How to update Harvester configuration after installation
+description: How to update Harvester configuration after installation
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.2/rancher/cloud-provider.md
@@ -10,7 +10,7 @@ keywords:
   - RKE2
   - rke2
   - Harvester Cloud Provider
-Description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
+description: The Harvester cloud provider used by the guest cluster in Harvester provides a CSI interface and cloud controller manager (CCM) which implements a built-in load balancer.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.2/rancher/node/node-driver.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Node Driver
-Description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
+description: The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.2/rancher/rancher-integration.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Rancher Integration
-Description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
+description: Rancher is an open source multi-cluster management platform. Harvester has integrated Rancher by default starting with Rancher v2.6.1.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.2/rancher/resource-quota.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Resource Quota
-Description: ResourceQuota allows administrators to set resource limits per namespace, preventing excessive resource usage and ensuring the smooth operation of other namespaces when the quota is reached.
+description: ResourceQuota allows administrators to set resource limits per namespace, preventing excessive resource usage and ensuring the smooth operation of other namespaces when the quota is reached.
 ---
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/versioned_docs/version-v1.2/upgrade/automatic.md
+++ b/versioned_docs/version-v1.2/upgrade/automatic.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Harvester Upgrade
-Description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
+description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/upload-image.md
+++ b/versioned_docs/version-v1.2/upload-image.md
@@ -9,7 +9,7 @@ keywords:
   - Rancher
   - rancher
   - Import Images
-Description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
+description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.2/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.2/vm/access-to-the-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Access to the VM
-Description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
+description: Once the VM is up and running, it can be accessed using either VNC or the serial console from the Harvester UI.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/backup-restore.md
+++ b/versioned_docs/version-v1.2/vm/backup-restore.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - VM Backup, Snapshot & Restore
-Description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM. VM Snapshot can work without Backup Target.
+description: VM backups are created from the Virtual Machines page. The VM backup volumes will be stored in the Backup Target(an NFS or S3 server) and they can be used to either restore a new VM or replace an existing VM. VM Snapshot can work without Backup Target.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/clone-vm.md
+++ b/versioned_docs/version-v1.2/vm/clone-vm.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Clone VM
-Description: VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
+description: VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/create-vm.md
+++ b/versioned_docs/version-v1.2/vm/create-vm.md
@@ -11,7 +11,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a VM
-Description: Create one or more virtual machines from the Virtual Machines page.
+description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.2/vm/create-windows-vm.md
@@ -12,7 +12,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Create a Windows VM
-Description: Create one or more Windows virtual machines from the Virtual Machines page.
+description: Create one or more Windows virtual machines from the Virtual Machines page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/edit-vm.md
+++ b/versioned_docs/version-v1.2/vm/edit-vm.md
@@ -10,7 +10,7 @@ keywords:
   - Virtual Machine
   - virtual machine
   - Edit a VM
-Description: Edit Virtual Machines from the Harvester VM page.
+description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.2/vm/hotplug-volume.md
@@ -6,7 +6,7 @@ keywords:
   - Harvester
   - Hot-plug
   - Volume
-Description: Adding hot-plug volumes to a running VM.
+description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/live-migration.md
+++ b/versioned_docs/version-v1.2/vm/live-migration.md
@@ -8,7 +8,7 @@ keywords:
   - Rancher
   - rancher
   - Live Migration
-Description: Live migration means moving a virtual machine to a different host without downtime.
+description: Live migration means moving a virtual machine to a different host without downtime.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.2/vm/resource-overcommit.md
@@ -7,7 +7,7 @@ keywords:
   - Overcommit
   - Overprovision
   - ballooning
-Description: Overcommit resources to a VM.
+description: Overcommit resources to a VM.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/volume/clone-volume.md
+++ b/versioned_docs/version-v1.2/volume/clone-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Clone a Volume
 title: "Clone a Volume"
 keywords:
 - Volume
-Description: Clone volume from the Volume page.
+description: Clone volume from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/volume/create-volume.md
+++ b/versioned_docs/version-v1.2/volume/create-volume.md
@@ -5,7 +5,7 @@ sidebar_label: Create a Volume
 title: "Create a Volume"
 keywords:
 - Volume
-Description: Create a volume from the Volume page.
+description: Create a volume from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/volume/edit-volume.md
+++ b/versioned_docs/version-v1.2/volume/edit-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Edit a Volume
 title: "Edit a Volume"
 keywords:
 - Volume
-Description: Edit volume from the Volume page.
+description: Edit volume from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/volume/export-volume.md
+++ b/versioned_docs/version-v1.2/volume/export-volume.md
@@ -4,7 +4,7 @@ sidebar_label: Export a Volume to Image
 title: "Export a Volume to Image"
 keywords:
 - Volume
-Description: Export volume to image from the Volume page.
+description: Export volume to image from the Volume page.
 ---
 
 <head>

--- a/versioned_docs/version-v1.2/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.2/volume/volume-snapshots.md
@@ -5,7 +5,7 @@ title: "Volume Snapshots"
 keywords:
 - Volume Snapshot
 - Volume Snapshots
-Description: Take a snapshot for a volume from the Volume page.
+description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>


### PR DESCRIPTION
The current [capitalized form is invalid](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter), which leads to the description being generated based on the body content instead.

E.g. On https://docs.harvesterhci.io/v1.2, the page source doesn't have an instance of `Harvester is an open source hyper-converged infrastructure (HCI) software built on Kube...` from https://github.com/harvester/docs/edit/main/versioned_docs/version-v1.2/index.md.