### PR TITLE
Update instructions for setting default GRUB boot menu entry

### DIFF
--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -123,7 +123,7 @@ You can configure the default entry by running the following commands:
 # grub2-editenv /run/initramfs/cos-state/grub_oem_env set saved_entry=debug
 ```
 
-This change can be reverted later if necessary by running `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`
+If necessary, you can undo the change by running the command `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`.  
 
 ## How to debug a system crash or hang
 

--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -90,12 +90,12 @@ The following steps are a workaround. Harvester will inform the community once a
 - Reboot for changes to take effect.
 ## How to change the default GRUB boot menu entry
 
-To change the default entry, first check the `--id` attribute of a menu entry. Grub menu entries are located in the following files:  
+To change the default entry, first check the `--id` attribute of a menu entry. Grub menu entries are located in the following files:
 
-- `/run/initramfs/cos-state/grub2/grub.cfg`: Contains the default, fallback, and recovery entries   
-- `/run/initramfs/cos-state/grubcustom`: Contains the debug entry  
+- `/run/initramfs/cos-state/grub2/grub.cfg`: Contains the default, fallback, and recovery entries
+- `/run/initramfs/cos-state/grubcustom`: Contains the debug entry
 
-In the following example, the id of the entry is `debug`.  
+In the following example, the id of the entry is `debug`.
 
 
 ```
@@ -116,14 +116,14 @@ menuentry "${display_name} (debug)" --id debug {
 }
 ```
 
-You can configure the default entry by running the following commands:  
+You can configure the default entry by running the following commands:
 
 ```
 # mount -o remount,rw /run/initramfs/cos-state
 # grub2-editenv /run/initramfs/cos-state/grub_oem_env set saved_entry=debug
 ```
 
-If necessary, you can undo the change by running the command `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`.  
+If necessary, you can undo the change by running the command `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`.
 
 ## How to debug a system crash or hang
 

--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -90,13 +90,16 @@ The following steps are a workaround. Harvester will inform the community once a
 - Reboot for changes to take effect.
 ## How to change the default GRUB boot menu entry
 
-To change the default entry, first check the `--id` attribute of a menu entry, as in the following example:
+To change the default entry, first check the `--id` attribute of a menu entry, as in the following example. Note that grub menu entries are split across two files, with the regular default, fallback and recovery entries in `/run/initramfs/cos-state/grub2/grub.cfg`, plus an additional debug entry in `/run/initramfs/cos-state/grubcustom`:
+
 
 ```
-# cat /run/initramfs/cos-state/grub2/grub.cfg
+# cat \
+    /run/initramfs/cos-state/grub2/grub.cfg \
+    /run/initramfs/cos-state/grubcustom
 
 <...>
-menuentry "${display_name} (debug)" --id cos-debug {
+menuentry "${display_name} (debug)" --id debug {
   search --no-floppy --set=root --label COS_STATE
   set img=/cOS/active.img
   set label=COS_ACTIVE
@@ -108,11 +111,15 @@ menuentry "${display_name} (debug)" --id cos-debug {
 }
 ```
 
-The id of the above entry is `cos-debug`. We can then set the default entry by:
+The id of the above entry is `debug`. We can then set the default entry by running:
 
 ```
-# grub2-editenv /oem/grubenv set saved_entry=cos-debug
+# mount -o remount,rw /run/initramfs/cos-state
+# grub2-editenv /run/initramfs/cos-state/grub_oem_env set saved_entry=debug
 ```
+
+This change can be reverted later if necessary by running `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`
+
 ## How to debug a system crash or hang
 
 ### Collect crash log

--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -116,7 +116,7 @@ menuentry "${display_name} (debug)" --id debug {
 }
 ```
 
-The id of the above entry is `debug`. We can then set the default entry by running:
+You can configure the default entry by running the following commands:  
 
 ```
 # mount -o remount,rw /run/initramfs/cos-state

--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -90,7 +90,12 @@ The following steps are a workaround. Harvester will inform the community once a
 - Reboot for changes to take effect.
 ## How to change the default GRUB boot menu entry
 
-To change the default entry, first check the `--id` attribute of a menu entry, as in the following example. Note that grub menu entries are split across two files, with the regular default, fallback and recovery entries in `/run/initramfs/cos-state/grub2/grub.cfg`, plus an additional debug entry in `/run/initramfs/cos-state/grubcustom`:
+To change the default entry, first check the `--id` attribute of a menu entry. Grub menu entries are located in the following files:  
+
+- `/run/initramfs/cos-state/grub2/grub.cfg`: Contains the default, fallback, and recovery entries   
+- `/run/initramfs/cos-state/grubcustom`: Contains the debug entry  
+
+In the following example, the id of the entry is `debug`.  
 
 
 ```

--- a/versioned_docs/version-v1.1/troubleshooting/os.md
+++ b/versioned_docs/version-v1.1/troubleshooting/os.md
@@ -91,24 +91,41 @@ The following steps are a workaround. Harvester will inform the community once a
 - Reboot for changes to take effect.
 ## How to change the default GRUB boot menu entry
 
-To change the default entry, first check the `--id` attribute of a menu entry, as in the following example:
+To change the default entry, first check the `--id` attribute of a menu entry. Grub menu entries are located in the following files:
+
+- `/run/initramfs/cos-state/grub2/grub.cfg`: Contains the default, fallback, and recovery entries
+- `/run/initramfs/cos-state/grubmenu`: Contains the debug entry
+
+In the following example, the id of the entry is `debug`.
+
 
 ```
-# cat /run/initramfs/cos-state/grub2/grub.cfg
+# cat \
+    /run/initramfs/cos-state/grub2/grub.cfg \
+    /run/initramfs/cos-state/grubmenu
 
 <...>
-menuentry "Harvester ea6e7f5-dirty (debug)" --id cos-debug {
-  search.fs_label COS_STATE root
+menuentry "${display_name} (debug)" --id debug {
+  search --no-floppy --set=root --label COS_STATE
   set img=/cOS/active.img
   set label=COS_ACTIVE
   loopback loop0 /$img
+  set root=($root)
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline} ${crash_kernel_params}
+  initrd (loop0)$initramfs
+}
 ```
 
-The id of the above entry is `cos-debug`. We can then set the default entry by:
+You can configure the default entry by running the following commands:
 
 ```
-# grub2-editenv /oem/grubenv set saved_entry=cos-debug
+# mount -o remount,rw /run/initramfs/cos-state
+# grub2-editenv /run/initramfs/cos-state/grub_oem_env set saved_entry=debug
 ```
+
+If necessary, you can undo the change by running the command `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`.
+
 ## How to debug a system crash or hang
 
 ### Collect crash log

--- a/versioned_docs/version-v1.2/troubleshooting/os.md
+++ b/versioned_docs/version-v1.2/troubleshooting/os.md
@@ -90,12 +90,12 @@ The following steps are a workaround. Harvester will inform the community once a
 - Reboot for changes to take effect.
 ## How to change the default GRUB boot menu entry
 
-To change the default entry, first check the `--id` attribute of a menu entry. Grub menu entries are located in the following files:  
+To change the default entry, first check the `--id` attribute of a menu entry. Grub menu entries are located in the following files:
 
-- `/run/initramfs/cos-state/grub2/grub.cfg`: Contains the default, fallback, and recovery entries   
-- `/run/initramfs/cos-state/grubcustom`: Contains the debug entry  
+- `/run/initramfs/cos-state/grub2/grub.cfg`: Contains the default, fallback, and recovery entries
+- `/run/initramfs/cos-state/grubcustom`: Contains the debug entry
 
-In the following example, the id of the entry is `debug`.  
+In the following example, the id of the entry is `debug`.
 
 
 ```
@@ -116,14 +116,14 @@ menuentry "${display_name} (debug)" --id debug {
 }
 ```
 
-You can configure the default entry by running the following commands:  
+You can configure the default entry by running the following commands:
 
 ```
 # mount -o remount,rw /run/initramfs/cos-state
 # grub2-editenv /run/initramfs/cos-state/grub_oem_env set saved_entry=debug
 ```
 
-If necessary, you can undo the change by running the command `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`.  
+If necessary, you can undo the change by running the command `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`.
 
 ## How to debug a system crash or hang
 

--- a/versioned_docs/version-v1.2/troubleshooting/os.md
+++ b/versioned_docs/version-v1.2/troubleshooting/os.md
@@ -90,7 +90,12 @@ The following steps are a workaround. Harvester will inform the community once a
 - Reboot for changes to take effect.
 ## How to change the default GRUB boot menu entry
 
-To change the default entry, first check the `--id` attribute of a menu entry, as in the following example. Note that grub menu entries are split across two files, with the regular default, fallback and recovery entries in `/run/initramfs/cos-state/grub2/grub.cfg`, plus an additional debug entry in `/run/initramfs/cos-state/grubcustom`:
+To change the default entry, first check the `--id` attribute of a menu entry. Grub menu entries are located in the following files:  
+
+- `/run/initramfs/cos-state/grub2/grub.cfg`: Contains the default, fallback, and recovery entries   
+- `/run/initramfs/cos-state/grubcustom`: Contains the debug entry  
+
+In the following example, the id of the entry is `debug`.  
 
 
 ```
@@ -111,14 +116,14 @@ menuentry "${display_name} (debug)" --id debug {
 }
 ```
 
-The id of the above entry is `debug`. We can then set the default entry by running:
+You can configure the default entry by running the following commands:  
 
 ```
 # mount -o remount,rw /run/initramfs/cos-state
 # grub2-editenv /run/initramfs/cos-state/grub_oem_env set saved_entry=debug
 ```
 
-This change can be reverted later if necessary by running `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`
+If necessary, you can undo the change by running the command `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`.  
 
 ## How to debug a system crash or hang
 

--- a/versioned_docs/version-v1.2/troubleshooting/os.md
+++ b/versioned_docs/version-v1.2/troubleshooting/os.md
@@ -90,13 +90,16 @@ The following steps are a workaround. Harvester will inform the community once a
 - Reboot for changes to take effect.
 ## How to change the default GRUB boot menu entry
 
-To change the default entry, first check the `--id` attribute of a menu entry, as in the following example:
+To change the default entry, first check the `--id` attribute of a menu entry, as in the following example. Note that grub menu entries are split across two files, with the regular default, fallback and recovery entries in `/run/initramfs/cos-state/grub2/grub.cfg`, plus an additional debug entry in `/run/initramfs/cos-state/grubcustom`:
+
 
 ```
-# cat /run/initramfs/cos-state/grub2/grub.cfg
+# cat \
+    /run/initramfs/cos-state/grub2/grub.cfg \
+    /run/initramfs/cos-state/grubcustom
 
 <...>
-menuentry "${display_name} (debug)" --id cos-debug {
+menuentry "${display_name} (debug)" --id debug {
   search --no-floppy --set=root --label COS_STATE
   set img=/cOS/active.img
   set label=COS_ACTIVE
@@ -108,11 +111,15 @@ menuentry "${display_name} (debug)" --id cos-debug {
 }
 ```
 
-The id of the above entry is `cos-debug`. We can then set the default entry by:
+The id of the above entry is `debug`. We can then set the default entry by running:
 
 ```
-# grub2-editenv /oem/grubenv set saved_entry=cos-debug
+# mount -o remount,rw /run/initramfs/cos-state
+# grub2-editenv /run/initramfs/cos-state/grub_oem_env set saved_entry=debug
 ```
+
+This change can be reverted later if necessary by running `grub2-editenv /run/initramfs/cos-state/grub_oem_env unset saved_entry`
+
 ## How to debug a system crash or hang
 
 ### Collect crash log


### PR DESCRIPTION
I've fixed this for v1.3 (dev) and v1.2 (latest) docs, but I've not made any changes for v1.1 or earlier.  Judging from the source for harvester-installer for these versions, we have a different file to look at ("grubmenu" as opposed to "grubcustom"), because that's what the older versions of elemental used when creating grub config.

Related issue: https://github.com/harvester/harvester/issues/4808