### PR TITLE
Add canonical links for all versions for v1.3 release

### DIFF
--- a/docs/advanced/addons.md
+++ b/docs/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Addons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons"/>
 </head>
 
 Harvester makes optional functionality available as Addons.

--- a/docs/advanced/addons/managed-dhcp.md
+++ b/docs/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/managed-dhcp"/>
 </head>
 
 _Available as of v1.3.0_

--- a/docs/advanced/addons/nvidiadrivertoolkit.md
+++ b/docs/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "Nvidia Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/advanced/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 _Available as of v1.3.0_

--- a/docs/advanced/addons/pcidevices.md
+++ b/docs/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/advanced/addons/rancher-vcluster.md
+++ b/docs/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/rancher-vcluster"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/advanced/addons/seeder.md
+++ b/docs/advanced/addons/seeder.md
@@ -5,7 +5,7 @@ title: "Seeder"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/seeder"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/advanced/addons/vmimport.md
+++ b/docs/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/vmimport"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/advanced/csidriver.md
+++ b/docs/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/csidriver"/>
 </head>
 
 

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/index"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -9,7 +9,7 @@ Description: Support for deployment of single-node clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters"/>
 </head>
 
 As of Harvester release v1.2.0, single-node clusters are supported for implementations that require minimal initial deployment resources or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).

--- a/docs/advanced/storageclass.md
+++ b/docs/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storageclass"/>
 </head>
 
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.

--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.

--- a/docs/advanced/vgpusupport.md
+++ b/docs/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/docs/advanced/witness.md
+++ b/docs/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/witness/"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/docs/developer/developer-mode-installation.md
+++ b/docs/developer/developer-mode-installation.md
@@ -12,6 +12,10 @@ keywords:
 Description: Developer mode (dev mode) is intended to be used for testing and development purposes.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/developer/developer-mode-installation"/>
+</head>
+
 # Developer Mode
 
 :::caution attention

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/docs/install/install-binaries-mode.md
+++ b/docs/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/install-binaries-mode"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/docs/install/management-address.md
+++ b/docs/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/docs/install/update-harvester-configuration.md
+++ b/docs/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/docs/install/usb-install.md
+++ b/docs/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/docs/logging/harvester-logging.md
+++ b/docs/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/monitoring/harvester-monitoring.md
+++ b/docs/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/index"/>
 </head>
 
 ## Concepts

--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
 </head>
 
 ## Concepts

--- a/docs/networking/deep-dive.md
+++ b/docs/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/deep-dive"/>
 </head>
 
 The network topology below reveals how we implement the Harvester network.

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/docs/networking/ippool.md
+++ b/docs/networking/ippool.md
@@ -5,6 +5,10 @@ title: "IP Pool"
 keywords:
 - IP Pool
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/ippool"/>
+</head>
 _Available as of v1.2.0_
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).

--- a/docs/networking/loadbalancer.md
+++ b/docs/networking/loadbalancer.md
@@ -5,6 +5,10 @@ title: "Load Balancer"
 keywords:
 - Load Balancer
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/loadbalancer"/>
+</head>
 _Available as of v1.2.0_
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.

--- a/docs/rancher/cloud-provider.md
+++ b/docs/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/docs/rancher/csi-driver.md
+++ b/docs/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a standard CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/docs/rancher/node/k3s-cluster.md
+++ b/docs/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/docs/rancher/node/node-driver.md
+++ b/docs/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/docs/rancher/node/rke1-cluster.md
+++ b/docs/rancher/node/rke1-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE1 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke1-cluster"/>
 </head>
 
 You can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/docs/rancher/node/rke2-cluster.md
+++ b/docs/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/rancher-integration"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/docs/rancher/resource-quota.md
+++ b/docs/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/docs/rancher/virtualization-management.md
+++ b/docs/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/docs/terraform/terraform-provider.md
+++ b/docs/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/docs/troubleshooting/harvester.md
+++ b/docs/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/docs/troubleshooting/monitoring.md
+++ b/docs/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/docs/troubleshooting/vm.md
+++ b/docs/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/index"/>
 </head>
 
 ## Upgrade support matrix

--- a/docs/upload-image.md
+++ b/docs/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/docs/vm/access-to-the-vm.md
+++ b/docs/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/docs/vm/backup-restore.md
+++ b/docs/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/docs/vm/clone-vm.md
+++ b/docs/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/vm/create-vm.md
+++ b/docs/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/docs/vm/create-vm.md
+++ b/docs/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/docs/vm/create-windows-vm.md
+++ b/docs/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/docs/vm/edit-vm.md
+++ b/docs/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/docs/vm/hotplug-volume.md
+++ b/docs/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/docs/vm/live-migration.md
+++ b/docs/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/docs/vm/resource-overcommit.md
+++ b/docs/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/docs/volume/clone-volume.md
+++ b/docs/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
 </head>
 
 ## Create an Empty Volume

--- a/docs/volume/edit-volume.md
+++ b/docs/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/docs/volume/export-volume.md
+++ b/docs/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/docs/volume/volume-snapshots.md
+++ b/docs/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v0.3/authentication.md
+++ b/versioned_docs/version-v0.3/authentication.md
@@ -12,7 +12,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v0.3/faq.md
+++ b/versioned_docs/version-v0.3/faq.md
@@ -5,7 +5,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v0.3/host/host.md
+++ b/versioned_docs/version-v0.3/host/host.md
@@ -5,7 +5,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are more than three nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v0.3/index.md
+++ b/versioned_docs/version-v0.3/index.md
@@ -12,7 +12,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3"/>
 </head>
 
 Harvester is an open-source [hyper-converged infrastructure](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) (HCI) software built on Kubernetes. It is an open alternative to using a proprietary HCI stack that incorporates the design and ethos of [Cloud Native Computing](https://en.wikipedia.org/wiki/Cloud_native_computing).

--- a/versioned_docs/version-v0.3/install/harvester-configuration.md
+++ b/versioned_docs/version-v0.3/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v0.3/install/iso-install.md
+++ b/versioned_docs/version-v0.3/install/iso-install.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
 </head>
 
 To get the Harvester ISO, download it from the [Github releases.](https://github.com/harvester/harvester/releases)

--- a/versioned_docs/version-v0.3/install/iso-install.md
+++ b/versioned_docs/version-v0.3/install/iso-install.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/index"/>
 </head>
 
 To get the Harvester ISO, download it from the [Github releases.](https://github.com/harvester/harvester/releases)

--- a/versioned_docs/version-v0.3/install/management-address.md
+++ b/versioned_docs/version-v0.3/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address. Users can see the management address on the console dashboard after installation.

--- a/versioned_docs/version-v0.3/install/pxe-boot-install.md
+++ b/versioned_docs/version-v0.3/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v0.3/install/usb-install.md
+++ b/versioned_docs/version-v0.3/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v0.3/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v0.3/monitoring/harvester-monitoring.md
@@ -4,7 +4,7 @@ sidebar_label: Monitoring
 title: "Monitoring"
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/networking/harvester-network.md
+++ b/versioned_docs/version-v0.3/networking/harvester-network.md
@@ -12,7 +12,7 @@ description: Harvester is built on Kubernetes, which uses CNI as an interface be
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
 </head>
 
 Harvester is built on top of [Kubernetes](https://kubernetes.io/) and leverages its built-in [CNI](https://github.com/containernetworking/cni) mechanism to provide the interface between network providers and its VM networks. 

--- a/versioned_docs/version-v0.3/networking/harvester-network.md
+++ b/versioned_docs/version-v0.3/networking/harvester-network.md
@@ -12,7 +12,7 @@ description: Harvester is built on Kubernetes, which uses CNI as an interface be
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/index"/>
 </head>
 
 Harvester is built on top of [Kubernetes](https://kubernetes.io/) and leverages its built-in [CNI](https://github.com/containernetworking/cni) mechanism to provide the interface between network providers and its VM networks. 

--- a/versioned_docs/version-v0.3/rancher/cloud-provider.md
+++ b/versioned_docs/version-v0.3/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/cloud-provider"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/rancher/csi-driver.md
+++ b/versioned_docs/version-v0.3/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/versioned_docs/version-v0.3/rancher/node/node-driver.md
+++ b/versioned_docs/version-v0.3/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/node-driver"/>
 </head>
 
 The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v0.3/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v0.3/rancher/node/rke1-cluster.md
@@ -13,7 +13,7 @@ description: Users can now provision RKE1 Kubernetes clusters on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke1-cluster"/>
 </head>
 
 Users can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.1+` using the built-in Harvester node driver.

--- a/versioned_docs/version-v0.3/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v0.3/rancher/node/rke2-cluster.md
@@ -13,7 +13,7 @@ description: Users can now provision RKE2 Kubernetes clusters on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke2-cluster"/>
 </head>
 
 Users can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.1+` using the built-in Harvester node driver.

--- a/versioned_docs/version-v0.3/rancher/rancher-integration.md
+++ b/versioned_docs/version-v0.3/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/rancher-integration"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/rancher/virtualization-management.md
+++ b/versioned_docs/version-v0.3/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/virtualization-management"/>
 </head>
 
 For Harvester v0.3.0 and above, virtualization management with the multi-cluster management feature will be supported using Rancher v2.6.x.

--- a/versioned_docs/version-v0.3/terraform/terraform-provider.md
+++ b/versioned_docs/version-v0.3/terraform/terraform-provider.md
@@ -5,7 +5,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/terraform/terraform-provider"/>
 </head>
 
 ## Requirements

--- a/versioned_docs/version-v0.3/troubleshooting/harvester.md
+++ b/versioned_docs/version-v0.3/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/harvester"/>
 </head>
 
 ## Generate a Support Bundle

--- a/versioned_docs/version-v0.3/troubleshooting/installation.md
+++ b/versioned_docs/version-v0.3/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v0.3/troubleshooting/installation.md
+++ b/versioned_docs/version-v0.3/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v0.3/troubleshooting/os.md
+++ b/versioned_docs/version-v0.3/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [cOS toolkit](https://github.com/rancher-sandbox/cOS-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v0.3/upgrade.md
+++ b/versioned_docs/version-v0.3/upgrade.md
@@ -11,6 +11,10 @@ keywords:
 description: Harvester provides two ways to upgrade. Users can either upgrade using the ISO image or upgrade through the UI.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/index"/>
+</head>
+
 :::note
 
 Upgrade is not supported from previous versions to v0.3.0 version.

--- a/versioned_docs/version-v0.3/upload-image.md
+++ b/versioned_docs/version-v0.3/upload-image.md
@@ -12,7 +12,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v0.3/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v0.3/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v0.3/vm/backup-restore.md
+++ b/versioned_docs/version-v0.3/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/backup-restore"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v0.3/vm/create-vm.md
+++ b/versioned_docs/version-v0.3/vm/create-vm.md
@@ -12,7 +12,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v0.3/vm/create-vm.md
+++ b/versioned_docs/version-v0.3/vm/create-vm.md
@@ -12,7 +12,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v0.3/vm/hotplug-volume.md
+++ b/versioned_docs/version-v0.3/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v0.3/vm/live-migration.md
+++ b/versioned_docs/version-v0.3/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.0/airgap.md
+++ b/versioned_docs/version-v1.0/airgap.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.0/authentication.md
+++ b/versioned_docs/version-v1.0/authentication.md
@@ -12,7 +12,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.0/faq.md
+++ b/versioned_docs/version-v1.0/faq.md
@@ -5,7 +5,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.0/host/host.md
+++ b/versioned_docs/version-v1.0/host/host.md
@@ -5,7 +5,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.0/index.md
+++ b/versioned_docs/version-v1.0/index.md
@@ -13,7 +13,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3"/>
 </head>
 
 Harvester is an open-source [hyper-converged infrastructure](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) (HCI) software built on Kubernetes. It is an open alternative to using a proprietary HCI stack that incorporates the design and ethos of [Cloud Native Computing](https://en.wikipedia.org/wiki/Cloud_native_computing).

--- a/versioned_docs/version-v1.0/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.0/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.0/install/iso-install.md
+++ b/versioned_docs/version-v1.0/install/iso-install.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
 </head>
 
 To get the Harvester ISO image, download it from the [Github releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.0/install/iso-install.md
+++ b/versioned_docs/version-v1.0/install/iso-install.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/index"/>
 </head>
 
 To get the Harvester ISO image, download it from the [Github releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.0/install/management-address.md
+++ b/versioned_docs/version-v1.0/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.0/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.0/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.0/install/requirements.md
+++ b/versioned_docs/version-v1.0/install/requirements.md
@@ -8,7 +8,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, Harvester has some minimum requirements as outlined below.

--- a/versioned_docs/version-v1.0/install/usb-install.md
+++ b/versioned_docs/version-v1.0/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.0/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.0/monitoring/harvester-monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.0/networking/harvester-network.md
+++ b/versioned_docs/version-v1.0/networking/harvester-network.md
@@ -12,7 +12,7 @@ description: Harvester is built on Kubernetes, which uses CNI as an interface be
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
 </head>
 
 Harvester is built on top of [Kubernetes](https://kubernetes.io/) and leverages its built-in [CNI](https://github.com/containernetworking/cni) mechanism to provide the interface between network providers and its VM networks. 

--- a/versioned_docs/version-v1.0/networking/harvester-network.md
+++ b/versioned_docs/version-v1.0/networking/harvester-network.md
@@ -12,7 +12,7 @@ description: Harvester is built on Kubernetes, which uses CNI as an interface be
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/index"/>
 </head>
 
 Harvester is built on top of [Kubernetes](https://kubernetes.io/) and leverages its built-in [CNI](https://github.com/containernetworking/cni) mechanism to provide the interface between network providers and its VM networks. 

--- a/versioned_docs/version-v1.0/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.0/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and [cluster Persistent Storage](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.0/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.0/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/csi-driver"/>
 </head>
 
 

--- a/versioned_docs/version-v1.0/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.0/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.3+` using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.0/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.0/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/node-driver"/>
 </head>
 
 The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.0/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.0/rancher/node/rke1-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE1 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke1-cluster"/>
 </head>
 
 You can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.3+` with the built-in Harvester node driver.

--- a/versioned_docs/version-v1.0/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.0/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke2-cluster"/>
 </head>
 
 Users can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.1+` using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.0/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.0/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/rancher-integration"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.0/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.0/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/virtualization-management"/>
 </head>
 
 For Harvester v0.3.0 and above, virtualization management with the multi-cluster management feature will be supported using Rancher v2.6 and above.

--- a/versioned_docs/version-v1.0/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.0/terraform/terraform-provider.md
@@ -5,7 +5,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/terraform/terraform-provider"/>
 </head>
 
 ## Requirements

--- a/versioned_docs/version-v1.0/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.0/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/harvester"/>
 </head>
 
 ## Generate a support bundle

--- a/versioned_docs/version-v1.0/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.0/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.0/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.0/troubleshooting/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.0/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.0/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.0/troubleshooting/os.md
+++ b/versioned_docs/version-v1.0/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [cOS toolkit](https://github.com/rancher-sandbox/cOS-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.0/upgrade/automatic.md
+++ b/versioned_docs/version-v1.0/upgrade/automatic.md
@@ -12,7 +12,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/index"/>
 </head>
 
 ## Upgrade support matrix

--- a/versioned_docs/version-v1.0/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.0/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.0/upload-image.md
+++ b/versioned_docs/version-v1.0/upload-image.md
@@ -12,7 +12,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.0/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.0/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/access-to-the-vm"/>
 </head>
 
 

--- a/versioned_docs/version-v1.0/vm/backup-restore.md
+++ b/versioned_docs/version-v1.0/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/backup-restore"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.0/vm/create-vm.md
+++ b/versioned_docs/version-v1.0/vm/create-vm.md
@@ -14,7 +14,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.0/vm/create-vm.md
+++ b/versioned_docs/version-v1.0/vm/create-vm.md
@@ -14,7 +14,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.0/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.0/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-windows-vm"/>
 </head>
 
 

--- a/versioned_docs/version-v1.0/vm/edit-vm.md
+++ b/versioned_docs/version-v1.0/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.0/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.0/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.0/vm/live-migration.md
+++ b/versioned_docs/version-v1.0/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.0/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.0/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../settings/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.1/advanced/addons.md
+++ b/versioned_docs/version-v1.1/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Addons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/advanced/settings.md
+++ b/versioned_docs/version-v1.1/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.1/advanced/settings.md
+++ b/versioned_docs/version-v1.1/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/index"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.1/advanced/storageclass.md
+++ b/versioned_docs/version-v1.1/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storageclass"/>
 </head>
 
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.

--- a/versioned_docs/version-v1.1/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.1/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.

--- a/versioned_docs/version-v1.1/airgap.md
+++ b/versioned_docs/version-v1.1/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.1/authentication.md
+++ b/versioned_docs/version-v1.1/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.1/faq.md
+++ b/versioned_docs/version-v1.1/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.1/host/host.md
+++ b/versioned_docs/version-v1.1/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.1/index.md
+++ b/versioned_docs/version-v1.1/index.md
@@ -14,7 +14,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/versioned_docs/version-v1.1/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.1/install/iso-install.md
+++ b/versioned_docs/version-v1.1/install/iso-install.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.1/install/iso-install.md
+++ b/versioned_docs/version-v1.1/install/iso-install.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.1/install/management-address.md
+++ b/versioned_docs/version-v1.1/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.1/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.1/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.1/install/requirements.md
+++ b/versioned_docs/version-v1.1/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements to install and run Harvester.

--- a/versioned_docs/version-v1.1/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/versioned_docs/version-v1.1/install/usb-install.md
+++ b/versioned_docs/version-v1.1/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.1/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.1/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.1/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.1/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.1/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.1/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.1/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.1/networking/deep-dive.md
+++ b/versioned_docs/version-v1.1/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/deep-dive"/>
 </head>
 
 The network topology below reveals how we implement the Harvester network.

--- a/versioned_docs/version-v1.1/networking/harvester-network.md
+++ b/versioned_docs/version-v1.1/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of virtual networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.1/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.1/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.1/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.1/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a standard CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/versioned_docs/version-v1.1/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.1/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.3+` using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.1/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.1/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/node-driver"/>
 </head>
 
 The Harvester node driver is used to provision VMs in the Harvester cluster. In this section, you'll learn how to configure Rancher to use the Harvester node driver to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.1/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.1/rancher/node/rke1-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE1 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke1-cluster"/>
 </head>
 
 You can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.3+` with the built-in Harvester node driver.

--- a/versioned_docs/version-v1.1/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.1/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke2-cluster"/>
 </head>
 
 Users can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher `v2.6.1+` using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.1/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.1/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/rancher-integration"/>
 </head>
 
 _Available as of v0.3.0_

--- a/versioned_docs/version-v1.1/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.1/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/virtualization-management"/>
 </head>
 
 For Harvester v0.3.0 and above, virtualization management with the multi-cluster management feature will be supported using Rancher v2.6 and above.

--- a/versioned_docs/version-v1.1/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.1/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.1/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.1/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.1/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.1/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.1/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.1/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.1/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.1/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.1/troubleshooting/os.md
+++ b/versioned_docs/version-v1.1/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [cOS toolkit](https://github.com/rancher-sandbox/cOS-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.1/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.1/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.1/upgrade/automatic.md
+++ b/versioned_docs/version-v1.1/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/index"/>
 </head>
 
 ## Upgrade support matrix

--- a/versioned_docs/version-v1.1/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.1/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.1/upgrade/v1-1-1-to-v1-1-3.md
+++ b/versioned_docs/version-v1.1/upgrade/v1-1-1-to-v1-1-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.1/v1.1.2 to v1.1.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/v1-1-1-to-v1-1-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/v1-1-1-to-v1-1-3"/>
 </head>
 
 

--- a/versioned_docs/version-v1.1/upgrade/v1-1-to-v1-1-2.md
+++ b/versioned_docs/version-v1.1/upgrade/v1-1-to-v1-1-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.0/v1.1.1 to v1.1.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/upgrade/v1-1-to-v1-1-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/v1-1-to-v1-1-2"/>
 </head>
 
 :::danger

--- a/versioned_docs/version-v1.1/upload-image.md
+++ b/versioned_docs/version-v1.1/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.1/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.1/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.1/vm/backup-restore.md
+++ b/versioned_docs/version-v1.1/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.1/vm/clone-vm.md
+++ b/versioned_docs/version-v1.1/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.1/vm/create-vm.md
+++ b/versioned_docs/version-v1.1/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.1/vm/create-vm.md
+++ b/versioned_docs/version-v1.1/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.1/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.1/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.1/vm/edit-vm.md
+++ b/versioned_docs/version-v1.1/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.1/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.1/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.1/vm/live-migration.md
+++ b/versioned_docs/version-v1.1/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.1/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.1/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.1/volume/clone-volume.md
+++ b/versioned_docs/version-v1.1/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/clone-volume"/>
 </head>
 
 After creating a volume, you can clone the volume by following the steps below:

--- a/versioned_docs/version-v1.1/volume/create-volume.md
+++ b/versioned_docs/version-v1.1/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.1/volume/create-volume.md
+++ b/versioned_docs/version-v1.1/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.1/volume/edit-volume.md
+++ b/versioned_docs/version-v1.1/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.1/volume/export-volume.md
+++ b/versioned_docs/version-v1.1/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.1/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.1/volume/volume-snapshots.md
@@ -9,7 +9,7 @@ description: Take a snapshot for a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.2/advanced/addons.md
+++ b/versioned_docs/version-v1.2/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Addons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons"/>
 </head>
 
 Harvester makes optional functionality available as Addons.

--- a/versioned_docs/version-v1.2/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.2/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.2/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.2/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/rancher-vcluster"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.2/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.2/advanced/addons/seeder.md
@@ -5,7 +5,7 @@ title: "Seeder"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/seeder"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.2/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.2/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/vmimport"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.2/advanced/csidriver.md
+++ b/versioned_docs/version-v1.2/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/csidriver"/>
 </head>
 
 

--- a/versioned_docs/version-v1.2/advanced/settings.md
+++ b/versioned_docs/version-v1.2/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.2/advanced/settings.md
+++ b/versioned_docs/version-v1.2/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/index"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.2/advanced/singlenodeclusters.md
@@ -9,7 +9,7 @@ Description: Support for deployment of single-node clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters"/>
 </head>
 
 As of Harvester release v1.2.0, single-node clusters are supported for implementations that require minimal initial deployment resources or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.2/install/index), [USB](https://docs.harvesterhci.io/v1.2/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.2/install/pxe-boot-install)).

--- a/versioned_docs/version-v1.2/advanced/storageclass.md
+++ b/versioned_docs/version-v1.2/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storageclass"/>
 </head>
 
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.

--- a/versioned_docs/version-v1.2/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.2/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.

--- a/versioned_docs/version-v1.2/airgap.md
+++ b/versioned_docs/version-v1.2/airgap.md
@@ -10,6 +10,10 @@ keywords:
 - HTTP proxy
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/airgap"/>
+</head>
+
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.
 
 The Harvester ISO image contains all the packages to make it work in an air gapped environment.

--- a/versioned_docs/version-v1.2/authentication.md
+++ b/versioned_docs/version-v1.2/authentication.md
@@ -12,6 +12,10 @@ keywords:
 description: With ISO installation mode, user will be prompted to set the password for the default `admin` user on the first-time login.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/authentication"/>
+</head>
+
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 
 ![auth](/img/v1.2/install/first-time-login.png)

--- a/versioned_docs/version-v1.2/faq.md
+++ b/versioned_docs/version-v1.2/faq.md
@@ -5,6 +5,10 @@ sidebar_label: FAQ
 title: "FAQ"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/faq"/>
+</head>
+
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 
 ### How can I ssh login to the Harvester node?

--- a/versioned_docs/version-v1.2/host/host.md
+++ b/versioned_docs/version-v1.2/host/host.md
@@ -5,6 +5,10 @@ sidebar_label: Host Management
 title: "Host Management"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/host"/>
+</head>
+
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 
 :::note

--- a/versioned_docs/version-v1.2/index.md
+++ b/versioned_docs/version-v1.2/index.md
@@ -12,6 +12,10 @@ keywords:
   - Harvester Intro
 description: Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix.
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3"/>
+</head>
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 ## Harvester Architecture

--- a/versioned_docs/version-v1.2/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.2/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.2/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.2/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/install-binaries-mode"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.2/install/iso-install.md
+++ b/versioned_docs/version-v1.2/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.2/install/iso-install.md
+++ b/versioned_docs/version-v1.2/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.2/install/management-address.md
+++ b/versioned_docs/version-v1.2/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.2/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.2/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.2/install/requirements.md
+++ b/versioned_docs/version-v1.2/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/versioned_docs/version-v1.2/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.2/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/versioned_docs/version-v1.2/install/usb-install.md
+++ b/versioned_docs/version-v1.2/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.2/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.2/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.2/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.2/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.2/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.2/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.2/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.2/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.2/networking/deep-dive.md
+++ b/versioned_docs/version-v1.2/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/deep-dive"/>
 </head>
 
 The network topology below reveals how we implement the Harvester network.

--- a/versioned_docs/version-v1.2/networking/harvester-network.md
+++ b/versioned_docs/version-v1.2/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.2/networking/ippool.md
+++ b/versioned_docs/version-v1.2/networking/ippool.md
@@ -5,6 +5,10 @@ title: "IP Pool"
 keywords:
 - IP Pool
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/ippool"/>
+</head>
 _Available as of v1.2.0_
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).

--- a/versioned_docs/version-v1.2/networking/loadbalancer.md
+++ b/versioned_docs/version-v1.2/networking/loadbalancer.md
@@ -5,6 +5,10 @@ title: "Load Balancer"
 keywords:
 - Load Balancer
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/loadbalancer"/>
+</head>
 _Available as of v1.2.0_
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.

--- a/versioned_docs/version-v1.2/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.2/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.2/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.2/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a standard CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/versioned_docs/version-v1.2/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.2/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.2/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.2/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.2/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.2/rancher/node/rke1-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE1 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke1-cluster"/>
 </head>
 
 You can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.2/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.2/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.2/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.2/rancher/rancher-integration.md
@@ -13,7 +13,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/rancher-integration"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/versioned_docs/version-v1.2/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.2/rancher/resource-quota.md
@@ -11,6 +11,10 @@ keywords:
 description: ResourceQuota allows administrators to set resource limits per namespace, preventing excessive resource usage and ensuring the smooth operation of other namespaces when the quota is reached.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/resource-quota"/>
+</head>
+
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.
 
 In Harvester, ResourceQuota can define usage limits for the following resources:

--- a/versioned_docs/version-v1.2/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.2/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v1.2/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.2/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.2/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.2/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.2/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.2/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.2/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.2/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.2/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.2/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.2/troubleshooting/os.md
+++ b/versioned_docs/version-v1.2/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.2/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.2/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.2/upgrade/automatic.md
+++ b/versioned_docs/version-v1.2/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/index"/>
 </head>
 
 ## Upgrade support matrix

--- a/versioned_docs/version-v1.2/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.2/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.2/upgrade/v1-1-1-to-v1-1-3.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-1-1-to-v1-1-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.1/v1.1.2 to v1.1.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-1-1-to-v1-1-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/v1-1-1-to-v1-1-3"/>
 </head>
 
 

--- a/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-1-2-to-v1-2-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-1-2-to-v1-2-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.2/upgrade/v1-1-to-v1-1-2.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-1-to-v1-1-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.0/v1.1.1 to v1.1.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-1-to-v1-1-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/v1-1-to-v1-1-2"/>
 </head>
 
 :::danger

--- a/versioned_docs/version-v1.2/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.2/upgrade/v1-2-0-to-v1-2-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2/v1.2.0 to v1.2.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upgrade/v1-2-0-to-v1-2-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/v1-2-0-to-v1-2-1"/>
 </head>
 
 

--- a/versioned_docs/version-v1.2/upload-image.md
+++ b/versioned_docs/version-v1.2/upload-image.md
@@ -12,6 +12,10 @@ keywords:
 description: To import virtual machine images in the **Images** page, enter a URL that can be accessed from the cluster. The image name will be auto-filled using the URL address's filename. You can always customize it when required.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upload-image"/>
+</head>
+
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 
 ### Upload Images via URL

--- a/versioned_docs/version-v1.2/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.2/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.2/vm/backup-restore.md
+++ b/versioned_docs/version-v1.2/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.2/vm/clone-vm.md
+++ b/versioned_docs/version-v1.2/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.2/vm/create-vm.md
+++ b/versioned_docs/version-v1.2/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.2/vm/create-vm.md
+++ b/versioned_docs/version-v1.2/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.2/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.2/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.2/vm/edit-vm.md
+++ b/versioned_docs/version-v1.2/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.2/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.2/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.2/vm/live-migration.md
+++ b/versioned_docs/version-v1.2/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.2/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.2/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.2/volume/clone-volume.md
+++ b/versioned_docs/version-v1.2/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/versioned_docs/version-v1.2/volume/create-volume.md
+++ b/versioned_docs/version-v1.2/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.2/volume/create-volume.md
+++ b/versioned_docs/version-v1.2/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.2/volume/edit-volume.md
+++ b/versioned_docs/version-v1.2/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.2/volume/export-volume.md
+++ b/versioned_docs/version-v1.2/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.2/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.2/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.3/advanced/addons.md
+++ b/versioned_docs/version-v1.3/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Addons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons"/>
 </head>
 
 Harvester makes optional functionality available as Addons.

--- a/versioned_docs/version-v1.3/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.3/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/managed-dhcp"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.3/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.3/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "Nvidia Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/advanced/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.3/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.3/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.3/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.3/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/rancher-vcluster"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.3/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.3/advanced/addons/seeder.md
@@ -5,7 +5,7 @@ title: "Seeder"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/seeder"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.3/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.3/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/addons/vmimport"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.3/advanced/csidriver.md
+++ b/versioned_docs/version-v1.3/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/csidriver"/>
 </head>
 
 

--- a/versioned_docs/version-v1.3/advanced/settings.md
+++ b/versioned_docs/version-v1.3/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.3/advanced/settings.md
+++ b/versioned_docs/version-v1.3/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/settings"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/index"/>
 </head>
 
 This page contains a list of advanced settings which can be used in Harvester.

--- a/versioned_docs/version-v1.3/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.3/advanced/singlenodeclusters.md
@@ -9,7 +9,7 @@ Description: Support for deployment of single-node clusters
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters"/>
 </head>
 
 As of Harvester release v1.2.0, single-node clusters are supported for implementations that require minimal initial deployment resources or that can tolerate lower resiliency. You can create single-node clusters using the standard installation methods ([ISO](https://docs.harvesterhci.io/v1.3/install/index), [USB](https://docs.harvesterhci.io/v1.3/install/usb-install), and [PXE boot](https://docs.harvesterhci.io/v1.3/install/pxe-boot-install)).

--- a/versioned_docs/version-v1.3/advanced/storageclass.md
+++ b/versioned_docs/version-v1.3/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storageclass"/>
 </head>
 
 A StorageClass allows administrators to describe the **classes** of storage they offer. Different Longhorn StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called **profiles** in other storage systems.

--- a/versioned_docs/version-v1.3/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.3/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.

--- a/versioned_docs/version-v1.3/advanced/vgpusupport.md
+++ b/versioned_docs/version-v1.3/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.3/advanced/witness.md
+++ b/versioned_docs/version-v1.3/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/advanced/witness/"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.3/airgap.md
+++ b/versioned_docs/version-v1.3/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.3/authentication.md
+++ b/versioned_docs/version-v1.3/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.3/developer/developer-mode-installation.md
+++ b/versioned_docs/version-v1.3/developer/developer-mode-installation.md
@@ -12,6 +12,10 @@ keywords:
 Description: Developer mode (dev mode) is intended to be used for testing and development purposes.
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/developer/developer-mode-installation"/>
+</head>
+
 # Developer Mode
 
 :::caution attention

--- a/versioned_docs/version-v1.3/faq.md
+++ b/versioned_docs/version-v1.3/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.3/host/host.md
+++ b/versioned_docs/version-v1.3/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.3/index.md
+++ b/versioned_docs/version-v1.3/index.md
@@ -14,7 +14,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/versioned_docs/version-v1.3/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.3/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.3/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.3/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/install-binaries-mode"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.3/install/iso-install.md
+++ b/versioned_docs/version-v1.3/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.3/install/iso-install.md
+++ b/versioned_docs/version-v1.3/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/iso-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/iso-install"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.3/install/management-address.md
+++ b/versioned_docs/version-v1.3/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.3/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.3/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.3/install/requirements.md
+++ b/versioned_docs/version-v1.3/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/versioned_docs/version-v1.3/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.3/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/versioned_docs/version-v1.3/install/usb-install.md
+++ b/versioned_docs/version-v1.3/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.3/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.3/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.3/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.3/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.3/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.3/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.3/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.3/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/clusternetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/clusternetwork"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.3/networking/deep-dive.md
+++ b/versioned_docs/version-v1.3/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/deep-dive"/>
 </head>
 
 The network topology below reveals how we implement the Harvester network.

--- a/versioned_docs/version-v1.3/networking/harvester-network.md
+++ b/versioned_docs/version-v1.3/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.3/networking/ippool.md
+++ b/versioned_docs/version-v1.3/networking/ippool.md
@@ -5,6 +5,10 @@ title: "IP Pool"
 keywords:
 - IP Pool
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/ippool"/>
+</head>
 _Available as of v1.2.0_
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).

--- a/versioned_docs/version-v1.3/networking/loadbalancer.md
+++ b/versioned_docs/version-v1.3/networking/loadbalancer.md
@@ -5,6 +5,10 @@ title: "Load Balancer"
 keywords:
 - Load Balancer
 ---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/networking/loadbalancer"/>
+</head>
 _Available as of v1.2.0_
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.

--- a/versioned_docs/version-v1.3/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.3/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.3/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.3/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/csi-driver"/>
 </head>
 
 The Harvester Container Storage Interface (CSI) Driver provides a standard CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.

--- a/versioned_docs/version-v1.3/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.3/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.3/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.3/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.3/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.3/rancher/node/rke1-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE1 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke1-cluster"/>
 </head>
 
 You can now provision RKE1 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.3/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.3/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.3/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.3/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/rancher-integration"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/versioned_docs/version-v1.3/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.3/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/versioned_docs/version-v1.3/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.3/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v1.3/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.3/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.3/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.3/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.3/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.3/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.3/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.3/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/installation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.3/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.3/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.3/troubleshooting/os.md
+++ b/versioned_docs/version-v1.3/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.3/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.3/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.3/upgrade/automatic.md
+++ b/versioned_docs/version-v1.3/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/automatic"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upgrade/index"/>
 </head>
 
 ## Upgrade support matrix

--- a/versioned_docs/version-v1.3/upload-image.md
+++ b/versioned_docs/version-v1.3/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.3/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.3/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.3/vm/backup-restore.md
+++ b/versioned_docs/version-v1.3/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.3/vm/clone-vm.md
+++ b/versioned_docs/version-v1.3/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.3/vm/create-vm.md
+++ b/versioned_docs/version-v1.3/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.3/vm/create-vm.md
+++ b/versioned_docs/version-v1.3/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-vm"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.3/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.3/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.3/vm/edit-vm.md
+++ b/versioned_docs/version-v1.3/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.3/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.3/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.3/vm/live-migration.md
+++ b/versioned_docs/version-v1.3/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.3/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.3/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.3/volume/clone-volume.md
+++ b/versioned_docs/version-v1.3/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/versioned_docs/version-v1.3/volume/create-volume.md
+++ b/versioned_docs/version-v1.3/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.3/volume/create-volume.md
+++ b/versioned_docs/version-v1.3/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/create-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/create-volume"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.3/volume/edit-volume.md
+++ b/versioned_docs/version-v1.3/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.3/volume/export-volume.md
+++ b/versioned_docs/version-v1.3/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.3/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.3/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.1/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.3/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.


### PR DESCRIPTION
Adding/updating canonical links for v1.3 release per https://github.com/btat/docs-helpers/tree/main?tab=readme-ov-file#canonical-links

1. @LucasSaintarbor Checking links locally (WIP)
2. Asking @jillian-maroket for a review

Update URLs for index pages all versions, i.e. https://docs.harvesterhci.io/v1.3/advanced/index. 

- [x] advanced (updated `advanced/settings`)
- [x] developer
- [x] host
- [x] install (updated `install/iso-install`)
- [x] logging
- [x] monitoring
- [x] networking (updated `networking/harvester-network` / `networking/clusternetwork`)
- [x] rancher
- [x] terraform 
- [x] troubleshooting (updated `troubleshooting/installation`)
- [x] upgrade
- [x] VM (updated `vm/create-vm`)
- [x] volume (updated `volume/create-volume`)