### PR TITLE
Host: fix misleading information about cordoning

### DIFF
--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -21,7 +21,7 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
 
 If you want to force individual VMs to shut down instead of migrating to other nodes, add the label `harvesterhci.io/maintain-mode-strategy` and one of the following values to those VMs:
 
@@ -38,7 +38,7 @@ If you want to execute a special command before shutting down a VM, consider usi
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful for performing short tasks on the node during small maintenance windows, like reboots, upgrades, or decommissions. When you’re done, power back on and make the node schedulable again by uncordoning it.
+Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -21,7 +21,7 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 If you want to force individual VMs to shut down instead of migrating to other nodes, add the label `harvesterhci.io/maintain-mode-strategy` and one of the following values to those VMs:
 
@@ -38,7 +38,7 @@ If you want to execute a special command before shutting down a VM, consider usi
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
+Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to prevent new workloads from being scheduled on a node. You can uncordon a node to make it schedulable again.
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v0.3/host/host.md
+++ b/versioned_docs/version-v0.3/host/host.md
@@ -20,13 +20,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 ![node-maintenance.png](./assets/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
+Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to prevent new workloads from being scheduled on a node. You can uncordon a node to make it schedulable again.
 
 ![cordon-node.png](./assets/cordon-nodes.png)
 

--- a/versioned_docs/version-v0.3/host/host.md
+++ b/versioned_docs/version-v0.3/host/host.md
@@ -20,13 +20,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
 
 ![node-maintenance.png](./assets/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful for performing short tasks on the node during small maintenance windows, like reboots, upgrades, or decommissions. When you’re done, power back on and make the node schedulable again by uncordoning it.
+Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
 
 ![cordon-node.png](./assets/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.0/host/host.md
+++ b/versioned_docs/version-v1.0/host/host.md
@@ -20,13 +20,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.0/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
+Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to prevent new workloads from being scheduled on a node. You can uncordon a node to make it schedulable again.
 
 ![cordon-node.png](/img/v1.0/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.0/host/host.md
+++ b/versioned_docs/version-v1.0/host/host.md
@@ -20,13 +20,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.0/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful for performing short tasks on the node during small maintenance windows, like reboots, upgrades, or decommissions. When you’re done, power back on and make the node schedulable again by uncordoning it.
+Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
 
 ![cordon-node.png](/img/v1.0/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.1/host/host.md
+++ b/versioned_docs/version-v1.1/host/host.md
@@ -21,13 +21,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.1/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful for performing short tasks on the node during small maintenance windows, like reboots, upgrades, or decommissions. When you’re done, power back on and make the node schedulable again by uncordoning it.
+Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
 
 ![cordon-node.png](/img/v1.1/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.1/host/host.md
+++ b/versioned_docs/version-v1.1/host/host.md
@@ -21,13 +21,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.1/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
+Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to prevent new workloads from being scheduled on a node. You can uncordon a node to make it schedulable again.
 
 ![cordon-node.png](/img/v1.1/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.2/host/host.md
+++ b/versioned_docs/version-v1.2/host/host.md
@@ -17,13 +17,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.2/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful for performing short tasks on the node during small maintenance windows, like reboots, upgrades, or decommissions. When you’re done, power back on and make the node schedulable again by uncordoning it.
+Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.2/host/host.md
+++ b/versioned_docs/version-v1.2/host/host.md
@@ -17,13 +17,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.2/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
+Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to prevent new workloads from being scheduled on a node. You can uncordon a node to make it schedulable again.
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.3/host/host.md
+++ b/versioned_docs/version-v1.3/host/host.md
@@ -21,13 +21,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.2/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful for performing short tasks on the node during small maintenance windows, like reboots, upgrades, or decommissions. When you’re done, power back on and make the node schedulable again by uncordoning it.
+Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.3/host/host.md
+++ b/versioned_docs/version-v1.3/host/host.md
@@ -21,13 +21,13 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.2/host/node-maintenance.png)
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
+Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to prevent new workloads from being scheduled on a node. You can uncordon a node to make it schedulable again.
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 

--- a/versioned_docs/version-v1.4/host/host.md
+++ b/versioned_docs/version-v1.4/host/host.md
@@ -21,7 +21,7 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
-For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
+For admin users, you can click **Enable Maintenance Mode** to evict all VMs from a node automatically. This mode is useful when you want to reboot, upgrade firmware, or replace hardware components. It will leverage the `VM live migration` feature to migrate all VMs to other nodes automatically. Note that at least two active nodes are required to use this feature.
 
 If you want to force individual VMs to shut down instead of migrating to other nodes, add the label `harvesterhci.io/maintain-mode-strategy` and one of the following values to those VMs:
 
@@ -38,7 +38,7 @@ If you want to execute a special command before shutting down a VM, consider usi
 
 ## Cordoning a Node
 
-Cordoning a node marks it as unschedulable. This feature is useful for performing short tasks on the node during small maintenance windows, like reboots, upgrades, or decommissions. When you’re done, power back on and make the node schedulable again by uncordoning it.
+Cordoning a node marks it as unschedulable. This feature is useful when you don't want new workload to be scheduled to a node. You can make the node schedulable again by uncordoning it.
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 


### PR DESCRIPTION
Cordoning a node make a node unschedulable. It's not suitable for rebooting a node to do maintenance tasks.