### PR TITLE
Removing extra formatting

### DIFF
--- a/docs/advanced/vgpusupport.md
+++ b/docs/advanced/vgpusupport.md
@@ -45,7 +45,6 @@ The [nvidia-driver-toolkit](./addons/nvidiadrivertoolkit.md) addon needs to be e
 
   After you select the first profile, the NVIDIA driver automatically configures the profiles available for the remaining vGPUs.
   :::
-:::
 
 1. Attach the vGPU to a new or existing VM.
 


### PR DESCRIPTION
The formatting on the vGPU page is broken for the notation. See: https://docs.harvesterhci.io/v1.3/advanced/vgpusupport