### PR TITLE
Rewrite and relocate node maintenance warning

### DIFF
--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -21,33 +21,35 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 :::warning
 
-Due to a recent [bug](https://github.com/harvester/harvester/issues/7128), there is a possibility that virtual machines (VMs) on a node may encounter an I/O error while in maintenance mode. To mitigate this issue until a fix is released, we advise using the following maintenance procedure:
+A [bug](https://github.com/harvester/harvester/issues/7128) may cause an I/O error to occur in virtual machines while Maintenance Mode is enabled on the underlying node. To mitigate the issue, you can set a taint on the node before enabling Maintenance Mode.
 
-1. Set the taint on the maintenance node:
+1. Set the taint on the target node.
 
     ```sh
     kubectl taint node <NODE> --overwrite kubevirt.io/drain=draining:NoSchedule
     ```
 
-1. Wait for all VMs to be live-migrated out of the maintenance node.
-1. Select **Enable Maintenance Mode** in the UI.
+1. Wait for all virtual machines to be live-migrated out of the node.
 
-After finishing the maintenance work, you need to:
-1. Remove the taint on the maintenance node:
+1. On the **Hosts** screen, select the target node, and then select **⋮ -> Enable Maintenance Mode**.
+
+Once the maintenance tasks are completed, perform the following steps to allow scheduling of workloads on the node.
+
+1. Remove the taint on the node.
 
     ```sh
     kubectl taint node <NODE> kubevirt.io/drain-
     ```
 
-1. Select **Disable Maintenance Mode** in the UI.
+1. On the **Hosts** screen, select the node, and then select **⋮ -> Disable Maintenance Mode**.
 
-For more information, please refer to issue [#7128](https://github.com/harvester/harvester/issues/7128).
+For more information, see [Issue #7128](https://github.com/harvester/harvester/issues/7128).
+
 :::
-
-Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 If you want to force individual VMs to shut down instead of migrating to other nodes, add the label `harvesterhci.io/maintain-mode-strategy` and one of the following values to those VMs:
 

--- a/versioned_docs/version-v1.2/host/host.md
+++ b/versioned_docs/version-v1.2/host/host.md
@@ -5,6 +5,10 @@ sidebar_label: Host Management
 title: "Host Management"
 ---
 
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.4/host"/>
+</head>
+
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 
 :::note
@@ -17,33 +21,35 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 :::warning
 
-Due to a recent [bug](https://github.com/harvester/harvester/issues/7128), there is a possibility that virtual machines (VMs) on a node may encounter an I/O error while in maintenance mode. To mitigate this issue until a fix is released, we advise using the following maintenance procedure:
+A [bug](https://github.com/harvester/harvester/issues/7128) may cause an I/O error to occur in virtual machines while Maintenance Mode is enabled on the underlying node. To mitigate the issue, you can set a taint on the node before enabling Maintenance Mode.
 
-1. Set the taint on the maintenance node:
+1. Set the taint on the target node.
 
     ```sh
     kubectl taint node <NODE> --overwrite kubevirt.io/drain=draining:NoSchedule
     ```
 
-1. Wait for all VMs to be live-migrated out of the maintenance node.
-1. Select **Enable Maintenance Mode** in the UI.
+1. Wait for all virtual machines to be live-migrated out of the node.
 
-After finishing the maintenance work, you need to:
-1. Remove the taint on the maintenance node:
+1. On the **Hosts** screen, select the target node, and then select **⋮ -> Enable Maintenance Mode**.
+
+Once the maintenance tasks are completed, perform the following steps to allow scheduling of workloads on the node.
+
+1. Remove the taint on the node.
 
     ```sh
     kubectl taint node <NODE> kubevirt.io/drain-
     ```
 
-1. Select **Disable Maintenance Mode** in the UI.
+1. On the **Hosts** screen, select the node, and then select **⋮ -> Disable Maintenance Mode**.
 
-For more information, please refer to issue [#7128](https://github.com/harvester/harvester/issues/7128).
+For more information, see [Issue #7128](https://github.com/harvester/harvester/issues/7128).
+
 :::
-
-Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.2/host/node-maintenance.png)
 

--- a/versioned_docs/version-v1.3/host/host.md
+++ b/versioned_docs/version-v1.3/host/host.md
@@ -21,33 +21,35 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 :::warning
 
-Due to a recent [bug](https://github.com/harvester/harvester/issues/7128), there is a possibility that virtual machines (VMs) on a node may encounter an I/O error while in maintenance mode. To mitigate this issue until a fix is released, we advise using the following maintenance procedure:
+A [bug](https://github.com/harvester/harvester/issues/7128) may cause an I/O error to occur in virtual machines while Maintenance Mode is enabled on the underlying node. To mitigate the issue, you can set a taint on the node before enabling Maintenance Mode.
 
-1. Set the taint on the maintenance node:
+1. Set the taint on the target node.
 
     ```sh
     kubectl taint node <NODE> --overwrite kubevirt.io/drain=draining:NoSchedule
     ```
 
-1. Wait for all VMs to be live-migrated out of the maintenance node.
-1. Select **Enable Maintenance Mode** in the UI.
+1. Wait for all virtual machines to be live-migrated out of the node.
 
-After finishing the maintenance work, you need to:
-1. Remove the taint on the maintenance node:
+1. On the **Hosts** screen, select the target node, and then select **⋮ -> Enable Maintenance Mode**.
+
+Once the maintenance tasks are completed, perform the following steps to allow scheduling of workloads on the node.
+
+1. Remove the taint on the node.
 
     ```sh
     kubectl taint node <NODE> kubevirt.io/drain-
     ```
 
-1. Select **Disable Maintenance Mode** in the UI.
+1. On the **Hosts** screen, select the node, and then select **⋮ -> Disable Maintenance Mode**.
 
-For more information, please refer to issue [#7128](https://github.com/harvester/harvester/issues/7128).
+For more information, see [Issue #7128](https://github.com/harvester/harvester/issues/7128).
+
 :::
-
-Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 ![node-maintenance.png](/img/v1.2/host/node-maintenance.png)
 

--- a/versioned_docs/version-v1.3/host/host.md
+++ b/versioned_docs/version-v1.3/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.2/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.4/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.4/host/host.md
+++ b/versioned_docs/version-v1.4/host/host.md
@@ -21,33 +21,35 @@ Because Harvester is built on top of Kubernetes and uses etcd as its database, t
 
 ## Node Maintenance
 
+Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 :::warning
 
-Due to a recent [bug](https://github.com/harvester/harvester/issues/7128), there is a possibility that virtual machines (VMs) on a node may encounter an I/O error while in maintenance mode. To mitigate this issue until a fix is released, we advise using the following maintenance procedure:
+A [bug](https://github.com/harvester/harvester/issues/7128) may cause an I/O error to occur in virtual machines while Maintenance Mode is enabled on the underlying node. To mitigate the issue, you can set a taint on the node before enabling Maintenance Mode.
 
-1. Set the taint on the maintenance node:
+1. Set the taint on the target node.
 
     ```sh
     kubectl taint node <NODE> --overwrite kubevirt.io/drain=draining:NoSchedule
     ```
 
-1. Wait for all VMs to be live-migrated out of the maintenance node.
-1. Select **Enable Maintenance Mode** in the UI.
+1. Wait for all virtual machines to be live-migrated out of the node.
 
-After finishing the maintenance work, you need to:
-1. Remove the taint on the maintenance node:
+1. On the **Hosts** screen, select the target node, and then select **⋮ -> Enable Maintenance Mode**.
+
+Once the maintenance tasks are completed, perform the following steps to allow scheduling of workloads on the node.
+
+1. Remove the taint on the node.
 
     ```sh
     kubectl taint node <NODE> kubevirt.io/drain-
     ```
 
-1. Select **Disable Maintenance Mode** in the UI.
+1. On the **Hosts** screen, select the node, and then select **⋮ -> Disable Maintenance Mode**.
 
-For more information, please refer to issue [#7128](https://github.com/harvester/harvester/issues/7128).
+For more information, see [Issue #7128](https://github.com/harvester/harvester/issues/7128).
+
 :::
-
-Admin users can enable Maintenance Mode (select **⋮ > Enable Maintenance Mode**) to automatically evict all virtual machines from a node. This mode leverages the **live migration** feature to migrate the virtual machines to other nodes, which is useful when you need to reboot, upgrade firmware, or replace hardware components. At least two active nodes are required to use this feature.
 
 If you want to force individual VMs to shut down instead of migrating to other nodes, add the label `harvesterhci.io/maintain-mode-strategy` and one of the following values to those VMs:
 


### PR DESCRIPTION
I rewrote the warning added in [PR 689](https://github.com/harvester/docs/pull/689/) to improve readability. I also placed the warning below the intro paragraph so that users new to Maintenance Mode can become familiar with it first.