### PR TITLE
Mention LHv2 doesn't support trim with AIO bdev driver

### DIFF
--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -73,9 +73,11 @@ The Longhorn V2 Data Engine is only available for newly created volumes. Existin
 
   :::note
 
-  Harvester sets the [Longhorn disk driver](https://longhorn.io/docs/1.7.2/v2-data-engine/features/node-disk-support/) to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance.
+  Harvester sets the [Longhorn disk driver](https://longhorn.io/docs/1.7.2/v2-data-engine/features/node-disk-support/) to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations like trimming.
   
   SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an *even multiple of 4096 bytes*. Non-NVMe disks that do not meet this size requirement cannot be added.
+
+  Additionally, the SPDK AIO bdev driver does not support the unmap operation. This means attempting to use trimming (also known as discard) with these devices will result in I/O errors and will pause your virtual machines. Accordingly, if you are using non-NVMe disks, you should avoid trim/discard.  For example, when creating an ext4 filesystem in a Linux VM, use `mkfs.ext4 -E nodiscard /dev/vdb` (assuming `/dev/vdb` is your device path).  On Windows VMs, trim support for NTFS can be disabled by running `fsutil behavior set disabledeletenotify NTFS 1` from the command prompt.
 
   :::
 


### PR DESCRIPTION
Non-NVMe disks use the SPDK AIO bdev driver, which doesn't support the unmap operation.  This means attempting to use trimming (also known as discard) with these devices will result in I/O errors and will pause your virtual machines.

This PR adds details about this limitation and gives an example for how to work around it when creating ext4 filesystems in Linux VMs, and also mentions how to disable trim for NTFS in Windows VMs. For reference, the latter command was found in this forum post:

  https://www.tenforums.com/tutorials/40028-enable-disable-trim-support-solid-state-drives-windows-10-a.html

I've added this information to the existing note about size limitations of non-NVMe disks, but if this note is getting too long I guess we could always break it out into a separate section.

As with the size limitation, this issue only affects non-NVMe disks. NVMe disks using the SPDK NVMe bdev driver support unmap and thus trim/discard works just fine on those.