### PR TITLE
Remove docusaurus-lunr-search plugin (to force usage of Algolia)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -233,15 +233,6 @@ const config = {
   plugins: [
     require.resolve('docusaurus-plugin-image-zoom'),
     [
-      require.resolve('docusaurus-lunr-search'), 
-      {
-        language: ['en'],
-        indexBaseUrl: true,
-        maxHits: 10,
-        highlightResult: true,
-      }
-    ],
-    [
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
     "docs-to-pdf": "^0.6.2",
-    "docusaurus-lunr-search": "^3.3.2",
     "docusaurus-plugin-image-zoom": "^1.0.0",
     "docusaurus-plugin-openapi-docs": "^2.1.2",
     "docusaurus-theme-openapi-docs": "^2.1.2",


### PR DESCRIPTION
The Harvester doc currently uses the Docusaurus Lunr plugin instead of Algolia, which should NOT be the case. PR #545 (API update, build fixes, add some API flows) added back the Lunr plugin that we removed in PR #547 (Reactivate Algolia search). #547 was merged before #545. 

![Screenshot 2024-05-14 at 2 39 06 PM](https://github.com/harvester/docs/assets/67180770/01255fd3-568f-441e-9c97-7055215e2397)