### PR TITLE
docs: include the privilege pods info on the upgrade page

### DIFF
--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -54,6 +54,7 @@ Check out the available [`upgrade-config` setting](../advanced/settings.md#upgra
 - Make sure your hardware meets the **preferred** [hardware requirements](../install/requirements.md#hardware-requirements). This is due to there will be intermediate resources consumed by an upgrade.
 - Make sure each node has at least 30 GiB of free system partition space (`df -h /usr/local/`). If any node in the cluster has less than 30 GiB of free system partition space, the upgrade will be denied. Check [free system partition space requirement](#free-system-partition-space-requirement) for more information.
 - Run the pre-check script on a Harvester control-plane node. Please pick a script according to your cluster's version: https://github.com/harvester/upgrade-helpers/tree/main/pre-check. 
+- A number of one-off privileged pods will be created in the `harvester-system` and `cattle-system` namespaces to perform host-level upgrade operations. If [pod security admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) is enabled, adjust these policies to allow these pods to run.
 
 :::
 


### PR DESCRIPTION
This PR updates the upgrade page to include info on privileged permissions required to successfully run the upgrade operation, per https://github.com/harvester/harvester/issues/6963#issuecomment-2477583792.

ref: https://github.com/harvester/harvester/issues/6963.