### PR TITLE
Add EOL label to v0.3, v1.0, v1.1 docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,17 +56,17 @@ const config = {
             },
             "v1.1": {
               label: 'v1.1 (EOL)',
-              path: "v1.1",
+              path: 'v1.1',
               banner: `unmaintained`
             },
             "v1.0": {
               label: 'v1.0 (EOL)',
-              path: "v1.0",
+              path: 'v1.0',
               banner: `unmaintained`
-            }
+            },
             "v0.3": {
               label: 'v0.3 (EOL)',
-              path: "v0.3",
+              path: 'v0.3',
               banner: `unmaintained`
             }
           }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,11 +55,18 @@ const config = {
               banner: `none`
             },
             "v1.1": {
+              label: 'v1.1 (EOL)',
               path: "v1.1",
-              banner: `none`
+              banner: `unmaintained`
             },
             "v1.0": {
+              label: 'v1.0 (EOL)',
               path: "v1.0",
+              banner: `unmaintained`
+            }
+            "v0.3": {
+              label: 'v0.3 (EOL)',
+              path: "v0.3",
               banner: `unmaintained`
             }
           }


### PR DESCRIPTION
The version selector in the doc site header must indicate which versions are EOL (to manage user expectations about product and doc quality). v1.1.x is officially EOL as of June 1, 2024.