### PR TITLE
Add caution/info boxes for VM image virtual size

### DIFF
--- a/docs/vm/create-vm.md
+++ b/docs/vm/create-vm.md
@@ -155,7 +155,9 @@ A volume's [StorageClass](../advanced/storageclass.md) can be specified when add
 
 :::info important
 
-When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt. By default, Harvester will set the volume size to 10GiB, or the virtual size of the image, whichever is greater.
+When creating volumes from a VM image, ensure that the volume size is greater than or equal to the image size. The volume may become corrupted if the configured volume size is less than the size of the underlying image. This is particularly important for qcow2 images because the virtual size is typically greater than the physical size.
+
+By default, Harvester sets the volume size to either 10 GiB or the virtual size of the VM image, whichever is greater.
 
 :::
 

--- a/docs/vm/create-vm.md
+++ b/docs/vm/create-vm.md
@@ -153,6 +153,12 @@ A disk can be made accessible via the following types:
 
 A volume's [StorageClass](../advanced/storageclass.md) can be specified when adding a new empty volume; for other volumes (such as VM images), the `StorageClass` is defined during image creation.
 
+:::info important
+
+When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt. By default, Harvester will set the volume size to 10GiB, or the virtual size of the image, whichever is greater.
+
+:::
+
 ![create-vm](/img/v1.2/vm/create-vm-volumes.png)
 
 ### Adding a container disk

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -83,6 +83,12 @@ resource "harvester_volume" "empty-volume" {
 1. Select an existing `Image`.
 1. Configure the `Size` of the volume.
 
+:::info important
+
+When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt. By default, Harvester will set the volume size to the virtual size of the image.
+
+:::
+
 ![create-image-volume](/img/v1.2/volume/create-image-volume.png)
 
 </TabItem>

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -85,7 +85,9 @@ resource "harvester_volume" "empty-volume" {
 
 :::info important
 
-When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt. By default, Harvester will set the volume size to the virtual size of the image.
+When creating volumes from a VM image, ensure that the volume size is greater than or equal to the image size. The volume may become corrupted if the configured volume size is less than the size of the underlying image. This is particularly important for qcow2 images because the virtual size is typically greater than the physical size.
+
+By default, Harvester will set the volume size to the virtual size of the image.
 
 :::
 

--- a/versioned_docs/version-v1.2/vm/create-vm.md
+++ b/versioned_docs/version-v1.2/vm/create-vm.md
@@ -57,6 +57,14 @@ A disk can be made accessible via the following types:
 
 A volume's [StorageClass](../advanced/storageclass.md) can be specified when adding a new empty volume; for other volumes (such as VM images), the `StorageClass` is defined during image creation.
 
+:::caution
+
+When creating volumes from a VM image, ensure that the volume size is greater than or equal to the image size. The volume may become corrupted if the configured volume size is less than the size of the underlying image. This is particularly important for qcow2 images because the virtual size is typically greater than the physical size. 
+
+Harvester sets the volume size to 10 GiB by default. You must verify if this value is sufficient and then modify it if necessary. To determine the virtual size of a qcow2 image, you can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2`.
+
+:::
+
 ![create-vm](/img/v1.2/vm/create-vm-volumes.png)
 
 ### Adding a container disk

--- a/versioned_docs/version-v1.2/volume/create-volume.md
+++ b/versioned_docs/version-v1.2/volume/create-volume.md
@@ -38,4 +38,12 @@ description: Create a volume from the Volume page.
 1. Select an existing `Image`.
 1. Configure the `Size` of the volume.
 
+:::caution
+
+When creating volumes from a VM image, ensure that the volume size is greater than or equal to the image size. The volume may become corrupted if the configured volume size is less than the size of the underlying image. This is particularly important for qcow2 images because the virtual size is typically greater than the physical size.
+
+To determine the virtual size of a qcow2 image, you can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2`.
+
+:::
+
 ![create-image-volume](/img/v1.2/volume/create-image-volume.png)

--- a/versioned_docs/version-v1.3/vm/create-vm.md
+++ b/versioned_docs/version-v1.3/vm/create-vm.md
@@ -57,6 +57,13 @@ A disk can be made accessible via the following types:
 
 A volume's [StorageClass](../advanced/storageclass.md) can be specified when adding a new empty volume; for other volumes (such as VM images), the `StorageClass` is defined during image creation.
 
+:::caution
+
+When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt.
+You can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2` to determine the virtual size of a qcow2 image.
+
+:::
+
 ![create-vm](/img/v1.2/vm/create-vm-volumes.png)
 
 ### Adding a container disk

--- a/versioned_docs/version-v1.3/vm/create-vm.md
+++ b/versioned_docs/version-v1.3/vm/create-vm.md
@@ -59,7 +59,9 @@ A volume's [StorageClass](../advanced/storageclass.md) can be specified when add
 
 :::caution
 
-When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt.
+When creating volumes from a VM image, ensure that the volume size is greater than or equal to the image size. The volume may become corrupted if the configured volume size is less than the size of the underlying image. This is particularly important for qcow2 images because the virtual size is typically greater than the physical size. 
+
+Harvester sets the volume size to 10 GiB by default. You must verify if this value is sufficient and then modify it if necessary. To determine the virtual size of a qcow2 image, you can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2`.
 You can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2` to determine the virtual size of a qcow2 image.
 
 :::

--- a/versioned_docs/version-v1.3/vm/create-vm.md
+++ b/versioned_docs/version-v1.3/vm/create-vm.md
@@ -62,7 +62,6 @@ A volume's [StorageClass](../advanced/storageclass.md) can be specified when add
 When creating volumes from a VM image, ensure that the volume size is greater than or equal to the image size. The volume may become corrupted if the configured volume size is less than the size of the underlying image. This is particularly important for qcow2 images because the virtual size is typically greater than the physical size. 
 
 Harvester sets the volume size to 10 GiB by default. You must verify if this value is sufficient and then modify it if necessary. To determine the virtual size of a qcow2 image, you can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2`.
-You can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2` to determine the virtual size of a qcow2 image.
 
 :::
 

--- a/versioned_docs/version-v1.3/volume/create-volume.md
+++ b/versioned_docs/version-v1.3/volume/create-volume.md
@@ -40,8 +40,9 @@ description: Create a volume from the Volume page.
 
 :::caution
 
-When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt.
-You can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2` to determine the virtual size of a qcow2 image.
+When creating volumes from a VM image, ensure that the volume size is greater than or equal to the image size. The volume may become corrupted if the configured volume size is less than the size of the underlying image. This is particularly important for qcow2 images because the virtual size is typically greater than the physical size.
+
+To determine the virtual size of a qcow2 image, you can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2`.
 
 :::
 

--- a/versioned_docs/version-v1.3/volume/create-volume.md
+++ b/versioned_docs/version-v1.3/volume/create-volume.md
@@ -38,4 +38,11 @@ description: Create a volume from the Volume page.
 1. Select an existing `Image`.
 1. Configure the `Size` of the volume.
 
+:::caution
+
+When creating volumes from VM images, be sure the volume size is sufficient for the image. This is particularly important with qcow2 images, which can have a virtual size larger than the physical image size. If the volume size is set smaller than size of the underlying image, the volume will potentially be corrupt.
+You can run the command `qemu-img info YOUR_IMAGE_FILE.qcow2` to determine the virtual size of a qcow2 image.
+
+:::
+
 ![create-image-volume](/img/v1.2/volume/create-image-volume.png)


### PR DESCRIPTION
When creating volumes from images, it's important the the volume size be greater than or equal to the size of the underlying image.  If this is not the case, you'll potentially end up with a corrupt or truncated filesystem in the volume.  This is particularly likely to occur with qcow2 images, which can have a virtual size larger than the physical image size.

In Harvester v1.3 and earlier, when creating VMs, the volume size just defaults to 10GiB, regardless of the size of the underyling image. When creating volumes on the volume screen, the size has no default. In both cases it's hard to know the correct size to use, because Harvester prior to v1.4 doesn't expose the virtual size of qcow2 images anywhere.  Because of this, I've used "caution" boxes for the v1.3 docs.

In Harvester v1.4, the dashboard will default to setting the size of volumes so they're at least as large as the virtual size of the image, which means users are unlikely to run into trouble (unless they deliberately choose to make the volume size smaller for some reason), so I've dialed it back a bit and used the "info important" style for this version.

If this looks generally OK, I'll copy the v1.3 docs back to v1.2 as well.

Related issue: https://github.com/harvester/harvester/issues/4905