### PR TITLE
Enable dark mode option

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -189,7 +189,7 @@ const config = {
 
       // Hides the switch in the navbar
       // Useful if you want to support a single color mode
-      disableSwitch: true,
+      disableSwitch: false,
     },
     footer: {
       style: "dark",


### PR DESCRIPTION
This change adds a button to the rightmost area of the header. The button allows users to switch from light mode (default) to dark mode with one click.