### PR TITLE
Add Document Conventions file to Getting Started section

### DIFF
--- a/docs/getting-started/document-conventions.md
+++ b/docs/getting-started/document-conventions.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 4
+sidebar_label: Document Conventions
+title: "Document Conventions"
+keywords:
+- Harvester
+- documentation
+- conventions
+- labels
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.4/getting-started/document-conventions"/>
+</head>
+
+## Release Labels
+
+- **Latest**: Pending
+
+- **Stable**: Pending
+
+- **Dev**: Pending
+
+- **EOL**: The software has reached the end of its useful life and no further code-level maintenance will be provided. You may continue to use the software within the terms of the licensing agreement.
+
+## Feature Labels
+
+Features that are labeled **Experimental** or **Technical Preview** are available to use in non-production or limited production environments. SUSE welcomes feedback for improving the functionality and usability of these features.
+
+- **Experimental**: The feature is incomplete but its essential functionality is operational. Tests in a controlled environment have shown that it can coexist with existing stable features. Because of the missing components and/or evolving functionality, the feature is not recommended for use in production environments.
+
+- **Technical Preview**: The feature is complete and its functionality is not expected to change significantly. Tests in a controlled environment have shown that it can coexist with existing stable features. Explore the feature extensively before using in production environments.
+
+:::note
+
+Experimental and Technical Preview features are usually disabled by default. The documentation provides information about how you can enable and configure such features. 
+
+:::

--- a/docs/getting-started/document-conventions.md
+++ b/docs/getting-started/document-conventions.md
@@ -44,3 +44,17 @@ Features that are labeled **Experimental** or **Technical Preview** are availabl
 Experimental and Technical Preview features are usually disabled by default. The documentation provides information about how you can enable and configure such features. 
 
 :::
+
+## Admonitions
+
+Admonitions are text blocks that provide additional or important information. Each text block is marked with a special label and icon.
+
+- **Note**: Additional information that is useful but not critical.
+
+- **Important**: Information that requires special attention, such as changes in product behavior.
+
+- **Tip**: Helpful advice and suggestions, such as alternative methods of completing a task.
+
+- **Caution**: Information that must be considered before proceeding with specific actions, such as errors that may occur.
+
+- **Warning**: Critical information about harmful consequences, such as irreversible damage and data loss.

--- a/docs/getting-started/document-conventions.md
+++ b/docs/getting-started/document-conventions.md
@@ -19,7 +19,7 @@ Harvester has a 26-week release cycle and an N - 1 support policy. Each release 
 
 - **Dev**: The software is under active development and has not been thoroughly tested. Upgrading from earlier versions or to later versions is not supported. Use this version only for testing purposes.
 
-- **Latest**: The software has passed all stages of verification and testing. All remaining known issues are considered acceptable. Use this version only in testing and limited production environments.
+- **Latest**: The software has passed all stages of verification and testing. All remaining known issues are considered acceptable. Use this version only for testing purposes.
 
 - **Stable**: The software is considered reliable and free of critical issues. This version is recommended for general use.
 
@@ -27,7 +27,7 @@ Harvester has a 26-week release cycle and an N - 1 support policy. Each release 
 
 :::note
 
-Harvester provides documentation for major and minor releases. Information about enhancements and bug fixes implemented in patch releases is added to the documentation for the relevant minor releases.
+Harvester provides documentation for major and minor releases. Information about enhancements and bug fixes implemented in patch releases is added to the minor release documentation.
 
 :::
 

--- a/docs/getting-started/document-conventions.md
+++ b/docs/getting-started/document-conventions.md
@@ -15,15 +15,15 @@ keywords:
 
 ## Release Labels
 
-Harvester has a 26-week release cycle and an N - 1 support policy. Each release is supported for 14 months (12 months of support and 2 months for upgrades). Only the two most recent minor versions receive security and bug fixes. For more information, see the [Support Matrix](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/).
+Harvester has a 26-week release cycle and an N - 1 support policy. Each release is supported for 14 months (12 months of support and 2 months for upgrades). Only the two most recent minor versions receive security and bug fixes.
 
-- **Dev**: The software is under active development and has not been thoroughly tested. Upgrading from earlier versions or to later versions is not supported. Use this version only for testing purposes.
+- **Dev**: The software is under active development and has not been thoroughly tested. Upgrading from earlier releases or to later releases is not supported. "Dev" releases typically occur at the end of a sprint, and may occur when other definitions of done are met. Given the unofficial nature of the release, use the software only for testing purposes.
 
-- **Latest**: The software has passed all stages of verification and testing. All remaining known issues are considered acceptable. Use this version only for testing purposes.
+- **Latest**: The software has passed all stages of verification and testing. All remaining known issues are considered acceptable. Use the software only for testing purposes.
 
-- **Stable**: The software is considered reliable and free of critical issues. This version is recommended for general use.
+- **Stable**: The software is considered reliable and free of critical issues. This release is recommended for general use.
 
-- **EOL**: The software has reached the end of its useful life and no further code-level maintenance is provided. You may continue to use the software within the terms of the licensing agreement. Upgrading to the latest stable version is recommended.
+- **EOL**: The software has reached the end of its useful life and no further code-level maintenance is provided. You may continue to use the software within the terms of the licensing agreement. Upgrading to a stable release is recommended.
 
 :::note
 
@@ -33,15 +33,22 @@ Harvester provides documentation for major and minor releases. Information about
 
 ## Feature Labels
 
-Features that are labeled **Experimental** or **Technical Preview** are available to use in non-production or limited production environments. SUSE welcomes feedback for improving the functionality and usability of these features. You can report issues in the [GitHub repository](https://github.com/harvester/harvester).
+Features that are labeled **Experimental** and **Technical Preview** provide glimpses into upcoming innovations and offer opportunities to test new technologies within your environment.
 
 - **Experimental**: The feature is incomplete but its essential functionality is operational. Tests in a controlled environment have shown that it can coexist with existing stable features. Because of the missing components and/or evolving functionality, the feature is not recommended for use in production environments.
 
-- **Technical Preview**: The feature is complete and its functionality is not expected to change significantly. Tests in a controlled environment have shown that it can coexist with existing stable features. Explore the feature extensively before using in production environments.
+- **Technical Preview**: The feature is almost complete and its functionality is not expected to change significantly. Tests in a controlled environment have shown that it can coexist with existing stable features. Explore the feature extensively before using in production environments.
+
+These features have the following limitations:
+
+- Still in development and may be functionally incomplete, unstable, or in other ways unsuitable for production use.
+- Not supported.
+- May only be available for specific hardware architectures. Details and functionality are subject to change. As a result, upgrading to subsequent releases may be impossible and may require a fresh installation.
+- Can be removed from the product at any time. This may occur, for example, if we discover that the feature does not meet customer or market needs, or does not comply with enterprise standards.
 
 :::note
 
-Experimental and Technical Preview features are usually disabled by default. The documentation provides information about how you can enable and configure such features. 
+**Experimental** and **Technical Preview** features are usually disabled by default. The documentation provides information about how you can enable and configure such features.
 
 :::
 

--- a/docs/getting-started/document-conventions.md
+++ b/docs/getting-started/document-conventions.md
@@ -15,17 +15,25 @@ keywords:
 
 ## Release Labels
 
-- **Latest**: Pending
+Harvester has a 26-week release cycle and an N - 1 support policy. Each release is supported for 14 months (12 months of support and 2 months for upgrades). Only the two most recent minor versions receive security and bug fixes. For more information, see the [Support Matrix](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/).
 
-- **Stable**: Pending
+- **Dev**: The software is under active development and has not been thoroughly tested. Upgrading from earlier versions or to later versions is not supported. Use this version only for testing purposes.
 
-- **Dev**: Pending
+- **Latest**: The software has passed all stages of verification and testing. All remaining known issues are considered acceptable. Use this version only in testing and limited production environments.
 
-- **EOL**: The software has reached the end of its useful life and no further code-level maintenance will be provided. You may continue to use the software within the terms of the licensing agreement.
+- **Stable**: The software is considered reliable and free of critical issues. This version is recommended for general use.
+
+- **EOL**: The software has reached the end of its useful life and no further code-level maintenance is provided. You may continue to use the software within the terms of the licensing agreement. Upgrading to the latest stable version is recommended.
+
+:::note
+
+Harvester provides documentation for major and minor releases. Information about enhancements and bug fixes implemented in patch releases is added to the documentation for the relevant minor releases.
+
+:::
 
 ## Feature Labels
 
-Features that are labeled **Experimental** or **Technical Preview** are available to use in non-production or limited production environments. SUSE welcomes feedback for improving the functionality and usability of these features.
+Features that are labeled **Experimental** or **Technical Preview** are available to use in non-production or limited production environments. SUSE welcomes feedback for improving the functionality and usability of these features. You can report issues in the [GitHub repository](https://github.com/harvester/harvester).
 
 - **Experimental**: The feature is incomplete but its essential functionality is operational. Tests in a controlled environment have shown that it can coexist with existing stable features. Because of the missing components and/or evolving functionality, the feature is not recommended for use in production environments.
 

--- a/versioned_docs/version-v1.3/getting-started/document-conventions.md
+++ b/versioned_docs/version-v1.3/getting-started/document-conventions.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 4
+sidebar_label: Document Conventions
+title: "Document Conventions"
+keywords:
+- Harvester
+- documentation
+- conventions
+- labels
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.4/getting-started/document-conventions"/>
+</head>
+
+## Release Labels
+
+Harvester has a 26-week release cycle and an N - 1 support policy. Each release is supported for 14 months (12 months of support and 2 months for upgrades). Only the two most recent minor versions receive security and bug fixes.
+
+- **Dev**: The software is under active development and has not been thoroughly tested. Upgrading from earlier releases or to later releases is not supported. "Dev" releases typically occur at the end of a sprint, and may occur when other definitions of done are met. Given the unofficial nature of the release, use the software only for testing purposes.
+
+- **Latest**: The software has passed all stages of verification and testing. All remaining known issues are considered acceptable. Use the software only for testing purposes.
+
+- **Stable**: The software is considered reliable and free of critical issues. This release is recommended for general use.
+
+- **EOL**: The software has reached the end of its useful life and no further code-level maintenance is provided. You may continue to use the software within the terms of the licensing agreement. Upgrading to a stable release is recommended.
+
+:::note
+
+Harvester provides documentation for major and minor releases. Information about enhancements and bug fixes implemented in patch releases is added to the minor release documentation.
+
+:::
+
+## Feature Labels
+
+Features that are labeled **Experimental** and **Technical Preview** provide glimpses into upcoming innovations and offer opportunities to test new technologies within your environment.
+
+- **Experimental**: The feature is incomplete but its essential functionality is operational. Tests in a controlled environment have shown that it can coexist with existing stable features. Because of the missing components and/or evolving functionality, the feature is not recommended for use in production environments.
+
+- **Technical Preview**: The feature is almost complete and its functionality is not expected to change significantly. Tests in a controlled environment have shown that it can coexist with existing stable features. Explore the feature extensively before using in production environments.
+
+These features have the following limitations:
+
+- Still in development and may be functionally incomplete, unstable, or in other ways unsuitable for production use.
+- Not supported.
+- May only be available for specific hardware architectures. Details and functionality are subject to change. As a result, upgrading to subsequent releases may be impossible and may require a fresh installation.
+- Can be removed from the product at any time. This may occur, for example, if we discover that the feature does not meet customer or market needs, or does not comply with enterprise standards.
+
+:::note
+
+**Experimental** and **Technical Preview** features are usually disabled by default. The documentation provides information about how you can enable and configure such features.
+
+:::
+
+## Admonitions
+
+Admonitions are text blocks that provide additional or important information. Each text block is marked with a special label and icon.
+
+- **Note**: Additional information that is useful but not critical.
+
+- **Important**: Information that requires special attention, such as changes in product behavior.
+
+- **Tip**: Helpful advice and suggestions, such as alternative methods of completing a task.
+
+- **Caution**: Information that must be considered before proceeding with specific actions, such as errors that may occur.
+
+- **Warning**: Critical information about harmful consequences, such as irreversible damage and data loss.

--- a/versioned_docs/version-v1.4/getting-started/document-conventions.md
+++ b/versioned_docs/version-v1.4/getting-started/document-conventions.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 4
+sidebar_label: Document Conventions
+title: "Document Conventions"
+keywords:
+- Harvester
+- documentation
+- conventions
+- labels
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.4/getting-started/document-conventions"/>
+</head>
+
+## Release Labels
+
+Harvester has a 26-week release cycle and an N - 1 support policy. Each release is supported for 14 months (12 months of support and 2 months for upgrades). Only the two most recent minor versions receive security and bug fixes.
+
+- **Dev**: The software is under active development and has not been thoroughly tested. Upgrading from earlier releases or to later releases is not supported. "Dev" releases typically occur at the end of a sprint, and may occur when other definitions of done are met. Given the unofficial nature of the release, use the software only for testing purposes.
+
+- **Latest**: The software has passed all stages of verification and testing. All remaining known issues are considered acceptable. Use the software only for testing purposes.
+
+- **Stable**: The software is considered reliable and free of critical issues. This release is recommended for general use.
+
+- **EOL**: The software has reached the end of its useful life and no further code-level maintenance is provided. You may continue to use the software within the terms of the licensing agreement. Upgrading to a stable release is recommended.
+
+:::note
+
+Harvester provides documentation for major and minor releases. Information about enhancements and bug fixes implemented in patch releases is added to the minor release documentation.
+
+:::
+
+## Feature Labels
+
+Features that are labeled **Experimental** and **Technical Preview** provide glimpses into upcoming innovations and offer opportunities to test new technologies within your environment.
+
+- **Experimental**: The feature is incomplete but its essential functionality is operational. Tests in a controlled environment have shown that it can coexist with existing stable features. Because of the missing components and/or evolving functionality, the feature is not recommended for use in production environments.
+
+- **Technical Preview**: The feature is almost complete and its functionality is not expected to change significantly. Tests in a controlled environment have shown that it can coexist with existing stable features. Explore the feature extensively before using in production environments.
+
+These features have the following limitations:
+
+- Still in development and may be functionally incomplete, unstable, or in other ways unsuitable for production use.
+- Not supported.
+- May only be available for specific hardware architectures. Details and functionality are subject to change. As a result, upgrading to subsequent releases may be impossible and may require a fresh installation.
+- Can be removed from the product at any time. This may occur, for example, if we discover that the feature does not meet customer or market needs, or does not comply with enterprise standards.
+
+:::note
+
+**Experimental** and **Technical Preview** features are usually disabled by default. The documentation provides information about how you can enable and configure such features.
+
+:::
+
+## Admonitions
+
+Admonitions are text blocks that provide additional or important information. Each text block is marked with a special label and icon.
+
+- **Note**: Additional information that is useful but not critical.
+
+- **Important**: Information that requires special attention, such as changes in product behavior.
+
+- **Tip**: Helpful advice and suggestions, such as alternative methods of completing a task.
+
+- **Caution**: Information that must be considered before proceeding with specific actions, such as errors that may occur.
+
+- **Warning**: Critical information about harmful consequences, such as irreversible damage and data loss.


### PR DESCRIPTION
Related comment: https://github.com/harvester/release-notes/pull/35#discussion_r1860014870

Scope:
- Create "Document Conventions" file with three sections: Release Labels, Feature Labels, Admonitions
- Write definitions for labels and terms in each section

Notes for reviewers:
- Are the definitions correct?
- Can users install the latest version in production? I'm asking because the Support Matrix says "Use Latest versions for test purposes only."
- Should I add the label `Stable` to the navbar dropdown list? Example: v1.3 (Stable)