### PR TITLE
Add back missing locale in Docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ const config = {
   projectName: "docs",
   i18n: {
     defaultLocale: "en",
-    locales: ["en"],
+    locales: ["en", "zh"],
     localeConfigs: {
       en: {
         label: "English",


### PR DESCRIPTION
Recent drone jobs have been failing. The likely cause is a missing value in the `locales` section of `docusaurus.config.js`, which we removed to be able to use the Lunr search plug-in for Docusaurus. That value was not added back when Algolia was re-enabled.

https://drone-publish.rancher.io/harvester/docs
<img width="806" alt="Screenshot 2024-05-03 at 5 06 56 PM" src="https://github.com/harvester/docs/assets/67180770/df5f312d-ede6-4c13-a2d7-5b30edff43f3">
