### PR TITLE
v1.5 docs are mentioning v1.4 erroneously

### DIFF
--- a/docs/advanced/addons/lvm-local-storage.md
+++ b/docs/advanced/addons/lvm-local-storage.md
@@ -10,7 +10,7 @@ title: "Local Storage Support"
 
 _Available as of v1.4.0_
 
-Harvester v1.4.0 allows you to use local storage on the host to create persistent volumes for your workloads with better performance and latency. This functionality is made possible by LVM, which provides logical volume management facilities on Linux.
+Harvester allows you to use local storage on the host to create persistent volumes for your workloads with better performance and latency. This functionality is made possible by LVM, which provides logical volume management facilities on Linux.
 
 ## Installing and Enabling harvester-csi-driver-lvm
 

--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -14,7 +14,7 @@ The Longhorn V2 Data Engine harnesses the power of the Storage Performance Devel
 
 :::caution
 
-The Longhorn V2 Data Engine is an **Experimental** feature in Harvester v1.4.0 and should not be utilized in a production environment.
+The Longhorn V2 Data Engine is an **Experimental** feature and should not be utilized in a production environment.
 
 :::
 

--- a/docs/image/image-security.md
+++ b/docs/image/image-security.md
@@ -17,7 +17,7 @@ keywords:
 
 _Available as of v1.4.0_
 
-Harvester v1.4.0 and later versions allow you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
+Harvester allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 
 ## Prerequisites
 

--- a/docs/volume/volume-security.md
+++ b/docs/volume/volume-security.md
@@ -13,7 +13,7 @@ keywords:
 
 _Available as of v1.4.0_
 
-Harvester v1.4.0 and later versions allow you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
+Harvester allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 
 ## Prerequisites
 

--- a/versioned_docs/version-v1.4/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.4/advanced/addons/lvm-local-storage.md
@@ -10,7 +10,7 @@ title: "Local Storage Support"
 
 _Available as of v1.4.0_
 
-Harvester v1.4.0 allows you to use local storage on the host to create persistent volumes for your workloads with better performance and latency. This functionality is made possible by LVM, which provides logical volume management facilities on Linux.
+Harvester allows you to use local storage on the host to create persistent volumes for your workloads with better performance and latency. This functionality is made possible by LVM, which provides logical volume management facilities on Linux.
 
 ## Installing and Enabling harvester-csi-driver-lvm
 

--- a/versioned_docs/version-v1.4/advanced/longhorn-v2.md
+++ b/versioned_docs/version-v1.4/advanced/longhorn-v2.md
@@ -14,7 +14,7 @@ The Longhorn V2 Data Engine harnesses the power of the Storage Performance Devel
 
 :::caution
 
-The Longhorn V2 Data Engine is an **Experimental** feature in Harvester v1.4.0 and should not be utilized in a production environment.
+The Longhorn V2 Data Engine is an **Experimental** feature and should not be utilized in a production environment.
 
 :::
 

--- a/versioned_docs/version-v1.4/image/image-security.md
+++ b/versioned_docs/version-v1.4/image/image-security.md
@@ -17,7 +17,7 @@ keywords:
 
 _Available as of v1.4.0_
 
-Harvester v1.4.0 and later versions allow you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
+Harvester allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 
 ## Prerequisites
 


### PR DESCRIPTION
There are several places where the documentation is mentioning v1.4 erroneously although it concerns v1.5.

Additionally there are several places that are mentioning v1.4.0 in the text which is redundant because it is already mentioned above in a `Available as of v1.4.0` note.

Fix the version from `1.4.0` to `1.4` because the doc relates to ALL versions not only to the patch version `.0`.

Related to: https://github.com/harvester/harvester/issues/7893