### PR TITLE
[DOCS] Add important note about RBAC usage

### DIFF
--- a/docs/rancher/virtualization-management.md
+++ b/docs/rancher/virtualization-management.md
@@ -139,6 +139,13 @@ Both global permissions and cluster and project roles are implemented on top of 
 - A cluster owner has full control over the cluster and all resources inside it, e.g., hosts, VMs, volumes, images, networks, backups, and settings.
 - A project user can be assigned to a specific project with permission to manage the resources inside the project.
 
+:::important
+
+It is strongly recommended to use the built-in role templates and project-scoped RBAC to manage user access. 
+
+Harvester implements its own RBAC model on top of Kubernetes and KubeVirt, integrating with Rancher-style Projects and multi-tenancy logic. During upgrades or reconfiguration, custom `RoleBindings` referencing only `kubevirt.io` roles may be lost, reset, or become inconsistent with Harvester's internal state.
+
+If CLI-only access to specific namespaces is required, you may combine Harvester roles with Kubernetes-native RBAC — but always ensure Harvester-specific CRDs are included.
 
 ### Multi-Tenancy Example
 The following example provides a good explanation of how the multi-tenant feature works:

--- a/docs/rancher/virtualization-management.md
+++ b/docs/rancher/virtualization-management.md
@@ -145,8 +145,6 @@ It is strongly recommended to use the built-in role templates and project-scoped
 
 Harvester implements its own RBAC model on top of Kubernetes and KubeVirt, integrating with Rancher-style Projects and multi-tenancy logic. During upgrades or reconfiguration, custom `RoleBindings` referencing only `kubevirt.io` roles may be lost, reset, or become inconsistent with Harvester's internal state.
 
-If CLI-only access to specific namespaces is required, you may combine Harvester roles with Kubernetes-native RBAC — but always ensure Harvester-specific CRDs are included.
-
 ### Multi-Tenancy Example
 The following example provides a good explanation of how the multi-tenant feature works:
 

--- a/docs/rancher/virtualization-management.md
+++ b/docs/rancher/virtualization-management.md
@@ -141,9 +141,11 @@ Both global permissions and cluster and project roles are implemented on top of 
 
 :::important
 
-It is strongly recommended to use the built-in role templates and project-scoped RBAC to manage user access. 
+Managing user access using the built-in role templates and project-scoped RBAC is strongly recommended.
 
 Harvester implements its own RBAC model on top of Kubernetes and KubeVirt, integrating with Rancher-style Projects and multi-tenancy logic. During upgrades or reconfiguration, custom `RoleBindings` referencing only `kubevirt.io` roles may be lost, reset, or become inconsistent with Harvester's internal state.
+
+:::
 
 ### Multi-Tenancy Example
 The following example provides a good explanation of how the multi-tenant feature works:

--- a/docs/rancher/virtualization-management.md
+++ b/docs/rancher/virtualization-management.md
@@ -139,7 +139,7 @@ Both global permissions and cluster and project roles are implemented on top of 
 - A cluster owner has full control over the cluster and all resources inside it, e.g., hosts, VMs, volumes, images, networks, backups, and settings.
 - A project user can be assigned to a specific project with permission to manage the resources inside the project.
 
-:::important
+:::info important
 
 Managing user access using the built-in role templates and project-scoped RBAC is strongly recommended.
 

--- a/versioned_docs/version-v1.3/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.3/rancher/virtualization-management.md
@@ -82,6 +82,13 @@ Both global permissions and cluster and project roles are implemented on top of 
 - A cluster owner has full control over the cluster and all resources inside it, e.g., hosts, VMs, volumes, images, networks, backups, and settings.
 - A project user can be assigned to a specific project with permission to manage the resources inside the project.
 
+:::info important
+
+Managing user access using the built-in role templates and project-scoped RBAC is strongly recommended.
+
+Harvester implements its own RBAC model on top of Kubernetes and KubeVirt, integrating with Rancher-style Projects and multi-tenancy logic. During upgrades or reconfiguration, custom `RoleBindings` referencing only `kubevirt.io` roles may be lost, reset, or become inconsistent with Harvester's internal state.
+
+:::
 
 ### Multi-Tenancy Example
 The following example provides a good explanation of how the multi-tenant feature works:

--- a/versioned_docs/version-v1.4/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.4/rancher/virtualization-management.md
@@ -139,6 +139,13 @@ Both global permissions and cluster and project roles are implemented on top of 
 - A cluster owner has full control over the cluster and all resources inside it, e.g., hosts, VMs, volumes, images, networks, backups, and settings.
 - A project user can be assigned to a specific project with permission to manage the resources inside the project.
 
+:::info important
+
+Managing user access using the built-in role templates and project-scoped RBAC is strongly recommended.
+
+Harvester implements its own RBAC model on top of Kubernetes and KubeVirt, integrating with Rancher-style Projects and multi-tenancy logic. During upgrades or reconfiguration, custom `RoleBindings` referencing only `kubevirt.io` roles may be lost, reset, or become inconsistent with Harvester's internal state.
+
+:::
 
 ### Multi-Tenancy Example
 The following example provides a good explanation of how the multi-tenant feature works:


### PR DESCRIPTION
Signed-off-by: Alexandra Settle <asettle@suse.com>

This addendum to the docs is after discovering certain users were leveraging kubevirt.io but then losing all their RBAC-related configurations during upgrades.

I'm not too sure if we should be advising customers to edit the Harvester CRDs alongside the Kubevirt roles but it's a workaround for now while we work to improve the default RBAC roles. 