### PR TITLE
Mark those unavailable addons on ARM64

### DIFF
--- a/docs/advanced/addons/pcidevices.md
+++ b/docs/advanced/addons/pcidevices.md
@@ -10,6 +10,8 @@ title: "PCI Devices"
 
 _Available as of v1.1.0_
 
+_Unavailable on ARM64 architecture_
+
 A `PCIDevice` in Harvester represents a host device with a PCI address. 
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, 
 or by using the UI to enable passthrough. Passing a device through the hypervisor means that 

--- a/docs/advanced/addons/seeder.md
+++ b/docs/advanced/addons/seeder.md
@@ -10,6 +10,8 @@ title: "Seeder"
 
 _Available as of v1.2.0_
 
+_Unavailable on ARM64 architecture_
+
 The `harvester-seeder` addon lets you perform out-of-band operations on underlying nodes. 
 
 This addon can also discover hardware and hardware events for bare-metal nodes that support redfish-based access and then associate the hardware with the corresponding Harvester nodes.

--- a/docs/advanced/addons/vmimport.md
+++ b/docs/advanced/addons/vmimport.md
@@ -10,6 +10,8 @@ title: "VM Import"
 
 _Available as of v1.1.0_
 
+_Unavailable on ARM64 architecture_
+
 Beginning with v1.1.0, users can import their virtual machines from VMWare and OpenStack into Harvester.
 
 This is accomplished using the vm-import-controller addon.

--- a/versioned_docs/version-v1.3/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.3/advanced/addons/pcidevices.md
@@ -10,6 +10,8 @@ title: "PCI Devices"
 
 _Available as of v1.1.0_
 
+_Unavailable on ARM64 architecture_
+
 A `PCIDevice` in Harvester represents a host device with a PCI address. 
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, 
 or by using the UI to enable passthrough. Passing a device through the hypervisor means that 

--- a/versioned_docs/version-v1.3/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.3/advanced/addons/seeder.md
@@ -10,6 +10,8 @@ title: "Seeder"
 
 _Available as of v1.2.0_
 
+_Unavailable on ARM64 architecture_
+
 The `harvester-seeder` addon lets you perform out-of-band operations on underlying nodes. 
 
 This addon can also discover hardware and hardware events for bare-metal nodes that support redfish-based access and then associate the hardware with the corresponding Harvester nodes.

--- a/versioned_docs/version-v1.3/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.3/advanced/addons/vmimport.md
@@ -10,6 +10,8 @@ title: "VM Import"
 
 _Available as of v1.1.0_
 
+_Unavailable on ARM64 architecture_
+
 Beginning with v1.1.0, users can import their virtual machines from VMWare and OpenStack into Harvester.
 
 This is accomplished using the vm-import-controller addon.


### PR DESCRIPTION
**Problem:**

Addon & repo chart version mis-matching (e.g. https://github.com/harvester/harvester/issues/5840)
Add version matching check.

**Solution:**

Per comment https://github.com/harvester/harvester-installer/pull/750#discussion_r1635719259, noticed we did not mark the addon on documents.