### PR TITLE
support bundle: fix env variable declaration error

### DIFF
--- a/docs/troubleshooting/harvester.md
+++ b/docs/troubleshooting/harvester.md
@@ -212,7 +212,7 @@ Harvester is unable to collect data and generate a support bundle when the node 
 1. Prepare the environment.
     ```sh
     mkdir -p /tmp/support-bundle # ensure /tmp/support-bundle exists
-    echo JOURNALCTL="/usr/bin/journalctl -o short-precise" > /tmp/common
+    echo 'JOURNALCTL="/usr/bin/journalctl -o short-precise"' > /tmp/common
     export SUPPORT_BUNDLE_NODE_NAME=$(hostname)
     ```
 

--- a/versioned_docs/version-v1.2/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.2/troubleshooting/harvester.md
@@ -207,7 +207,7 @@ Harvester is unable to collect data and generate a support bundle when the node 
 1. Prepare the environment.
     ```sh
     mkdir -p /tmp/support-bundle # ensure /tmp/support-bundle exists
-    echo JOURNALCTL="/usr/bin/journalctl -o short-precise" > /tmp/common
+    echo 'JOURNALCTL="/usr/bin/journalctl -o short-precise"' > /tmp/common
     export SUPPORT_BUNDLE_NODE_NAME=$(hostname)
     ```
 

--- a/versioned_docs/version-v1.3/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.3/troubleshooting/harvester.md
@@ -212,7 +212,7 @@ Harvester is unable to collect data and generate a support bundle when the node 
 1. Prepare the environment.
     ```sh
     mkdir -p /tmp/support-bundle # ensure /tmp/support-bundle exists
-    echo JOURNALCTL="/usr/bin/journalctl -o short-precise" > /tmp/common
+    echo 'JOURNALCTL="/usr/bin/journalctl -o short-precise"' > /tmp/common
     export SUPPORT_BUNDLE_NODE_NAME=$(hostname)
     ```
 

--- a/versioned_docs/version-v1.4/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.4/troubleshooting/harvester.md
@@ -212,7 +212,7 @@ Harvester is unable to collect data and generate a support bundle when the node 
 1. Prepare the environment.
     ```sh
     mkdir -p /tmp/support-bundle # ensure /tmp/support-bundle exists
-    echo JOURNALCTL="/usr/bin/journalctl -o short-precise" > /tmp/common
+    echo 'JOURNALCTL="/usr/bin/journalctl -o short-precise"' > /tmp/common
     export SUPPORT_BUNDLE_NODE_NAME=$(hostname)
     ```
 


### PR DESCRIPTION
The variable assignment must be quoted in the created file:

Existing example:
```
# cat /tmp/common
JOURNALCTL=/usr/bin/journalctl -o short-precise
```

And the collection fails with:
```
<...>
+ mkdir -p scc
+ mkdir -p logs
+ cd logs
./collector-harvester: line 102: JOURNALCTL: unbound variable
```

With the single quote:
```
# cat /tmp/common
JOURNALCTL="/usr/bin/journalctl -o short-precise"
```