### PR TITLE
doc(upgrade): delete fluentd pod to avoid waiting backoff time

### DIFF
--- a/docs/upgrade/v1-4-2-to-v1-5-0.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-0.md
@@ -84,18 +84,18 @@ To fix the issue, perform any of the following actions:
 
   ```bash
   # Get the Logging CR names
-  OPERATOR_LOGGING_NAME=$(kubectl get logging -l app.kubernetes.io/name=rancher-logging -o jsonpath="{.items[0].metadata.name}")
-  INFRA_LOGGING_NAME=$(kubectl get logging -l harvesterhci.io/upgradeLogComponent=infra -o jsonpath="{.items[0].metadata.name}")
+  OPERATOR_LOGGING_NAME=$(kubectl get loggings -l app.kubernetes.io/name=rancher-logging -o jsonpath="{.items[0].metadata.name}")
+  INFRA_LOGGING_NAME=$(kubectl get loggings -l harvesterhci.io/upgradeLogComponent=infra -o jsonpath="{.items[0].metadata.name}")
 
   # Gather image info from operator's Logging CR
-  FLUENTD_IMAGE_REPO=$(kubectl get logging $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.image.repository}")
-  FLUENTD_IMAGE_TAG=$(kubectl get logging $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.image.tag}")
+  FLUENTD_IMAGE_REPO=$(kubectl get loggings $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.image.repository}")
+  FLUENTD_IMAGE_TAG=$(kubectl get loggings $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.image.tag}")
 
-  FLUENTBIT_IMAGE_REPO=$(kubectl get logging $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentbit.image.repository}")
-  FLUENTBIT_IMAGE_TAG=$(kubectl get logging $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentbit.image.tag}")
+  FLUENTBIT_IMAGE_REPO=$(kubectl get loggings $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentbit.image.repository}")
+  FLUENTBIT_IMAGE_TAG=$(kubectl get loggings $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentbit.image.tag}")
 
-  CONFIG_RELOADER_IMAGE_REPO=$(kubectl get logging $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.configReloaderImage.repository}")
-  CONFIG_RELOADER_IMAGE_TAG=$(kubectl get logging $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.configReloaderImage.tag}")
+  CONFIG_RELOADER_IMAGE_REPO=$(kubectl get loggings $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.configReloaderImage.repository}")
+  CONFIG_RELOADER_IMAGE_TAG=$(kubectl get loggings $OPERATOR_LOGGING_NAME -o jsonpath="{.spec.fluentd.configReloaderImage.tag}")
 
   # Patch the Logging CR
   kubectl patch logging $INFRA_LOGGING_NAME --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/fluentbit/image\",\"value\":{\"repository\":\"$FLUENTBIT_IMAGE_REPO\",\"tag\":\"$FLUENTBIT_IMAGE_TAG\"}}]"
@@ -103,7 +103,14 @@ To fix the issue, perform any of the following actions:
   kubectl patch logging $INFRA_LOGGING_NAME --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/fluentd/configReloaderImage\",\"value\":{\"repository\":\"$CONFIG_RELOADER_IMAGE_REPO\",\"tag\":\"$CONFIG_RELOADER_IMAGE_TAG\"}}]"
   ```
 
-  The status of the Fluentd and Fluent Bit pods should change to `Running` and the upgrade process should continue after the Logging CR is updated.
+  The status of the Fluentd and Fluent Bit pods should change to `Running` in a moment and the upgrade process should continue after the Logging CR is updated. If the Fluentd pod is still in the `ImagePullBackOff` status, try deleting it with the following command to force it to restart:
+
+  ```bash
+  UPGRADE_NAME=$(kubectl -n harvester-system get upgrades -l harvesterhci.io/latestUpgrade=true -o jsonpath='{.items[0].metadata.name}')
+  UPGRADELOG_NAME=$(kubectl -n harvester-system get upgradelogs -l harvesterhci.io/upgrade=$UPGRADE_NAME -o jsonpath='{.items[0].metadata.name}')
+
+  kubectl -n harvester-system delete pods -l harvesterhci.io/upgradeLog=$UPGRADELOG_NAME,harvesterhci.io/upgradeLogComponent=aggregator
+  ```
 
 - On a computer with internet access, pull the required container images and then export them to a TAR file. Next, transfer the TAR file to the cluster nodes and then import the images by running the following comands on each node:
 


### PR DESCRIPTION
This is a supplement PR following PR #759. Users may want to avoid waiting for the logging-operator to reconcile the stuck fluentd pod. They can optionally delete the pod for an immediate restart. Thanks to the heads-up from @TachunLin!

Related issue: harvester/harvester#7955
