### PR TITLE
doc: support `os.sshd.sftp`

### DIFF
--- a/versioned_docs/version-v1.2/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.2/install/harvester-configuration.md
@@ -425,6 +425,21 @@ os:
     mylabel: myvalue
 ```
 
+### `os.sshd.sftp` 
+*since v1.2.2*
+
+#### Definition
+
+Subsystem used to configure the OpenSSH Daemon (sshd). Harvester currently only supports `sftp`.
+
+#### Example
+
+```yaml
+os:
+  sshd:
+    sftp: true  #  The SFTP subsystem is enabled.
+```
+
 ### `install.mode`
 
 #### Definition


### PR DESCRIPTION

Hi @jillian-maroket, @bk201.
I missed this configuration for v1.2.2.

Also, add the version reminder for more clarity.
Please help to review. Thanks!