### PR TITLE
Fix broken links flagged by Docusaurus

### DIFF
--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -31,7 +31,7 @@ Guest nodes are managed through a control plane that controls pod-related activi
 
 Group of integrated physical servers (hosts) on which the Harvester hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
 
-A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](./advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](./advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration).
 
 Harvester clusters can be imported into and managed by Rancher. Within the Rancher context, an imported Harvester cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
 

--- a/versioned_docs/version-v1.2/getting-started/deploy-ha-cluster.md
+++ b/versioned_docs/version-v1.2/getting-started/deploy-ha-cluster.md
@@ -11,7 +11,7 @@ keywords:
 - virtual machine
 ---
 
-A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 
+A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one witness node (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 
 
 This guide walks you through the steps required to deploy a **high-availability cluster** and virtual machines (VMs) that can host [guest clusters](../getting-started/glossary.md#guest-cluster--guest-kubernetes-cluster) and run custom workloads. 
 
@@ -24,7 +24,7 @@ Harvester is built for bare metal servers using enterprise-grade open-source sof
 You can download the installation files from the [Harvester Releases](https://github.com/harvester/harvester/releases) page. The **Downloads** section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available: 
 
 - **Full ISO**: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing Harvester behind a firewall or proxy, and in environments without internet connectivity. 
-- [**Net install ISO**](../install/net-install.md): Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub). 
+- **Net install ISO**: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub). 
 
 
 | Method | Required Installation Files | Other Requirements |

--- a/versioned_docs/version-v1.2/getting-started/deploy-singlenode-cluster.md
+++ b/versioned_docs/version-v1.2/getting-started/deploy-singlenode-cluster.md
@@ -11,7 +11,7 @@ keywords:
 - virtual machine
 ---
 
-A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 
+A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one witness node (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 
 
 This guide walks you through the steps required to deploy a **single-node cluster** and virtual machines (VMs) that can host [guest clusters](../getting-started/glossary.md#guest-cluster--guest-kubernetes-cluster) and run custom workloads. 
 
@@ -24,7 +24,7 @@ Harvester is built for bare metal servers using enterprise-grade open-source sof
 You can download the installation files from the [Harvester Releases](https://github.com/harvester/harvester/releases) page. The **Downloads** section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available: 
 
 - **Full ISO**: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing Harvester behind a firewall or proxy, and in environments without internet connectivity. 
-- [**Net install ISO**](../install/net-install.md): Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub). 
+- **Net install ISO**: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub). 
 
 
 | Method | Required Installation Files | Other Requirements |

--- a/versioned_docs/version-v1.2/getting-started/glossary.md
+++ b/versioned_docs/version-v1.2/getting-started/glossary.md
@@ -27,7 +27,7 @@ Guest nodes are managed through a control plane that controls pod-related activi
 
 Group of integrated physical servers (hosts) on which the Harvester hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
 
-A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one witness node (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration).
 
 Harvester clusters can be imported into and managed by Rancher. Within the Rancher context, an imported Harvester cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
 
@@ -41,8 +41,8 @@ Specialized operating system and [software stack](../index.md#harvester-architec
 
 Physical server on which the Harvester hypervisor is installed. 
 
-Each node that joins a Harvester cluster must be assigned a [role](./host/host.md#role-management) that determines the functions the node can perform within the cluster. All Harvester nodes process data but not all can store data.
+Each node that joins a Harvester cluster must be assigned a role that determines the functions the node can perform within the cluster. All Harvester nodes process data but not all can store data.
 
 ## **Harvester Node Driver**
 
-[Driver](./rancher/node/node-driver.md) that Rancher uses to provision VMs in a Harvester cluster, and to launch and manage guest Kubernetes clusters on top of those VMs.
+[Driver](../rancher/node/node-driver.md) that Rancher uses to provision VMs in a Harvester cluster, and to launch and manage guest Kubernetes clusters on top of those VMs.

--- a/versioned_docs/version-v1.4/getting-started/glossary.md
+++ b/versioned_docs/version-v1.4/getting-started/glossary.md
@@ -31,7 +31,7 @@ Guest nodes are managed through a control plane that controls pod-related activi
 
 Group of integrated physical servers (hosts) on which the Harvester hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
 
-A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](./advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](./advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration).
 
 Harvester clusters can be imported into and managed by Rancher. Within the Rancher context, an imported Harvester cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
 


### PR DESCRIPTION
Change log:
- v1.5: Added missing "."
- v1.4: Added missing "."
- v1.2: Added missing "."; removed links to pages that exist only in later versions of the doc (the corresponding features were mentioned in high-level descriptions)

> [!NOTE]
> I fixed the v1.2 doc issues to keep the build log clean. We no longer add content to that version.