### PR TITLE
feat: add crawler configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
       contents: write
       pages: write
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -59,3 +62,10 @@ jobs:
           AUTHOR_EMAIL: ${{ steps.vars.outputs.email }}
           COMMIT: ${{ steps.vars.outputs.sha_short }}
           GITHUB_REPO_LINK: "${{ github.server_url }}/${{ github.repository }}.git"
+      - name: Crawler
+        run: |
+          docker run \
+          -e APPLICATION_ID=${{ secrets.ALGOLIA_APP_ID }} \
+          -e API_KEY=${{ secrets.ALGOLIA_CRAWLER_API_KEY }} \
+          -e "CONFIG=$(cat ./docsearch.json | jq -r tostring)" \
+          algolia/docsearch-scraper

--- a/docsearch.json
+++ b/docsearch.json
@@ -1,0 +1,23 @@
+{
+    "index_name": "harvester",
+    "sitemap_urls": ["http://docs.harvesterhci.io/sitemap.xml"],
+    "start_urls": ["http://docs.harvesterhci.io/"],
+    "selectors": {
+      "lvl0": "",
+      "lvl1": "article h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5",
+      "lvl6": "article h6",
+      "text": "article p, article li, article td:last-child"
+    },
+    "custom_settings": {
+      "attributesForFaceting": [
+        "language",
+        "version",
+        "type",
+        "docusaurus_tag"
+      ]
+    }
+  }


### PR DESCRIPTION
Related Issue: https://github.com/harvester/harvester/issues/6623

Add a new Github Action for DocSearch crawler. 

[In my testing Github Action](https://github.com/Yu-Jack/docs/actions/runs/12250639089/job/34173924809), it ran for 5 minutes. There are few errors. They're about service limitations. We can improve our section later for better searching. 

Basically, we can have 1m records based on [pricing page](https://www.algolia.com/pricing). 

TODO:

- [x] Add two new secrets

![image](https://github.com/user-attachments/assets/c7aaa6bc-27a9-4ac0-9528-defcba54291b)

![image](https://github.com/user-attachments/assets/380926bb-6f24-485f-a94e-f9339a0a5deb)
