### PR TITLE
Update how to delete all resources in cattle-monitoring-system

### DIFF
--- a/docs/upgrade/v1-1-2-to-v1-2-0.md
+++ b/docs/upgrade/v1-1-2-to-v1-2-0.md
@@ -288,6 +288,8 @@ If you notice the upgrade is stuck in the **Upgrading System Service** state for
 
 ![](/img/v1.2/upgrade/known_issues/4484-apply-manifests-stuck.png)
 
+#### POD prometheus-rancher-monitoring-prometheus-0 is to be deleted
+
 1. Check the log of the `apply-manifests` pod to see if the following messages repeat.
 
     ```
@@ -336,6 +338,76 @@ If you notice the upgrade is stuck in the **Upgrading System Service** state for
 
 - Related issue
   - [[BUG] The rancher-monitoring Pod stuck at terminating status when upgrading from v1.1.2 to v1.2.0-rc6](https://github.com/harvester/harvester/issues/4484)
+
+#### Multiple PODs in cattle-monitoring-system namespace are to be deleted
+
+1. Check the log of the `apply-manifests` pod to see if the following messages repeat.
+
+    ```
+    there are still 10 pods in cattle-monitoring-system to be deleted
+    Fri Dec  8 19:06:56 UTC 2023
+    there are still 10 pods in cattle-monitoring-system to be deleted
+    Fri Dec  8 19:07:01 UTC 2023
+    ```
+    When it continues to show 10 (or other number) pods, it encounters below issue.
+
+    ```
+    The monitoring feature is deployed from the rancher-monitoring ManagedChart, in Harvester v1.2.0,v1.2.1,
+    this ManagedChart is converted to Harvester Addon feature when upgrading.
+    The ManagedChart rancher-monitoring is deleted, normally, all the generated resources including deployment, 
+    daemonset etc. will be deleted automatically. But in this case, those resources are not deleted.
+    The above log reflects the result.
+    Following instructions will guide to delete them manually.
+    ```
+
+1. Locate the affected resources in the `cattle-monitoring-system` namespace.
+
+    ```
+    Root level resources in cattle-monitoring-system
+
+    Customized CRD: Prometheus
+      Object: rancher-monitoring-prometheus
+      Sub-object: statefulset.apps/prometheus-rancher-monitoring-prometheus
+
+    Customized CRD: Alertmanager
+      object:  rancher-monitoring-alertmanager 
+      Sub-object:  statefulset.apps/alertmanager-rancher-monitoring-alertmanager
+
+    Deployment:
+      rancher-monitoring-grafana
+      rancher-monitoring-kube-state-metrics
+      rancher-monitoring-operator
+      rancher-monitoring-prometheus-adapter
+
+    Daemonset:
+      rancher-monitoring-prometheus-node-exporter
+    ```
+
+1. Delete the affected resources.
+
+    ```
+    Use below commands to delete them, meanwhile check the log of the `apply-manifests` until it does not
+    report `there are still x pods in cattle-monitoring-system to be deleted`.
+
+    kubectl delete prometheus rancher-monitoring-prometheus -n cattle-monitoring-system
+    kubectl delete alertmanager rancher-monitoring-alertmanager -n cattle-monitoring-system
+
+    kubectl delete deployment rancher-monitoring-grafana -n cattle-monitoring-system
+    kubectl delete deployment rancher-monitoring-kube-state-metrics -n cattle-monitoring-system
+    kubectl delete deployment rancher-monitoring-operator -n cattle-monitoring-system
+    kubectl delete deployment rancher-monitoring-prometheus-adapter -n cattle-monitoring-system
+
+    kubectl delete daemonset rancher-monitoring-prometheus-node-exporter -n cattle-monitoring-system
+    ```
+    
+    :::note
+
+    You may need to run some of the commands more than once to completely delete the resources.
+
+    :::
+
+- Related issue
+  - [[BUG] upgrade hung on apply-manifests](https://github.com/harvester/harvester/issues/4846)
 
 ---
 

--- a/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
@@ -288,6 +288,8 @@ If you notice the upgrade is stuck in the **Upgrading System Service** state for
 
 ![](/img/v1.2/upgrade/known_issues/4484-apply-manifests-stuck.png)
 
+#### POD prometheus-rancher-monitoring-prometheus-0 is to be deleted
+
 1. Check the log of the `apply-manifests` pod to see if the following messages repeat.
 
     ```
@@ -336,6 +338,76 @@ If you notice the upgrade is stuck in the **Upgrading System Service** state for
 
 - Related issue
   - [[BUG] The rancher-monitoring Pod stuck at terminating status when upgrading from v1.1.2 to v1.2.0-rc6](https://github.com/harvester/harvester/issues/4484)
+
+#### Multiple PODs in cattle-monitoring-system namespace are to be deleted
+
+1. Check the log of the `apply-manifests` pod to see if the following messages repeat.
+
+    ```
+    there are still 10 pods in cattle-monitoring-system to be deleted
+    Fri Dec  8 19:06:56 UTC 2023
+    there are still 10 pods in cattle-monitoring-system to be deleted
+    Fri Dec  8 19:07:01 UTC 2023
+    ```
+    When it continues to show 10 (or other number) pods, it encounters below issue.
+
+    ```
+    The monitoring feature is deployed from the rancher-monitoring ManagedChart, in Harvester v1.2.0,v1.2.1,
+    this ManagedChart is converted to Harvester Addon feature when upgrading.
+    The ManagedChart rancher-monitoring is deleted, normally, all the generated resources including deployment, 
+    daemonset etc. will be deleted automatically. But in this case, those resources are not deleted.
+    The above log reflects the result.
+    Following instructions will guide to delete them manually.
+    ```
+
+1. Locate the affected resources in the `cattle-monitoring-system` namespace.
+
+    ```
+    Root level resources in cattle-monitoring-system
+
+    Customized CRD: Prometheus
+      Object: rancher-monitoring-prometheus
+      Sub-object: statefulset.apps/prometheus-rancher-monitoring-prometheus
+
+    Customized CRD: Alertmanager
+      object:  rancher-monitoring-alertmanager 
+      Sub-object:  statefulset.apps/alertmanager-rancher-monitoring-alertmanager
+
+    Deployment:
+      rancher-monitoring-grafana
+      rancher-monitoring-kube-state-metrics
+      rancher-monitoring-operator
+      rancher-monitoring-prometheus-adapter
+
+    Daemonset:
+      rancher-monitoring-prometheus-node-exporter
+    ```
+
+1. Delete the affected resources.
+
+    ```
+    Use below commands to delete them, meanwhile check the log of the `apply-manifests` until it does not
+    report `there are still x pods in cattle-monitoring-system to be deleted`.
+
+    kubectl delete prometheus rancher-monitoring-prometheus -n cattle-monitoring-system
+    kubectl delete alertmanager rancher-monitoring-alertmanager -n cattle-monitoring-system
+
+    kubectl delete deployment rancher-monitoring-grafana -n cattle-monitoring-system
+    kubectl delete deployment rancher-monitoring-kube-state-metrics -n cattle-monitoring-system
+    kubectl delete deployment rancher-monitoring-operator -n cattle-monitoring-system
+    kubectl delete deployment rancher-monitoring-prometheus-adapter -n cattle-monitoring-system
+
+    kubectl delete daemonset rancher-monitoring-prometheus-node-exporter -n cattle-monitoring-system
+    ```
+    
+    :::note
+
+    You may need to run some of the commands more than once to completely delete the resources.
+
+    :::
+
+- Related issue
+  - [[BUG] upgrade hung on apply-manifests](https://github.com/harvester/harvester/issues/4846)
 
 ---
 


### PR DESCRIPTION
When managedchart rancher-monitoring is deleted, the generated resources is not deleted, it blocks the upgrade.

Related issue:
https://github.com/harvester/harvester/issues/4846


For reference:
https://github.com/harvester/harvester/issues/4484