### PR TITLE
Add v1.4 API doc to docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -289,6 +289,12 @@ const config = {
             label: "dev", // Current version label
             baseUrl: "/dev/api", // Leading slash is important
             versions: {
+              "v1.4": {
+                specPath: "api/v1.4-swagger.json",
+                outputDir: "versioned_docs/version-v1.4/api", // No trailing slash
+                label: "v1.4",
+                baseUrl: "/v1.4/api", // Leading slash is important
+              },              
               "v1.3": {
                 specPath: "api/v1.3-swagger.json",
                 outputDir: "versioned_docs/version-v1.3/api", // No trailing slash

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -266,7 +266,7 @@ const config = {
       {
         redirects: [
           { // Redirects for links in the Harvester README.md file
-            to: '/v1.1/install/pxe-boot-install',
+            to: '/v1.4/install/pxe-boot-install',
             from: '/latest/install/pxe-boot-install'
           },
         ],


### PR DESCRIPTION
The v1.4 API doc now appears in the sidebar.