### PR TITLE
Remove API link from navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,8 +130,8 @@ const config = {
           dropdownActiveClassDisabled: true,
         },
         //{
-        //  type: 'docSidebar',
-        //  label: 'API',
+        //  type: 'docSidebar', 
+        //  label: 'API', # Redundant link
         //  position: 'left',
         //  sidebarId: 'api',
         //},

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,12 +129,6 @@ const config = {
           position: 'left',
           dropdownActiveClassDisabled: true,
         },
-        //{
-        //  type: 'docSidebar', 
-        //  label: 'API', # Redundant link
-        //  position: 'left',
-        //  sidebarId: 'api',
-        //},
         {
           type: "localeDropdown",
           position: "left",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,12 +129,12 @@ const config = {
           position: 'left',
           dropdownActiveClassDisabled: true,
         },
-        {
-          type: 'docSidebar',
-          label: 'API',
-          position: 'left',
-          sidebarId: 'api',
-        },
+        //{
+        //  type: 'docSidebar',
+        //  label: 'API',
+        //  position: 'left',
+        //  sidebarId: 'api',
+        //},
         {
           type: "localeDropdown",
           position: "left",


### PR DESCRIPTION
This PR removes the "API" link in the header (`navbar` in `docusaurus.config.js`) because of the following:
- That link currently points to "Harvester Overview" (`index.md`) instead of the API doc file (`v1.x-swagger.json`). 
- The sidebar already contains a link to the API doc file.