### PR TITLE
Activate Algolia Search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,7 +70,6 @@ const config = {
   ],
   themeConfig: {
     zoom: {},
-    /*
     algolia: {
       appId: 'U7QCSJFCWR',
       apiKey: '954c1b1327687e818ef6930a5e8f8770',
@@ -80,7 +79,6 @@ const config = {
       // Optional: path for search page that enabled by default (`false` to disable it)
       searchPagePath: 'search',
     },
-    */
     docs: {
       sidebar: {
         hideable: true,
@@ -229,7 +227,7 @@ const config = {
   },
   plugins: [
     require.resolve('docusaurus-plugin-image-zoom'),
-    require.resolve("@cmfcmf/docusaurus-search-local"),
+    /*require.resolve("@cmfcmf/docusaurus-search-local"),*/
     [
       '@docusaurus/plugin-client-redirects',
       {


### PR DESCRIPTION
Related to https://github.com/harvester/docs/pull/524

- Algolia Search limit has refreshed.
- Re-activating Algolia search.

<img width="1058" alt="Screenshot 2024-03-13 at 9 19 03 PM" src="https://github.com/harvester/docs/assets/83089978/2e58dc25-a86b-4a3b-8788-706493bcca58">
