### PR TITLE
Add harvester-ui-extension 1.0.6 support matrix

### DIFF
--- a/docs/rancher/harvester-ui-extension.md
+++ b/docs/rancher/harvester-ui-extension.md
@@ -29,10 +29,10 @@ Versions of the Harvester operating system and the Harvester UI Extension will a
 
 | Harvester Cluster         | Harvester UI Extension          | Minimum supported Rancher  |
 | --------------------------| ------------------------------- | ------------------------   |
-| v1.3.0, v1.3.1,  v1.3.2   | v1.0.2                          | Rancher 2.10.1             |
+| v1.3.0, v1.3.1, v1.3.2    | v1.0.2                          | Rancher 2.10.1             |
 | v1.4.1                    | v1.0.3                          | Rancher 2.10.1             |
-| v1.4.2                    | v1.0.4                          | Rancher 2.10.1             |
-| v1.4.2                    | v1.0.5                          | Rancher 2.10.1             |
+| v1.4.2                    | v1.0.4, v1.0.5                  | Rancher 2.10.1             |
+| v1.4.3                    | v1.0.6                          | Rancher 2.10.1             |
 | v1.5.0                    | v1.5.0                          | Rancher 2.11.0             |
 
 Installing the extension over the network is not possible in air-gapped environments, so you must perform the workaround outlined in [Harvester UI Extension with Rancher Integration](/v1.5/airgap#harvester-ui-extension-with-rancher-integration).

--- a/versioned_docs/version-v1.3/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.3/rancher/harvester-ui-extension.md
@@ -29,7 +29,7 @@ Versions of the Harvester operating system and the Harvester UI Extension will a
 
 | Harvester Cluster         | Harvester UI Extension          | Minimum supported Rancher  |
 | --------------------------| ------------------------------- | ------------------------   |
-| v1.3.0, v1.3.1,  v1.3.2   | v1.0.2                          | Rancher 2.10.1             |
+| v1.3.0, v1.3.1, v1.3.2    | v1.0.2                          | Rancher 2.10.1             |
 
 Installing the extension over the network is not possible in air-gapped environments, so you must perform the workaround outlined in [Harvester UI Extension with Rancher Integration](/v1.3/airgap#harvester-ui-extension-with-rancher-integration).
 

--- a/versioned_docs/version-v1.4/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.4/rancher/harvester-ui-extension.md
@@ -31,8 +31,8 @@ Versions of the Harvester operating system and the Harvester UI Extension will a
 | --------------------------| ------------------------------- | ------------------------   |
 | v1.3.0, v1.3.1,  v1.3.2   | v1.0.2                          | Rancher 2.10.1             |
 | v1.4.1                    | v1.0.3                          | Rancher 2.10.1             |
-| v1.4.2                    | v1.0.4                          | Rancher 2.10.1             |
-| v1.4.2                    | v1.0.5                          | Rancher 2.10.1             |
+| v1.4.2                    | v1.0.4, v1.0.5                  | Rancher 2.10.1             |
+| v1.4.3                    | v1.0.6                          | Rancher 2.10.1             |
 
 Installing the extension over the network is not possible in air-gapped environments, so you must perform the workaround outlined in [Harvester UI Extension with Rancher Integration](/v1.4/airgap#harvester-ui-extension-with-rancher-integration).
 

--- a/versioned_docs/version-v1.5/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.5/rancher/harvester-ui-extension.md
@@ -29,10 +29,10 @@ Versions of the Harvester operating system and the Harvester UI Extension will a
 
 | Harvester Cluster         | Harvester UI Extension          | Minimum supported Rancher  |
 | --------------------------| ------------------------------- | ------------------------   |
-| v1.3.0, v1.3.1,  v1.3.2   | v1.0.2                          | Rancher 2.10.1             |
+| v1.3.0, v1.3.1, v1.3.2    | v1.0.2                          | Rancher 2.10.1             |
 | v1.4.1                    | v1.0.3                          | Rancher 2.10.1             |
-| v1.4.2                    | v1.0.4                          | Rancher 2.10.1             |
-| v1.4.2                    | v1.0.5                          | Rancher 2.10.1             |
+| v1.4.2                    | v1.0.4, v1.0.5                  | Rancher 2.10.1             |
+| v1.4.3                    | v1.0.6                          | Rancher 2.10.1             |
 | v1.5.0                    | v1.5.0                          | Rancher 2.11.0             |
 
 Installing the extension over the network is not possible in air-gapped environments, so you must perform the workaround outlined in [Harvester UI Extension with Rancher Integration](/v1.5/airgap#harvester-ui-extension-with-rancher-integration).


### PR DESCRIPTION
#### Problem:
Add harvester-ui-extension 1.0.6 support matrix.

We can merge this PR after harvester 1.4.3 release.

#### Solution: 
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8193

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
