### PR TITLE
Add EOL label and unmaintained banner to v1.2

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,9 +72,9 @@ const config = {
               banner: `none`
             },
             "v1.2": {
-              label: 'v1.2',
+              label: 'v1.2 (EOL)',
               path: 'v1.2',
-              banner: `none`
+              banner: `unmaintained`
             },
             "v1.1": {
               label: 'v1.1 (EOL)',


### PR DESCRIPTION
According to the [Support Matrix](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/harvester-v1-2-x/), all versions listed below have an EOL date of 08 September 2024.

| Version | Released |
| --- | --- |
| 1.2.2 | 16 May 2024 |
| 1.2.1 | 26 Oct 2023 |
| 1.2.0 | 07 Sep 2023 |

![Screenshot 2024-10-31 at 10 41 46 AM](https://github.com/user-attachments/assets/2f25a749-0ecd-46db-b82c-1e62b30522b2)