### PR TITLE
ci: fix release build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,6 +65,7 @@ steps:
     env:
           NODE_OPTIONS: "--max_old_space_size=7168"
     commands:
+      - yarn gen-api-docs
       - yarn build
 
   - name: release


### PR DESCRIPTION
Fix the documentation's release build process by adding a step, which generates the API documentation, prior to building the entire documentation page and publishing it.
This is necessary because PR#545 removed the pre-generated API documentation from the source repository. As a result, prior to building the documentation, the API documentation now needs to be re-generated.