### PR TITLE
doc(rancher): suggest managed dhcp for creating guest cluster

### DIFF
--- a/docs/rancher/node/k3s-cluster.md
+++ b/docs/rancher/node/k3s-cluster.md
@@ -15,6 +15,7 @@ You can now provision K3s Kubernetes clusters on top of the Harvester cluster in
 :::note
 
 - Harvester K3s node driver is in **Tech Preview**.
+- Provisioning K3s Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
 - Harvester node driver only supports cloud images.
 - For the port requirements of the guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).

--- a/docs/rancher/node/rke1-cluster.md
+++ b/docs/rancher/node/rke1-cluster.md
@@ -17,6 +17,7 @@ RKE1 and RKE2 have several slight behavioral differences. Refer to the [differen
 :::note
 
 - VLAN network is required for Harvester node driver.
+- Provisioning RKE1 Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For port requirements of guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 

--- a/docs/rancher/node/rke2-cluster.md
+++ b/docs/rancher/node/rke2-cluster.md
@@ -15,6 +15,7 @@ You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster i
 :::note
 
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
+- Provisioning RKE2 Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For the port requirements of the guest clusters deployed within Harvester, please refer to the doc [here](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 - For RKE2 with Harvester cloud provider support matrix, please refer to the website [here](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/).

--- a/versioned_docs/version-v1.3/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.3/rancher/node/k3s-cluster.md
@@ -16,6 +16,7 @@ You can now provision K3s Kubernetes clusters on top of the Harvester cluster in
 
 - Harvester K3s node driver is in **Tech Preview**.
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
+- Provisioning K3s Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For the port requirements of the guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 

--- a/versioned_docs/version-v1.3/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.3/rancher/node/rke1-cluster.md
@@ -17,6 +17,7 @@ RKE1 and RKE2 have several slight behavioral differences. Refer to the [differen
 :::note
 
 - VLAN network is required for Harvester node driver.
+- Provisioning RKE1 Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For port requirements of guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 

--- a/versioned_docs/version-v1.3/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.3/rancher/node/rke2-cluster.md
@@ -15,6 +15,7 @@ You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster i
 :::note
 
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
+- Provisioning RKE2 Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For the port requirements of the guest clusters deployed within Harvester, please refer to the doc [here](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 - For RKE2 with Harvester cloud provider support matrix, please refer to the website [here](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/).

--- a/versioned_docs/version-v1.4/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.4/rancher/node/k3s-cluster.md
@@ -16,6 +16,7 @@ You can now provision K3s Kubernetes clusters on top of the Harvester cluster in
 
 - Harvester K3s node driver is in **Tech Preview**.
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
+- Provisioning K3s Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For the port requirements of the guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 

--- a/versioned_docs/version-v1.4/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.4/rancher/node/rke1-cluster.md
@@ -17,6 +17,7 @@ RKE1 and RKE2 have several slight behavioral differences. Refer to the [differen
 :::note
 
 - VLAN network is required for Harvester node driver.
+- Provisioning RKE1 Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For port requirements of guest clusters deployed within Harvester, please refer to the [port requirements for guest clusters](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 

--- a/versioned_docs/version-v1.4/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.4/rancher/node/rke2-cluster.md
@@ -15,6 +15,7 @@ You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster i
 :::note
 
 - [VLAN network](../../networking/harvester-network.md#vlan-network) is required for Harvester node driver.
+- Provisioning RKE2 Kubernetes clusters involves configuring the IP address of the underlying virtual machines. You can do this using a DHCP server on the VLAN network that the virtual machines are attached to. If such a server does not exist on the network, you can use the [Managed DHCP](../../advanced/addons/managed-dhcp.md) feature to configure the IP address.
 - Harvester node driver only supports cloud images.
 - For the port requirements of the guest clusters deployed within Harvester, please refer to the doc [here](../../install/requirements.md#port-requirements-for-k3s-or-rkerke2-clusters).
 - For RKE2 with Harvester cloud provider support matrix, please refer to the website [here](https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/).


### PR DESCRIPTION
This is to give users a hint that there is another way to set up DHCP for creating guest clusters.

Related issue: harvester/harvester#6469