### PR TITLE
Fix list indent on Custom SUSE VM Images page

### DIFF
--- a/docs/advanced/customsuseimages.md
+++ b/docs/advanced/customsuseimages.md
@@ -32,29 +32,29 @@ You can create custom images based on what SUSE provides using OBS [image templa
 
 1. Specify a name for the image, and then select **Create appliance**.
 
-![](/img/v1.3/advanced/custom-vm-01-select-template.png)
+   ![](/img/v1.3/advanced/custom-vm-01-select-template.png)
 
-OBS automatically builds the image. By default, the interface shows the **Overview** tab, which contains information such as the number of included packages and the build status.
+   OBS automatically builds the image. By default, the interface shows the **Overview** tab, which contains information such as the number of included packages and the build status.
 
-![](/img/v1.3/advanced/custom-vm-02-image-overview.png)
+   ![](/img/v1.3/advanced/custom-vm-02-image-overview.png)
 
 ### 2. Select image profiles and add packages.
 
 1. Go to the **Software** tab.
 
-2. Select the image profiles that you want OBS to build.
+1. Select the image profiles that you want OBS to build.
 
   :::info
   For most cases, you can use the *Minimal VM Cloud* qcow2 images because these include the cloud-init tool necessary for automatic VM configuration. Other image variants require you to log onto the VM console and then perform initial configuration.
   :::
 
-![](/img/v1.3/advanced/custom-vm-03-image-software.png)
+   ![](/img/v1.3/advanced/custom-vm-03-image-software.png)
 
-3. (Optional) Add and remove packages.
+1. (Optional) Add and remove packages.
 
-![](/img/v1.3/advanced/custom-vm-04-image-software-packages.png)
+   ![](/img/v1.3/advanced/custom-vm-04-image-software-packages.png)
 
-![](/img/v1.3/advanced/custom-vm-05-image-software-add-package.png)
+   ![](/img/v1.3/advanced/custom-vm-05-image-software-add-package.png)
 
 ### 3. (Optional) Switch to *View Package* mode.
 


### PR DESCRIPTION
By indenting the screenshots and other text, we can go back to using "1." everywhere as the numbered list item prefix, so don't have to worry about counting list items (e.g. the explicit "3." I added earlier is no longer necessary).  Also, this makes the screenshots indent nicely when they appear inside list items.

The only thing I'm not sure about is whether it matters that the following screenshots under the later headings ("3. (Optional) Switch to View Package mode", etc.) are not indented the same as the ones that appear inside lists?