### PR TITLE
update swagger.json for v1.3 API docs

### DIFF
--- a/api/v1.3-swagger.json
+++ b/api/v1.3-swagger.json
@@ -7798,9 +7798,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "List Cluster Networks",
-        "description": "Get a list of all ClusterNetwork objects.",
-        "operationId": "listClusterNetwork",
+        "summary": "List Namespaced Cluster Networks",
+        "description": "Get a list of ClusterNetwork objects in a namespace.",
+        "operationId": "listNamespacedClusterNetwork",
         "parameters": [
           {
             "name": "continue",
@@ -7840,6 +7840,16 @@
             "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Object name and auth scope, such as for teams and projects",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "[a-z0-9][a-z0-9\\-]*"
             }
           },
           {
@@ -7914,9 +7924,21 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Create a Cluster Network",
+        "summary": "Create a Namespaced Cluster Network",
         "description": "Create a ClusterNetwork object.",
-        "operationId": "createClusterNetwork",
+        "operationId": "createNamespacedClusterNetwork",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Object name and auth scope, such as for teams and projects",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "[a-z0-9][a-z0-9\\-]*"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -8001,9 +8023,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Read a Cluster Network",
+        "summary": "Read a Namespaced Cluster Network",
         "description": "Get a ClusterNetwork object.",
-        "operationId": "readClusterNetwork",
+        "operationId": "readNamespacedClusterNetwork",
         "parameters": [
           {
             "name": "exact",
@@ -8069,9 +8091,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Replace a Cluster Network",
+        "summary": "Replace a Namespaced Cluster Network",
         "description": "Update a ClusterNetwork object.",
-        "operationId": "replaceClusterNetwork",
+        "operationId": "replaceNamespacedClusterNetwork",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8139,9 +8161,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Delete a Cluster Network",
+        "summary": "Delete a Namespaced Cluster Network",
         "description": "Delete a ClusterNetwork object.",
-        "operationId": "deleteClusterNetwork",
+        "operationId": "deleteNamespacedClusterNetwork",
         "parameters": [
           {
             "name": "gracePeriodSeconds",
@@ -8220,9 +8242,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Patch a Cluster Network",
+        "summary": "Patch a Namespaced Cluster Network",
         "description": "Patch a ClusterNetwork object.",
-        "operationId": "patchClusterNetwork",
+        "operationId": "patchNamespacedClusterNetwork",
         "requestBody": {
           "content": {
             "application/json-patch+json": {
@@ -8271,6 +8293,16 @@
             "type": "string",
             "pattern": "[a-z0-9][a-z0-9\\-]*"
           }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "Object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "[a-z0-9][a-z0-9\\-]*"
+          }
         }
       ]
     },
@@ -8279,9 +8311,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "List Node Networks",
-        "description": "Get a list of all NodeNetwork objects.",
-        "operationId": "listNodeNetwork",
+        "summary": "List Namespaced Node Networks",
+        "description": "Get a list of NodeNetwork objects in a namespace.",
+        "operationId": "listNamespacedNodeNetwork",
         "parameters": [
           {
             "name": "continue",
@@ -8321,6 +8353,16 @@
             "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Object name and auth scope, such as for teams and projects",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "[a-z0-9][a-z0-9\\-]*"
             }
           },
           {
@@ -8395,9 +8437,21 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Create a Node Network",
+        "summary": "Create a Namespaced Node Network",
         "description": "Create a NodeNetwork object.",
-        "operationId": "createNodeNetwork",
+        "operationId": "createNamespacedNodeNetwork",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Object name and auth scope, such as for teams and projects",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "[a-z0-9][a-z0-9\\-]*"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -8482,9 +8536,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Read a Node Network",
+        "summary": "Read a Namespaced Node Network",
         "description": "Get a NodeNetwork object.",
-        "operationId": "readNodeNetwork",
+        "operationId": "readNamespacedNodeNetwork",
         "parameters": [
           {
             "name": "exact",
@@ -8550,9 +8604,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Replace a Node Network",
+        "summary": "Replace a Namespaced Node Network",
         "description": "Update a NodeNetwork object.",
-        "operationId": "replaceNodeNetwork",
+        "operationId": "replaceNamespacedNodeNetwork",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8620,9 +8674,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Delete a Node Network",
+        "summary": "Delete a Namespaced Node Network",
         "description": "Delete a NodeNetwork object.",
-        "operationId": "deleteNodeNetwork",
+        "operationId": "deleteNamespacedNodeNetwork",
         "parameters": [
           {
             "name": "gracePeriodSeconds",
@@ -8701,9 +8755,9 @@
         "tags": [
           "Networks"
         ],
-        "summary": "Patch a Node Network",
+        "summary": "Patch a Namespaced Node Network",
         "description": "Patch a NodeNetwork object.",
-        "operationId": "patchNodeNetwork",
+        "operationId": "patchNamespacedNodeNetwork",
         "requestBody": {
           "content": {
             "application/json-patch+json": {
@@ -8747,6 +8801,16 @@
           "name": "name",
           "in": "path",
           "description": "Name of the resource",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "[a-z0-9][a-z0-9\\-]*"
+          }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "Object name and auth scope, such as for teams and projects",
           "required": true,
           "schema": {
             "type": "string",
@@ -9492,7 +9556,12 @@
           },
           "sourceType": {
             "type": "string",
-            "default": ""
+            "default": "",
+            "enum": [
+              "download",
+              "export-from-volume",
+              "upload"
+            ]
           },
           "storageClassParameters": {
             "type": "object",


### PR DESCRIPTION
Update swagger.json file with regenerated content from the latest HEAD of the v1.3 branch. This updates the v1.3 API docs, including the changes introduced by the backport of
https://github.com/harvester/harvester/pull/5511
here: https://github.com/harvester/harvester/pull/5850

I've taken the newly generated swagger.json verbatim, which is why there are a bunch of unrelated lines that changed. This is a result of changes in the API definition generator program.