### PR TITLE
Add workaround to fix the modified state of rancher-monitoring-crd

### DIFF
--- a/docs/troubleshooting/monitoring.md
+++ b/docs/troubleshooting/monitoring.md
@@ -316,3 +316,277 @@ You may encounter this when you install the Harvester v1.3.0 or higher version c
     rancher-monitoring-prometheus-adapter-55dc9ccd5d-vtssc   1/1     Running     0          3m55s
     rancher-monitoring-prometheus-node-exporter-lgb88        1/1     Running     0          3m55s
     ```
+
+## `rancher-monitoring-crd` ManagedChart State is `Modified`
+
+### Issue Description
+
+In certain situations, the state of the `rancher-monitoring-crd` ManagedChart object changes to `Modified` (with the message `...rancher-monitoring-crd-manager missing...`).
+
+Example:
+
+```
+$ kubectl get managedchart rancher-monitoring-crd -n fleet-local -o yaml
+apiVersion: management.cattle.io/v3
+kind: ManagedChart
+...
+spec:
+  chart: rancher-monitoring-crd
+  defaultNamespace: cattle-monitoring-system
+  paused: false
+  releaseName: rancher-monitoring-crd
+  repoName: harvester-charts
+  targets:
+  - clusterName: local
+    clusterSelector:
+      matchExpressions:
+      - key: provisioning.cattle.io/unmanaged-system-agent
+        operator: DoesNotExist
+  version: 102.0.0+up40.1.2
+...
+status:
+  conditions:
+  - lastUpdateTime: "2024-02-22T14:03:11Z"
+    message: Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io
+      rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io
+      rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest
+      missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager
+      missing
+    status: "False"
+    type: Ready
+  - lastUpdateTime: "2024-02-22T14:03:11Z"
+    status: "True"
+    type: Processed
+  - lastUpdateTime: "2024-04-02T07:45:26Z"
+    status: "True"
+    type: Defined
+  display:
+    readyClusters: 0/1
+    state: Modified
+...
+```
+
+The `ManagedChart` object has a downstream object named `Bundle`, which has similar information.
+
+Example:
+
+```
+$ kubectl get bundles -A
+NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
+fleet-local   fleet-agent-local                             1/1
+fleet-local   local-managed-system-agent                    1/1
+fleet-local   mcc-harvester                                 1/1
+fleet-local   mcc-harvester-crd                             1/1
+fleet-local   mcc-local-managed-system-upgrade-controller   1/1
+fleet-local   mcc-rancher-logging-crd                       1/1
+fleet-local   mcc-rancher-monitoring-crd                    0/1                       Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager missing
+```
+
+When the issue exists and you [start an upgrade](../upgrade/automatic.md#start-an-upgrade), Harvester may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
+
+Also, when you search for the objects marked as `missing`, you will find that they exist in the cluster.
+
+Example:
+
+```
+$ kubectl get clusterrole rancher-monitoring-crd-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  ...
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - delete
+
+$ kubectl get clusterrolebinding rancher-monitoring-crd-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  ...
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rancher-monitoring-crd-manager
+subjects:
+- kind: ServiceAccount
+  name: rancher-monitoring-crd-manager
+  namespace: cattle-monitoring-system
+
+$ kubectl get configmap -n cattle-monitoring-system rancher-monitoring-crd-manifest
+apiVersion: v1
+data:
+  crd-manifest.tgz.b64: ...
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manifest
+  namespace: cattle-monitoring-system
+  ...
+
+$ kubectl get ServiceAccount -n cattle-monitoring-system rancher-monitoring-crd-manager
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  namespace: cattle-monitoring-system
+  ...
+```
+
+### Root Cause
+
+The objects that are marked as `missing` do not have the related annotations and labels required by the `ManagedChart` object.
+
+Example:
+
+```
+One of the manually recreated object:
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+    objectset.rio.cattle.io/id: default-mcc-rancher-monitoring-crd-cattle-fleet-local-system   # This required item is not in the above object.
+  creationTimestamp: "2024-04-03T10:23:55Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+    objectset.rio.cattle.io/hash: 2da503261617e9ea2da822d2da7cdcfccad847a9    # This required item is not in the above object.
+  name: rancher-monitoring-crd-manager
+...
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - delete
+  - update
+```
+
+### Workaround
+
+1. Patch the ClusterRole object `rancher-monitoring-crd-manager` to add the `update` operation.
+
+    ```
+    $ cat > patchrules.yaml << EOF
+    rules:
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - create
+      - get
+      - patch
+      - delete
+      - update
+    EOF
+
+    $ kubectl patch ClusterRole rancher-monitoring-crd-manager --patch-file ./patchrules.yaml --type merge
+
+    $ rm ./patchrules.yaml
+    ```
+
+1. Patch the marked as `missing` objects to add the required annotations and labels.
+
+    ```
+    $ cat > patchhash.yaml << EOF
+    metadata:
+      annotations:
+        objectset.rio.cattle.io/id: default-mcc-rancher-monitoring-crd-cattle-fleet-local-system
+      labels:
+        objectset.rio.cattle.io/hash: 2da503261617e9ea2da822d2da7cdcfccad847a9
+    EOF
+
+    $ kubectl patch ClusterRole rancher-monitoring-crd-manager --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ClusterRoleBinding rancher-monitoring-crd-manager --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ServiceAccount rancher-monitoring-crd-manager -n cattle-monitoring-system --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ConfigMap rancher-monitoring-crd-manifest -n cattle-monitoring-system --patch-file ./patchhash.yaml --type merge
+
+    $ rm ./patchhash.yaml
+    ```
+
+1. Check the `rancher-monitoring-crd` ManagedChart object.
+
+    After a few seconds, the status of the `rancher-monitoring-crd` ManagedChart object changes to `Ready`.
+
+    ```
+    $ kubectl get managedchart -n fleet-local rancher-monitoring-crd -oyaml
+    apiVersion: management.cattle.io/v3
+    kind: ManagedChart
+    metadata:
+    ...
+      name: rancher-monitoring-crd
+      namespace: fleet-local
+    ...
+    status:
+      conditions:
+      - lastUpdateTime: "2024-04-22T21:41:44Z"
+        status: "True"
+        type: Ready
+    ...
+    ```
+
+    Also, error indicators are no longer displayed for the downstream objects.
+
+    ```
+    $ kubectl bundle -A
+    NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
+    fleet-local   fleet-agent-local                             1/1
+    fleet-local   local-managed-system-agent                    1/1
+    fleet-local   mcc-harvester                                 1/1
+    fleet-local   mcc-harvester-crd                             1/1
+    fleet-local   mcc-local-managed-system-upgrade-controller   1/1
+    fleet-local   mcc-rancher-logging-crd                       1/1
+    fleet-local   mcc-rancher-monitoring-crd                    1/1
+
+    ```
+
+1. (Optional) Retry the upgrade (if previously unsuccessful because of this issue).
+
+### Related Issue
+
+https://github.com/harvester/harvester/issues/5505

--- a/docs/upgrade/v1-1-2-to-v1-2-0.md
+++ b/docs/upgrade/v1-1-2-to-v1-2-0.md
@@ -685,3 +685,9 @@ If an upgrade is stuck in an **Upgrading System Service** state for an extended 
   - https://github.com/harvester/harvester/issues/4519#issuecomment-1727132383
 
 ---
+
+### 11. An upgrade is denied due to `managed chart rancher-monitoring-crd is not ready`
+
+When you [start an upgrade](../upgrade/automatic.md#start-an-upgrade) and Harvester returns such an error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`. Please follow this [troubleshooting](../troubleshooting/monitoring.md#the-state-of-the-rancher-monitoring-crd-managedchart-is-modified).
+
+---

--- a/versioned_docs/version-v1.2/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.2/troubleshooting/monitoring.md
@@ -187,3 +187,276 @@ The `Volume` is attached to the new POD.
 
 To now, the `Volume` is expanded to the new size and the POD is using it smoothly.
 
+## `rancher-monitoring-crd` ManagedChart State is `Modified`
+
+### Issue Description
+
+In certain situations, the state of the `rancher-monitoring-crd` ManagedChart object changes to `Modified` (with the message `...rancher-monitoring-crd-manager missing...`).
+
+Example:
+
+```
+$ kubectl get managedchart rancher-monitoring-crd -n fleet-local -o yaml
+apiVersion: management.cattle.io/v3
+kind: ManagedChart
+...
+spec:
+  chart: rancher-monitoring-crd
+  defaultNamespace: cattle-monitoring-system
+  paused: false
+  releaseName: rancher-monitoring-crd
+  repoName: harvester-charts
+  targets:
+  - clusterName: local
+    clusterSelector:
+      matchExpressions:
+      - key: provisioning.cattle.io/unmanaged-system-agent
+        operator: DoesNotExist
+  version: 102.0.0+up40.1.2
+...
+status:
+  conditions:
+  - lastUpdateTime: "2024-02-22T14:03:11Z"
+    message: Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io
+      rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io
+      rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest
+      missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager
+      missing
+    status: "False"
+    type: Ready
+  - lastUpdateTime: "2024-02-22T14:03:11Z"
+    status: "True"
+    type: Processed
+  - lastUpdateTime: "2024-04-02T07:45:26Z"
+    status: "True"
+    type: Defined
+  display:
+    readyClusters: 0/1
+    state: Modified
+...
+```
+
+The `ManagedChart` object has a downstream object named `Bundle`, which has similar information.
+
+Example:
+
+```
+$ kubectl get bundles -A
+NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
+fleet-local   fleet-agent-local                             1/1
+fleet-local   local-managed-system-agent                    1/1
+fleet-local   mcc-harvester                                 1/1
+fleet-local   mcc-harvester-crd                             1/1
+fleet-local   mcc-local-managed-system-upgrade-controller   1/1
+fleet-local   mcc-rancher-logging-crd                       1/1
+fleet-local   mcc-rancher-monitoring-crd                    0/1                       Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager missing
+```
+
+When the issue exists and you [start an upgrade](../upgrade/automatic.md#start-an-upgrade), Harvester may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
+
+Also, when you search for the objects marked as `missing`, you will find that they exist in the cluster.
+
+Example:
+
+```
+$ kubectl get clusterrole rancher-monitoring-crd-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  ...
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - delete
+
+$ kubectl get clusterrolebinding rancher-monitoring-crd-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  ...
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rancher-monitoring-crd-manager
+subjects:
+- kind: ServiceAccount
+  name: rancher-monitoring-crd-manager
+  namespace: cattle-monitoring-system
+
+$ kubectl get configmap -n cattle-monitoring-system rancher-monitoring-crd-manifest
+apiVersion: v1
+data:
+  crd-manifest.tgz.b64: ...
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manifest
+  namespace: cattle-monitoring-system
+  ...
+
+$ kubectl get ServiceAccount -n cattle-monitoring-system rancher-monitoring-crd-manager
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  namespace: cattle-monitoring-system
+  ...
+```
+
+### Root Cause
+
+The objects that are marked as `missing` do not have the related annotations and labels required by the `ManagedChart` object.
+
+Example:
+
+```
+One of the manually recreated object:
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+    objectset.rio.cattle.io/id: default-mcc-rancher-monitoring-crd-cattle-fleet-local-system   # This required item is not in the above object.
+  creationTimestamp: "2024-04-03T10:23:55Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+    objectset.rio.cattle.io/hash: 2da503261617e9ea2da822d2da7cdcfccad847a9    # This required item is not in the above object.
+  name: rancher-monitoring-crd-manager
+...
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - delete
+  - update
+```
+
+### Workaround
+
+1. Patch the ClusterRole object `rancher-monitoring-crd-manager` to add the `update` operation.
+
+    ```
+    $ cat > patchrules.yaml << EOF
+    rules:
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - create
+      - get
+      - patch
+      - delete
+      - update
+    EOF
+
+    $ kubectl patch ClusterRole rancher-monitoring-crd-manager --patch-file ./patchrules.yaml --type merge
+
+    $ rm ./patchrules.yaml
+    ```
+
+1. Patch the marked as `missing` objects to add the required annotations and labels.
+
+    ```
+    $ cat > patchhash.yaml << EOF
+    metadata:
+      annotations:
+        objectset.rio.cattle.io/id: default-mcc-rancher-monitoring-crd-cattle-fleet-local-system
+      labels:
+        objectset.rio.cattle.io/hash: 2da503261617e9ea2da822d2da7cdcfccad847a9
+    EOF
+
+    $ kubectl patch ClusterRole rancher-monitoring-crd-manager --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ClusterRoleBinding rancher-monitoring-crd-manager --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ServiceAccount rancher-monitoring-crd-manager -n cattle-monitoring-system --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ConfigMap rancher-monitoring-crd-manifest -n cattle-monitoring-system --patch-file ./patchhash.yaml --type merge
+
+    $ rm ./patchhash.yaml
+    ```
+
+1. Check the `rancher-monitoring-crd` ManagedChart object.
+
+    After a few seconds, the status of the `rancher-monitoring-crd` ManagedChart object changes to `Ready`.
+
+    ```
+    $ kubectl get managedchart -n fleet-local rancher-monitoring-crd -oyaml
+    apiVersion: management.cattle.io/v3
+    kind: ManagedChart
+    metadata:
+    ...
+      name: rancher-monitoring-crd
+      namespace: fleet-local
+    ...
+    status:
+      conditions:
+      - lastUpdateTime: "2024-04-22T21:41:44Z"
+        status: "True"
+        type: Ready
+    ...
+    ```
+
+    Also, error indicators are no longer displayed for the downstream objects.
+
+    ```
+    $ kubectl bundle -A
+    NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
+    fleet-local   fleet-agent-local                             1/1
+    fleet-local   local-managed-system-agent                    1/1
+    fleet-local   mcc-harvester                                 1/1
+    fleet-local   mcc-harvester-crd                             1/1
+    fleet-local   mcc-local-managed-system-upgrade-controller   1/1
+    fleet-local   mcc-rancher-logging-crd                       1/1
+    fleet-local   mcc-rancher-monitoring-crd                    1/1
+
+    ```
+
+1. (Optional) Retry the upgrade (if previously unsuccessful because of this issue).
+
+### Related Issue
+
+https://github.com/harvester/harvester/issues/5505

--- a/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
@@ -685,3 +685,9 @@ If an upgrade is stuck in an **Upgrading System Service** state for an extended 
   - https://github.com/harvester/harvester/issues/4519#issuecomment-1727132383
 
 ---
+
+### 11. An upgrade is denied due to `managed chart rancher-monitoring-crd is not ready`
+
+When you [start an upgrade](../upgrade/automatic.md#start-an-upgrade) and Harvester returns such an error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`. Please follow this [troubleshooting](../troubleshooting/monitoring.md#the-state-of-the-rancher-monitoring-crd-managedchart-is-modified).
+
+---

--- a/versioned_docs/version-v1.3/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.3/troubleshooting/monitoring.md
@@ -316,3 +316,277 @@ You may encounter this when you install the Harvester v1.3.0 or higher version c
     rancher-monitoring-prometheus-adapter-55dc9ccd5d-vtssc   1/1     Running     0          3m55s
     rancher-monitoring-prometheus-node-exporter-lgb88        1/1     Running     0          3m55s
     ```
+
+## `rancher-monitoring-crd` ManagedChart State is `Modified`
+
+### Issue Description
+
+In certain situations, the state of the `rancher-monitoring-crd` ManagedChart object changes to `Modified` (with the message `...rancher-monitoring-crd-manager missing...`).
+
+Example:
+
+```
+$ kubectl get managedchart rancher-monitoring-crd -n fleet-local -o yaml
+apiVersion: management.cattle.io/v3
+kind: ManagedChart
+...
+spec:
+  chart: rancher-monitoring-crd
+  defaultNamespace: cattle-monitoring-system
+  paused: false
+  releaseName: rancher-monitoring-crd
+  repoName: harvester-charts
+  targets:
+  - clusterName: local
+    clusterSelector:
+      matchExpressions:
+      - key: provisioning.cattle.io/unmanaged-system-agent
+        operator: DoesNotExist
+  version: 102.0.0+up40.1.2
+...
+status:
+  conditions:
+  - lastUpdateTime: "2024-02-22T14:03:11Z"
+    message: Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io
+      rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io
+      rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest
+      missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager
+      missing
+    status: "False"
+    type: Ready
+  - lastUpdateTime: "2024-02-22T14:03:11Z"
+    status: "True"
+    type: Processed
+  - lastUpdateTime: "2024-04-02T07:45:26Z"
+    status: "True"
+    type: Defined
+  display:
+    readyClusters: 0/1
+    state: Modified
+...
+```
+
+The `ManagedChart` object has a downstream object named `Bundle`, which has similar information.
+
+Example:
+
+```
+$ kubectl get bundles -A
+NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
+fleet-local   fleet-agent-local                             1/1
+fleet-local   local-managed-system-agent                    1/1
+fleet-local   mcc-harvester                                 1/1
+fleet-local   mcc-harvester-crd                             1/1
+fleet-local   mcc-local-managed-system-upgrade-controller   1/1
+fleet-local   mcc-rancher-logging-crd                       1/1
+fleet-local   mcc-rancher-monitoring-crd                    0/1                       Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager missing
+```
+
+When the issue exists and you [start an upgrade](../upgrade/automatic.md#start-an-upgrade), Harvester may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
+
+Also, when you search for the objects marked as `missing`, you will find that they exist in the cluster.
+
+Example:
+
+```
+$ kubectl get clusterrole rancher-monitoring-crd-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  ...
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - delete
+
+$ kubectl get clusterrolebinding rancher-monitoring-crd-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  ...
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rancher-monitoring-crd-manager
+subjects:
+- kind: ServiceAccount
+  name: rancher-monitoring-crd-manager
+  namespace: cattle-monitoring-system
+
+$ kubectl get configmap -n cattle-monitoring-system rancher-monitoring-crd-manifest
+apiVersion: v1
+data:
+  crd-manifest.tgz.b64: ...
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manifest
+  namespace: cattle-monitoring-system
+  ...
+
+$ kubectl get ServiceAccount -n cattle-monitoring-system rancher-monitoring-crd-manager
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+  creationTimestamp: "2023-01-09T11:04:33Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+  name: rancher-monitoring-crd-manager
+  namespace: cattle-monitoring-system
+  ...
+```
+
+### Root Cause
+
+The objects that are marked as `missing` do not have the related annotations and labels required by the `ManagedChart` object.
+
+Example:
+
+```
+One of the manually recreated object:
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    meta.helm.sh/release-name: rancher-monitoring-crd
+    meta.helm.sh/release-namespace: cattle-monitoring-system
+    objectset.rio.cattle.io/id: default-mcc-rancher-monitoring-crd-cattle-fleet-local-system   # This required item is not in the above object.
+  creationTimestamp: "2024-04-03T10:23:55Z"
+  labels:
+    app: rancher-monitoring-crd-manager
+    app.kubernetes.io/managed-by: Helm
+    objectset.rio.cattle.io/hash: 2da503261617e9ea2da822d2da7cdcfccad847a9    # This required item is not in the above object.
+  name: rancher-monitoring-crd-manager
+...
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - patch
+  - delete
+  - update
+```
+
+### Workaround
+
+1. Patch the ClusterRole object `rancher-monitoring-crd-manager` to add the `update` operation.
+
+    ```
+    $ cat > patchrules.yaml << EOF
+    rules:
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - create
+      - get
+      - patch
+      - delete
+      - update
+    EOF
+
+    $ kubectl patch ClusterRole rancher-monitoring-crd-manager --patch-file ./patchrules.yaml --type merge
+
+    $ rm ./patchrules.yaml
+    ```
+
+1. Patch the marked as `missing` objects to add the required annotations and labels.
+
+    ```
+    $ cat > patchhash.yaml << EOF
+    metadata:
+      annotations:
+        objectset.rio.cattle.io/id: default-mcc-rancher-monitoring-crd-cattle-fleet-local-system
+      labels:
+        objectset.rio.cattle.io/hash: 2da503261617e9ea2da822d2da7cdcfccad847a9
+    EOF
+
+    $ kubectl patch ClusterRole rancher-monitoring-crd-manager --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ClusterRoleBinding rancher-monitoring-crd-manager --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ServiceAccount rancher-monitoring-crd-manager -n cattle-monitoring-system --patch-file ./patchhash.yaml --type merge
+
+    $ kubectl patch ConfigMap rancher-monitoring-crd-manifest -n cattle-monitoring-system --patch-file ./patchhash.yaml --type merge
+
+    $ rm ./patchhash.yaml
+    ```
+
+1. Check the `rancher-monitoring-crd` ManagedChart object.
+
+    After a few seconds, the status of the `rancher-monitoring-crd` ManagedChart object changes to `Ready`.
+
+    ```
+    $ kubectl get managedchart -n fleet-local rancher-monitoring-crd -oyaml
+    apiVersion: management.cattle.io/v3
+    kind: ManagedChart
+    metadata:
+    ...
+      name: rancher-monitoring-crd
+      namespace: fleet-local
+    ...
+    status:
+      conditions:
+      - lastUpdateTime: "2024-04-22T21:41:44Z"
+        status: "True"
+        type: Ready
+    ...
+    ```
+
+    Also, error indicators are no longer displayed for the downstream objects.
+
+    ```
+    $ kubectl bundle -A
+    NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
+    fleet-local   fleet-agent-local                             1/1
+    fleet-local   local-managed-system-agent                    1/1
+    fleet-local   mcc-harvester                                 1/1
+    fleet-local   mcc-harvester-crd                             1/1
+    fleet-local   mcc-local-managed-system-upgrade-controller   1/1
+    fleet-local   mcc-rancher-logging-crd                       1/1
+    fleet-local   mcc-rancher-monitoring-crd                    1/1
+
+    ```
+
+1. (Optional) Retry the upgrade (if previously unsuccessful because of this issue).
+
+### Related Issue
+
+https://github.com/harvester/harvester/issues/5505

--- a/versioned_docs/version-v1.3/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.3/upgrade/v1-1-2-to-v1-2-0.md
@@ -685,3 +685,9 @@ If an upgrade is stuck in an **Upgrading System Service** state for an extended 
   - https://github.com/harvester/harvester/issues/4519#issuecomment-1727132383
 
 ---
+
+### 11. An upgrade is denied due to `managed chart rancher-monitoring-crd is not ready`
+
+When you [start an upgrade](../upgrade/automatic.md#start-an-upgrade) and Harvester returns such an error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`. Please follow this [troubleshooting](../troubleshooting/monitoring.md#the-state-of-the-rancher-monitoring-crd-managedchart-is-modified).
+
+---


### PR DESCRIPTION
Issue: https://github.com/harvester/harvester/issues/5505

Add workaround to document.

To manually test the workaroud, you can use below command to reproduce the error, and then patch it.

```
cat > patchhash-bad.yaml << EOF
metadata:
  annotations:
    objectset.rio.cattle.io/id: default-mcc-rancher-monitoring-crd-cattle-fleet-local-system
  labels:
    objectset.rio.cattle.io/hash: 2da503261617e9ea2da822d2da7cdcfccad847a8  
EOF

# 2da503261617e9ea2da822d2da7cdcfccad847a8 is the wrong hash value

kubectl patch ClusterRole rancher-monitoring-crd-manager --patch-file ./patchhash-bad.yaml --type merge

kubectl get bundle -A
```

The hash value is computed via the function below, the input string is: `default-mcc-rancher-monitoring-crd-cattle-fleet-local-system`, the output is `2da503261617e9ea2da822d2da7cdcfccad847a9`.

```
func objectSetHash(labels map[string]string) string {
	dig := sha1.New()
	for _, key := range hashOrder {
		dig.Write([]byte(labels[key]))
	}
	return hex.EncodeToString(dig.Sum(nil))
}
```