### PR TITLE
fix: Fixed typo in harvester configuration example

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -75,7 +75,7 @@ install:
   vip_mode: dhcp
   cluster_pod_cidr: 10.52.0.0/16
   cluster_service_cidr: 10.53.0.0/16
-  cluster_dns_ip: 10.53.0.10
+  cluster_dns: 10.53.0.10
   force_mbr: false
   addons:
     harvester_vm_import_controller:


### PR DESCRIPTION
This PR fixed a typo found in the Harvester configuration example where the cluster DNS field should be `cluster_dns`, not `cluster_dns_ip`. This is a 1.5 feature.

Relevant issue: https://github.com/harvester/harvester/issues/7797