### PR TITLE
add note for preventing backing image missing during upgrade to v1.4.0

### DIFF
--- a/docs/upgrade/v1-3-2-to-v1-4-0.md
+++ b/docs/upgrade/v1-3-2-to-v1-4-0.md
@@ -14,6 +14,248 @@ An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvest
 
 For air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
 
+### Preventing Corruption of VM Images During Upgrade
+
+:::caution
+
+Before proceeding with the upgrade to Harvester **v1.4.0**, please make sure the **BackingImage** CRD is updated to the [Longhorn **v1.7.2** version](https://github.com/longhorn/longhorn/blob/v1.7.2/deploy/longhorn.yaml#L486-L690) beforehand.
+
+If this step is skipped, it may lead to backing image corruption, as described in this [known Longhorn issue](https://github.com/longhorn/longhorn/issues/10644).
+
+:::
+
+To prevent the issue from occurring, you can manually update the `BackingImage` CRD before upgrading Harvester.
+
+1. Patch the **Harvester managedchart** to avoid related errors and warnings.
+
+  ```sh
+  kubectl patch managedchart harvester \
+  -n fleet-local \
+  --type='json' \
+  -p='[
+    {
+      "op":"add",
+      "path":"/spec/diff/comparePatches/-",
+      "value": {
+        "apiVersion":"apiextensions.k8s.io/v1",
+        "jsonPointers":["/spec","/metadata/annotations", "/metadata/labels", "/status"],
+        "kind":"CustomResourceDefinition",
+        "name":"backingimages.longhorn.io"
+      }
+    }
+  ]'
+  ```
+
+1. Apply the **Longhorn v1.7.2** [`BackingImage` CRD](https://github.com/longhorn/longhorn/blob/v1.7.2/deploy/longhorn.yaml#L486-L690).
+
+  ```
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.15.0
+    labels:
+      app.kubernetes.io/name: longhorn
+      app.kubernetes.io/instance: longhorn
+      app.kubernetes.io/version: v1.7.2
+      longhorn-manager: ""
+    name: backingimages.longhorn.io
+  spec:
+    conversion:
+      strategy: Webhook
+      webhook:
+        clientConfig:
+          service:
+            name: longhorn-conversion-webhook
+            namespace: longhorn-system
+            path: /v1/webhook/conversion
+            port: 9501
+        conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+    group: longhorn.io
+    names:
+      kind: BackingImage
+      listKind: BackingImageList
+      plural: backingimages
+      shortNames:
+      - lhbi
+      singular: backingimage
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - description: The backing image name
+        jsonPath: .spec.image
+        name: Image
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+      - description: The system generated UUID
+        jsonPath: .status.uuid
+        name: UUID
+        type: string
+      - description: The source of the backing image file data
+        jsonPath: .spec.sourceType
+        name: SourceType
+        type: string
+      - description: The backing image file size in each disk
+        jsonPath: .status.size
+        name: Size
+        type: string
+      - description: The virtual size of the image (may be larger than file size)
+        jsonPath: .status.virtualSize
+        name: VirtualSize
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackingImageSpec defines the desired state of the Longhorn
+                backing image
+              properties:
+                checksum:
+                  type: string
+                diskFileSpecMap:
+                  additionalProperties:
+                    properties:
+                      evictionRequested:
+                        type: boolean
+                    type: object
+                  type: object
+                diskSelector:
+                  items:
+                    type: string
+                  type: array
+                disks:
+                  additionalProperties:
+                    type: string
+                  description: Deprecated. We are now using DiskFileSpecMap to assign
+                    different spec to the file on different disks.
+                  type: object
+                minNumberOfCopies:
+                  type: integer
+                nodeSelector:
+                  items:
+                    type: string
+                  type: array
+                secret:
+                  type: string
+                secretNamespace:
+                  type: string
+                sourceParameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                sourceType:
+                  enum:
+                  - download
+                  - upload
+                  - export-from-volume
+                  - restore
+                  - clone
+                  type: string
+              type: object
+            status:
+              description: BackingImageStatus defines the observed state of the Longhorn
+                backing image status
+              properties:
+                checksum:
+                  type: string
+                diskFileStatusMap:
+                  additionalProperties:
+                    properties:
+                      lastStateTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      progress:
+                        type: integer
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                diskLastRefAtMap:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                ownerID:
+                  type: string
+                size:
+                  format: int64
+                  type: integer
+                uuid:
+                  type: string
+                virtualSize:
+                  description: Virtual size of image, which may be larger than physical
+                    size. Will be zero until known (e.g. while a backing image is uploading)
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  ```
+
+3. Start the upgrade process.
 
 ## Known issues
 

--- a/versioned_docs/version-v1.3/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.3/upgrade/v1-3-2-to-v1-4-0.md
@@ -14,6 +14,248 @@ An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvest
 
 For air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
 
+### Preventing Corruption of VM Images During Upgrade
+
+:::caution
+
+Before proceeding with the upgrade to Harvester **v1.4.0**, please make sure the **BackingImage** CRD is updated to the [Longhorn **v1.7.2** version](https://github.com/longhorn/longhorn/blob/v1.7.2/deploy/longhorn.yaml#L486-L690) beforehand.
+
+If this step is skipped, it may lead to backing image corruption, as described in this [known Longhorn issue](https://github.com/longhorn/longhorn/issues/10644).
+
+:::
+
+To prevent the issue from occurring, you can manually update the `BackingImage` CRD before upgrading Harvester.
+
+1. Patch the **Harvester managedchart** to avoid related errors and warnings.
+
+  ```sh
+  kubectl patch managedchart harvester \
+  -n fleet-local \
+  --type='json' \
+  -p='[
+    {
+      "op":"add",
+      "path":"/spec/diff/comparePatches/-",
+      "value": {
+        "apiVersion":"apiextensions.k8s.io/v1",
+        "jsonPointers":["/spec","/metadata/annotations", "/metadata/labels", "/status"],
+        "kind":"CustomResourceDefinition",
+        "name":"backingimages.longhorn.io"
+      }
+    }
+  ]'
+  ```
+
+1. Apply the **Longhorn v1.7.2** [`BackingImage` CRD](https://github.com/longhorn/longhorn/blob/v1.7.2/deploy/longhorn.yaml#L486-L690).
+
+  ```
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.15.0
+    labels:
+      app.kubernetes.io/name: longhorn
+      app.kubernetes.io/instance: longhorn
+      app.kubernetes.io/version: v1.7.2
+      longhorn-manager: ""
+    name: backingimages.longhorn.io
+  spec:
+    conversion:
+      strategy: Webhook
+      webhook:
+        clientConfig:
+          service:
+            name: longhorn-conversion-webhook
+            namespace: longhorn-system
+            path: /v1/webhook/conversion
+            port: 9501
+        conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+    group: longhorn.io
+    names:
+      kind: BackingImage
+      listKind: BackingImageList
+      plural: backingimages
+      shortNames:
+      - lhbi
+      singular: backingimage
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - description: The backing image name
+        jsonPath: .spec.image
+        name: Image
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+      - description: The system generated UUID
+        jsonPath: .status.uuid
+        name: UUID
+        type: string
+      - description: The source of the backing image file data
+        jsonPath: .spec.sourceType
+        name: SourceType
+        type: string
+      - description: The backing image file size in each disk
+        jsonPath: .status.size
+        name: Size
+        type: string
+      - description: The virtual size of the image (may be larger than file size)
+        jsonPath: .status.virtualSize
+        name: VirtualSize
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackingImageSpec defines the desired state of the Longhorn
+                backing image
+              properties:
+                checksum:
+                  type: string
+                diskFileSpecMap:
+                  additionalProperties:
+                    properties:
+                      evictionRequested:
+                        type: boolean
+                    type: object
+                  type: object
+                diskSelector:
+                  items:
+                    type: string
+                  type: array
+                disks:
+                  additionalProperties:
+                    type: string
+                  description: Deprecated. We are now using DiskFileSpecMap to assign
+                    different spec to the file on different disks.
+                  type: object
+                minNumberOfCopies:
+                  type: integer
+                nodeSelector:
+                  items:
+                    type: string
+                  type: array
+                secret:
+                  type: string
+                secretNamespace:
+                  type: string
+                sourceParameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                sourceType:
+                  enum:
+                  - download
+                  - upload
+                  - export-from-volume
+                  - restore
+                  - clone
+                  type: string
+              type: object
+            status:
+              description: BackingImageStatus defines the observed state of the Longhorn
+                backing image status
+              properties:
+                checksum:
+                  type: string
+                diskFileStatusMap:
+                  additionalProperties:
+                    properties:
+                      lastStateTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      progress:
+                        type: integer
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                diskLastRefAtMap:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                ownerID:
+                  type: string
+                size:
+                  format: int64
+                  type: integer
+                uuid:
+                  type: string
+                virtualSize:
+                  description: Virtual size of image, which may be larger than physical
+                    size. Will be zero until known (e.g. while a backing image is uploading)
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  ```
+
+3. Start the upgrade process.
 
 ## Known issues
 

--- a/versioned_docs/version-v1.4/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-3-2-to-v1-4-0.md
@@ -14,6 +14,248 @@ An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvest
 
 For air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
 
+### Preventing Corruption of VM Images During Upgrade
+
+:::caution
+
+Before proceeding with the upgrade to Harvester **v1.4.0**, please make sure the **BackingImage** CRD is updated to the [Longhorn **v1.7.2** version](https://github.com/longhorn/longhorn/blob/v1.7.2/deploy/longhorn.yaml#L486-L690) beforehand.
+
+If this step is skipped, it may lead to backing image corruption, as described in this [known Longhorn issue](https://github.com/longhorn/longhorn/issues/10644).
+
+:::
+
+To prevent the issue from occurring, you can manually update the `BackingImage` CRD before upgrading Harvester.
+
+1. Patch the **Harvester managedchart** to avoid related errors and warnings.
+
+  ```sh
+  kubectl patch managedchart harvester \
+  -n fleet-local \
+  --type='json' \
+  -p='[
+    {
+      "op":"add",
+      "path":"/spec/diff/comparePatches/-",
+      "value": {
+        "apiVersion":"apiextensions.k8s.io/v1",
+        "jsonPointers":["/spec","/metadata/annotations", "/metadata/labels", "/status"],
+        "kind":"CustomResourceDefinition",
+        "name":"backingimages.longhorn.io"
+      }
+    }
+  ]'
+  ```
+
+1. Apply the **Longhorn v1.7.2** [`BackingImage` CRD](https://github.com/longhorn/longhorn/blob/v1.7.2/deploy/longhorn.yaml#L486-L690).
+
+  ```
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.15.0
+    labels:
+      app.kubernetes.io/name: longhorn
+      app.kubernetes.io/instance: longhorn
+      app.kubernetes.io/version: v1.7.2
+      longhorn-manager: ""
+    name: backingimages.longhorn.io
+  spec:
+    conversion:
+      strategy: Webhook
+      webhook:
+        clientConfig:
+          service:
+            name: longhorn-conversion-webhook
+            namespace: longhorn-system
+            path: /v1/webhook/conversion
+            port: 9501
+        conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+    group: longhorn.io
+    names:
+      kind: BackingImage
+      listKind: BackingImageList
+      plural: backingimages
+      shortNames:
+      - lhbi
+      singular: backingimage
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - description: The backing image name
+        jsonPath: .spec.image
+        name: Image
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+      - description: The system generated UUID
+        jsonPath: .status.uuid
+        name: UUID
+        type: string
+      - description: The source of the backing image file data
+        jsonPath: .spec.sourceType
+        name: SourceType
+        type: string
+      - description: The backing image file size in each disk
+        jsonPath: .status.size
+        name: Size
+        type: string
+      - description: The virtual size of the image (may be larger than file size)
+        jsonPath: .status.virtualSize
+        name: VirtualSize
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackingImageSpec defines the desired state of the Longhorn
+                backing image
+              properties:
+                checksum:
+                  type: string
+                diskFileSpecMap:
+                  additionalProperties:
+                    properties:
+                      evictionRequested:
+                        type: boolean
+                    type: object
+                  type: object
+                diskSelector:
+                  items:
+                    type: string
+                  type: array
+                disks:
+                  additionalProperties:
+                    type: string
+                  description: Deprecated. We are now using DiskFileSpecMap to assign
+                    different spec to the file on different disks.
+                  type: object
+                minNumberOfCopies:
+                  type: integer
+                nodeSelector:
+                  items:
+                    type: string
+                  type: array
+                secret:
+                  type: string
+                secretNamespace:
+                  type: string
+                sourceParameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                sourceType:
+                  enum:
+                  - download
+                  - upload
+                  - export-from-volume
+                  - restore
+                  - clone
+                  type: string
+              type: object
+            status:
+              description: BackingImageStatus defines the observed state of the Longhorn
+                backing image status
+              properties:
+                checksum:
+                  type: string
+                diskFileStatusMap:
+                  additionalProperties:
+                    properties:
+                      lastStateTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      progress:
+                        type: integer
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                diskLastRefAtMap:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                ownerID:
+                  type: string
+                size:
+                  format: int64
+                  type: integer
+                uuid:
+                  type: string
+                virtualSize:
+                  description: Virtual size of image, which may be larger than physical
+                    size. Will be zero until known (e.g. while a backing image is uploading)
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  ```
+
+3. Start the upgrade process.
 
 ## Known issues
 


### PR DESCRIPTION
Related issue https://github.com/harvester/harvester/issues/7958