### PR TITLE
settings: explain support-bundle-image setting fields

### DIFF
--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -424,6 +424,14 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 }
 ```
 
+**Supported options and values**:
+
+The value is a JSON object literal that contains the following key-value pairs:
+
+- `repository`: Name of the repository that stores the support bundle image.
+- `tag`:  Tag assigned to the support bundle image.
+- `imagePullPolicy`: Pull policy of the support bundle image. The supported values are `IfNotPresent`, `Always`, and `Never`. For more information, see [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) in the Kubernetes documentation.
+
 ### `support-bundle-namespaces`
 
 **Versions**: v1.2.0 and later

--- a/versioned_docs/version-v1.2/advanced/settings.md
+++ b/versioned_docs/version-v1.2/advanced/settings.md
@@ -411,6 +411,14 @@ Default:
 }
 ```
 
+**Supported options and values**:
+
+The value is a JSON object literal that contains the following key-value pairs:
+
+- `repository`: Name of the repository that stores the support bundle image.
+- `tag`:  Tag assigned to the support bundle image.
+- `imagePullPolicy`: Pull policy of the support bundle image. The supported values are `IfNotPresent`, `Always`, and `Never`. For more information, see [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) in the Kubernetes documentation.
+
 ## `support-bundle-namespaces`
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.3/advanced/settings.md
+++ b/versioned_docs/version-v1.3/advanced/settings.md
@@ -424,6 +424,14 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 }
 ```
 
+**Supported options and values**:
+
+The value is a JSON object literal that contains the following key-value pairs:
+
+- `repository`: Name of the repository that stores the support bundle image.
+- `tag`:  Tag assigned to the support bundle image.
+- `imagePullPolicy`: Pull policy of the support bundle image. The supported values are `IfNotPresent`, `Always`, and `Never`. For more information, see [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) in the Kubernetes documentation.
+
 ### `support-bundle-namespaces`
 
 **Versions**: v1.2.0 and later


### PR DESCRIPTION
**Related Issue**
https://github.com/harvester/harvester/issues/4298

While the default value in https://docs.harvesterhci.io/v1.3/advanced/index#support-bundle-image is self-explained, add more docs to the fields.
