### PR TITLE
Update upgrade matrix and known issues for v1.4.3 release

### DIFF
--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -22,7 +22,8 @@ The following table shows the upgrade path of all supported versions.
 
 | Upgrade from version | Supported new version(s) |
 |----------------------|--------------------------|
-| [v1.4.2](./v1-4-2-to-v1-5-0.md) | v1.5.0        |
+| [v1.4.2/v1.4.3](./v1-4-2-to-v1-5-0.md) | v1.5.0        |
+| [v1.4.1/v1.4.2](./v1-4-1-to-v1-4-3.md) | v1.4.3        |
 | [v1.4.1](./v1-4-1-to-v1-4-2.md) | v1.4.2        |
 | [v1.4.0](./v1-4-0-to-v1-4-1.md) | v1.4.1        |
 | [v1.3.2](./v1-3-2-to-v1-4-0.md) | v1.4.0        |

--- a/docs/upgrade/v1-4-1-to-v1-4-3.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-3.md
@@ -12,6 +12,8 @@ title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 
 An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvester version that you can upgrade to becomes available. For more information, see [Start an upgrade](./automatic.md#start-an-upgrade).
 
+Harvester v1.4.2 and v1.4.3 use the same minor version of RKE2 (v1.31). This makes it possible to upgrade directly from Harvester v1.4.1 to v1.4.3, without needing to upgrade to v1.4.2 first.
+
 For air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
 
 ## Known issues

--- a/docs/upgrade/v1-4-1-to-v1-4-3.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-3.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 3
-sidebar_label: Upgrade from v1.4.2 to v1.4.3
-title: "Upgrade from v1.4.2 to v1.4.3"
+sidebar_label: Upgrade from v1.4.1/v1.4.2 to v1.4.3
+title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/v1-4-2-to-v1-4-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General information

--- a/docs/upgrade/v1-4-1-to-v1-4-3.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-3.md
@@ -108,3 +108,38 @@ To fix the issue, perform any of the following actions:
 
 Related issues:
 - [[BUG] AirGap Upgrades Seem Blocked with Fluentbit/FluentD](https://github.com/harvester/harvester/issues/7955)
+
+### 2. Oversized Volumes
+
+In Harvester v1.4.3, which uses Longhorn v1.7.3, oversized volumes (for example, 999999 Gi in size) are marked **Not Ready** and cannot be deleted.
+
+To resolve this issue, perform the following steps:
+
+1. Temporarily remove the PVC webhook rule.
+
+   ```bash
+   RULE_INDEX=$(kubectl get \
+     validatingwebhookconfiguration longhorn-webhook-validator -o json \
+     | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
+   
+   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+     --type='json' \
+     -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   ```
+
+1. Wait for the related PVC to be deleted.
+
+1. Restore the PVC webhook rule to re-enable validation.
+
+   ```bash
+   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+     --type='json' \
+     -p='[{"op": "add", "path": "/webhooks/0/rules/-", "value": {"apiGroups":[""],"apiVersions":["v1"],"operations":["UPDATE"],"resources":["persistentvolumeclaims"],"scope":"Namespaced"}}]'
+   ```
+
+The issue will be addressed in Longhorn v1.8.2, which will likely be included in Harvester v1.5.1.
+
+Related issues:
+- Harvester: [Issue #8096](https://github.com/harvester/harvester/issues/8096)
+- Longhorn: [Issue #10741](https://github.com/longhorn/longhorn/issues/10741)
+

--- a/docs/upgrade/v1-4-1-to-v1-4-3.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-3.md
@@ -124,9 +124,11 @@ To resolve this issue, perform the following steps:
      validatingwebhookconfiguration longhorn-webhook-validator -o json \
      | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
    
-   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
-     --type='json' \
-     -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   if [ -n "$RULE_INDEX" -a "$RULE_INDEX" != "null" ]; then
+     kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+       --type='json' \
+       -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   fi
    ```
 
 1. Wait for the related PVC to be deleted.

--- a/docs/upgrade/v1-4-2-to-v1-5-0.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-0.md
@@ -12,6 +12,8 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 
 An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvester version that you can upgrade to becomes available. For more information, see [Start an upgrade](./automatic.md#start-an-upgrade).
 
+Harvester v1.4.2 and v1.4.3 use the same minor version of RKE2 (v1.31). This makes it possible to upgrade directly from Harvester v1.4.2 to v1.5.0, without needing to upgrade to v1.4.3 first.
+
 For air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
 
 ### Update Harvester UI Extension on Rancher v2.11.0

--- a/docs/upgrade/v1-4-2-to-v1-5-0.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-0.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
-sidebar_label: Upgrade from v1.4.2 to v1.5.0
-title: "Upgrade from v1.4.2 to v1.5.0"
+sidebar_label: Upgrade from v1.4.2/v1.4.3 to v1.5.0
+title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 ---
 
 <head>

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -42,9 +42,11 @@ To resolve this issue, perform the following steps:
      validatingwebhookconfiguration longhorn-webhook-validator -o json \
      | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
    
-   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
-     --type='json' \
-     -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   if [ -n "$RULE_INDEX" -a "$RULE_INDEX" != "null" ]; then
+     kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+       --type='json' \
+       -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   fi
    ```
 
 1. Wait for the related PVC to be deleted.

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -38,9 +38,13 @@ To resolve this issue, perform the following steps:
 1. Temporarily remove the PVC webhook rule.
 
    ```bash
+   RULE_INDEX=$(kubectl get \
+     validatingwebhookconfiguration longhorn-webhook-validator -o json \
+     | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
+   
    kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
      --type='json' \
-     -p='[{"op": "remove", "path": "/webhooks/0/rules/17"}]'
+     -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
    ```
 
 1. Wait for the related PVC to be deleted.

--- a/versioned_docs/version-v1.4/upgrade/automatic.md
+++ b/versioned_docs/version-v1.4/upgrade/automatic.md
@@ -22,6 +22,7 @@ The following table shows the upgrade path of all supported versions.
 
 | Upgrade from version | Supported new version(s) |
 |----------------------|--------------------------|
+| [v1.4.1/v1.4.2](./v1-4-1-to-v1-4-3.md) | v1.4.3        |
 | [v1.4.1](./v1-4-1-to-v1-4-2.md) | v1.4.2        |
 | [v1.4.0](./v1-4-0-to-v1-4-1.md) | v1.4.1        |
 | [v1.3.2](./v1-3-2-to-v1-4-0.md) | v1.4.0        |

--- a/versioned_docs/version-v1.4/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.4/upgrade/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 sidebar_label: Troubleshooting
 title: "Troubleshooting"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-1-2-to-v1-2-0.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 sidebar_label: Upgrade from v1.1.2 to v1.2.0 (not recommended)
 title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-2-0-to-v1-2-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 sidebar_label: Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1
 title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-2-1-to-v1-2-2.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-2-1-to-v1-2-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Upgrade from v1.2.1 to v1.2.2
 title: "Upgrade from v1.2.1 to v1.2.2"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-2-2-to-v1-3-1.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-2-2-to-v1-3-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 sidebar_label: Upgrade from v1.2.2/v1.3.0 to v1.3.1
 title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-3-1-to-v1-3-2.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-3-1-to-v1-3-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 sidebar_label: Upgrade from v1.3.1 to v1.3.2
 title: "Upgrade from v1.3.1 to v1.3.2"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-3-2-to-v1-4-0.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Upgrade from v1.3.2 to v1.4.0
 title: "Upgrade from v1.3.2 to v1.4.0"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-4-0-to-v1-4-1.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-4-0-to-v1-4-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Upgrade from v1.4.0 to v1.4.1
 title: "Upgrade from v1.4.0 to v1.4.1"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-2.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: Upgrade from v1.4.1 to v1.4.2
 title: "Upgrade from v1.4.1 to v1.4.2"
 ---

--- a/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-3.md
@@ -1,54 +1,26 @@
 ---
 sidebar_position: 2
-sidebar_label: Upgrade from v1.4.2/v1.4.3 to v1.5.0
-title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
+sidebar_label: Upgrade from v1.4.1/v1.4.2 to v1.4.3
+title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/v1-4-2-to-v1-5-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General information
 
 An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvester version that you can upgrade to becomes available. For more information, see [Start an upgrade](./automatic.md#start-an-upgrade).
 
-Harvester v1.4.2 and v1.4.3 use the same minor version of RKE2 (v1.31). This makes it possible to upgrade directly from Harvester v1.4.2 to v1.5.0, without needing to upgrade to v1.4.3 first.
+Harvester v1.4.2 and v1.4.3 use the same minor version of RKE2 (v1.31). This makes it possible to upgrade directly from Harvester v1.4.1 to v1.4.3, without needing to upgrade to v1.4.2 first.
 
 For air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
-
-### Update Harvester UI Extension on Rancher v2.11.0
-
-To import Harvester v1.5.0 clusters on Rancher v2.11.0, you must use **v1.5.0** of the Rancher UI extension for Harvester.
-
-
-1. On the Rancher UI, go to **local > Apps > Repositories**.
-
-1. Locate the repository named **harvester**, and then select **⋮ > Refresh**.
-
-1. Go to the **Extensions** screen.
-
-1. Locate the extension named **Harvester**, and then click **Update**.
-
-1. Select version **1.5.0**, and then click **Update**.
-
-1. Allow some time for the extension to be updated, and then refresh the screen.
 
 ## Known issues
 
 ---
 
-### 1. Management URL status is "NotReady" during upgrade
-
-The Harvester console on some nodes may display `Status: NotReady` while the upgrade is in progress.
-
-![](/img/v1.4/upgrade/cluster-management-url-not-ready.png)
-
-The correct status is displayed after the upgrade to v1.5.0 is completed.
-
-Related issues:
-  - [[BUG] Harvester cluster status keep in NotReady on the second joined node from iso installation](https://github.com/harvester/harvester/issues/7963)
-
-### 2. Air-gapped upgrade stuck with `ImagePullBackOff` error in Fluentd and Fluent Bit pods
+### 1. Air-gapped upgrade stuck with `ImagePullBackOff` error in Fluentd and Fluent Bit pods
 
 The upgrade may become stuck at the very beginning of the process, as indicated by 0% progress and items marked **Pending** in the **Upgrade** dialog of the Harvester UI.
 
@@ -139,70 +111,39 @@ To fix the issue, perform any of the following actions:
 Related issues:
 - [[BUG] AirGap Upgrades Seem Blocked with Fluentbit/FluentD](https://github.com/harvester/harvester/issues/7955)
 
+### 2. Oversized Volumes
 
-### 3. Upgrade stuck on waiting for `mcc-harvester` bundle CR
+In Harvester v1.4.3, which uses Longhorn v1.7.3, oversized volumes (for example, 999999 Gi in size) are marked **Not Ready** and cannot be deleted.
 
-When you upgrade from an old Harvester version (such `v1.0.x`, `v1.1.x`, and `v1.2.x`), the upgrade process may become stuck on waiting for the `mcc-harvester` bundle CR to become ready.
+To resolve this issue, perform the following steps:
 
-```shell
-> kubectl get bundles -n fleet-local
-NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
-mcc-harvester                                 0/1                       Modified(1) [Cluster fleet-local/local]; kubevirt.kubevirt.io harvester-system/kubevirt modified {"spec":{"configuration":{"vmStateStorageClass":"vmstate-persistence"}}}
-```
+1. Temporarily remove the PVC webhook rule.
 
-The root cause is that the latest `dependency_charts` CRDs were not applied, which occurred because Helm does not manage CRDs for Harvester. To allow the upgrade to continue, run the following script:
+   ```bash
+   RULE_INDEX=$(kubectl get \
+     validatingwebhookconfiguration longhorn-webhook-validator -o json \
+     | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
+   
+   if [ -n "$RULE_INDEX" -a "$RULE_INDEX" != "null" ]; then
+     kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+       --type='json' \
+       -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   fi
+   ```
 
-```shell
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/kubevirt-operator/crds/crd-kubevirt.yaml
+1. Wait for the related PVC to be deleted.
 
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/csi-snapshotter/crds/volumesnapshotclasses.yaml
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/csi-snapshotter/crds/volumesnapshotcontents.yaml
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/csi-snapshotter/crds/volumesnapshots.yaml
+1. Restore the PVC webhook rule to re-enable validation.
 
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_ippools.yaml
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
-```
+   ```bash
+   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+     --type='json' \
+     -p='[{"op": "add", "path": "/webhooks/0/rules/-", "value": {"apiGroups":[""],"apiVersions":["v1"],"operations":["UPDATE"],"resources":["persistentvolumeclaims"],"scope":"Namespaced"}}]'
+   ```
 
-After five minutes, check the status in the `mcc-harvester` bundle CR of `bundle.fleet.cattle.io/v1alpha1`. If the same error is still displayed, you must resync the bundle CR using the following script:
+The issue will be addressed in Longhorn v1.8.2, which will likely be included in Harvester v1.5.1.
 
-```shell
-#!/bin/bash
+Related issues:
+- Harvester: [Issue #8096](https://github.com/harvester/harvester/issues/8096)
+- Longhorn: [Issue #10741](https://github.com/longhorn/longhorn/issues/10741)
 
-patch_fleet_bundle() {
-  local bundleName=$1
-  local generation=$(kubectl get -n fleet-local bundle ${bundleName} -o jsonpath='{.spec.forceSyncGeneration}')
-  local new_generation=$((generation+1))
-  patch_manifest="$(mktemp)"
-  cat > "$patch_manifest" <<EOF
-{
-  "spec": {
-    "forceSyncGeneration": $new_generation
-  }
-}
-EOF
-  echo "patch bundle to new generation: $new_generation"
-  kubectl patch -n fleet-local bundle ${bundleName}  --type=merge --patch-file $patch_manifest
-  rm -f $patch_manifest
-}
-
-for bundle in mcc-harvester
-do
-  patch_fleet_bundle ${bundle}
-done
-```
-
-You must also ensure that the `cdi` CRD exists.
-
-```shell
-> kubectl get bundle -n fleet-local
-NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
-fleet-local   mcc-harvester                                 0/1                       Modified(1) [Cluster fleet-local/local]; cdi.cdi.kubevirt.io cdi missing
-```
-
-If the `cdi` CRD exists, run the `patch_fleet_bundle` script to resync the `mcc-harvester` bundle CR. Otherwise, run the following script to create the `cdi` CRD:
-
-  ```shell
-  kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/cdi/crds/cdi.yaml
-  ```
-
-Related issue: [#8163](https://github.com/harvester/harvester/issues/8163)

--- a/versioned_docs/version-v1.4/volume/create-volume.md
+++ b/versioned_docs/version-v1.4/volume/create-volume.md
@@ -42,9 +42,11 @@ To resolve this issue, perform the following steps:
      validatingwebhookconfiguration longhorn-webhook-validator -o json \
      | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
    
-   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
-     --type='json' \
-     -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   if [ -n "$RULE_INDEX" -a "$RULE_INDEX" != "null" ]; then
+     kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+       --type='json' \
+       -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   fi
    ```
 
 1. Wait for the related PVC to be deleted.

--- a/versioned_docs/version-v1.5/upgrade/automatic.md
+++ b/versioned_docs/version-v1.5/upgrade/automatic.md
@@ -22,7 +22,8 @@ The following table shows the upgrade path of all supported versions.
 
 | Upgrade from version | Supported new version(s) |
 |----------------------|--------------------------|
-| [v1.4.2](./v1-4-2-to-v1-5-0.md) | v1.5.0        |
+| [v1.4.2/v1.4.3](./v1-4-2-to-v1-5-0.md) | v1.5.0        |
+| [v1.4.1/v1.4.2](./v1-4-1-to-v1-4-3.md) | v1.4.3        |
 | [v1.4.1](./v1-4-1-to-v1-4-2.md) | v1.4.2        |
 | [v1.4.0](./v1-4-0-to-v1-4-1.md) | v1.4.1        |
 | [v1.3.2](./v1-3-2-to-v1-4-0.md) | v1.4.0        |

--- a/versioned_docs/version-v1.5/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.5/upgrade/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: Troubleshooting
 title: "Troubleshooting"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-1-2-to-v1-2-0.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 sidebar_label: Upgrade from v1.1.2 to v1.2.0 (not recommended)
 title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-2-0-to-v1-2-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 sidebar_label: Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1
 title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-2-1-to-v1-2-2.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-2-1-to-v1-2-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 sidebar_label: Upgrade from v1.2.1 to v1.2.2
 title: "Upgrade from v1.2.1 to v1.2.2"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-2-2-to-v1-3-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-2-2-to-v1-3-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Upgrade from v1.2.2/v1.3.0 to v1.3.1
 title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-3-1-to-v1-3-2.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-3-1-to-v1-3-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 sidebar_label: Upgrade from v1.3.1 to v1.3.2
 title: "Upgrade from v1.3.1 to v1.3.2"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-3-2-to-v1-4-0.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 sidebar_label: Upgrade from v1.3.2 to v1.4.0
 title: "Upgrade from v1.3.2 to v1.4.0"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-4-0-to-v1-4-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-0-to-v1-4-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Upgrade from v1.4.0 to v1.4.1
 title: "Upgrade from v1.4.0 to v1.4.1"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-2.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Upgrade from v1.4.1 to v1.4.2
 title: "Upgrade from v1.4.1 to v1.4.2"
 ---

--- a/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-3.md
@@ -1,54 +1,26 @@
 ---
-sidebar_position: 2
-sidebar_label: Upgrade from v1.4.2/v1.4.3 to v1.5.0
-title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
+sidebar_position: 3
+sidebar_label: Upgrade from v1.4.1/v1.4.2 to v1.4.3
+title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/v1-4-2-to-v1-5-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General information
 
 An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvester version that you can upgrade to becomes available. For more information, see [Start an upgrade](./automatic.md#start-an-upgrade).
 
-Harvester v1.4.2 and v1.4.3 use the same minor version of RKE2 (v1.31). This makes it possible to upgrade directly from Harvester v1.4.2 to v1.5.0, without needing to upgrade to v1.4.3 first.
+Harvester v1.4.2 and v1.4.3 use the same minor version of RKE2 (v1.31). This makes it possible to upgrade directly from Harvester v1.4.1 to v1.4.3, without needing to upgrade to v1.4.2 first.
 
 For air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
-
-### Update Harvester UI Extension on Rancher v2.11.0
-
-To import Harvester v1.5.0 clusters on Rancher v2.11.0, you must use **v1.5.0** of the Rancher UI extension for Harvester.
-
-
-1. On the Rancher UI, go to **local > Apps > Repositories**.
-
-1. Locate the repository named **harvester**, and then select **⋮ > Refresh**.
-
-1. Go to the **Extensions** screen.
-
-1. Locate the extension named **Harvester**, and then click **Update**.
-
-1. Select version **1.5.0**, and then click **Update**.
-
-1. Allow some time for the extension to be updated, and then refresh the screen.
 
 ## Known issues
 
 ---
 
-### 1. Management URL status is "NotReady" during upgrade
-
-The Harvester console on some nodes may display `Status: NotReady` while the upgrade is in progress.
-
-![](/img/v1.4/upgrade/cluster-management-url-not-ready.png)
-
-The correct status is displayed after the upgrade to v1.5.0 is completed.
-
-Related issues:
-  - [[BUG] Harvester cluster status keep in NotReady on the second joined node from iso installation](https://github.com/harvester/harvester/issues/7963)
-
-### 2. Air-gapped upgrade stuck with `ImagePullBackOff` error in Fluentd and Fluent Bit pods
+### 1. Air-gapped upgrade stuck with `ImagePullBackOff` error in Fluentd and Fluent Bit pods
 
 The upgrade may become stuck at the very beginning of the process, as indicated by 0% progress and items marked **Pending** in the **Upgrade** dialog of the Harvester UI.
 
@@ -139,70 +111,39 @@ To fix the issue, perform any of the following actions:
 Related issues:
 - [[BUG] AirGap Upgrades Seem Blocked with Fluentbit/FluentD](https://github.com/harvester/harvester/issues/7955)
 
+### 2. Oversized Volumes
 
-### 3. Upgrade stuck on waiting for `mcc-harvester` bundle CR
+In Harvester v1.4.3, which uses Longhorn v1.7.3, oversized volumes (for example, 999999 Gi in size) are marked **Not Ready** and cannot be deleted.
 
-When you upgrade from an old Harvester version (such `v1.0.x`, `v1.1.x`, and `v1.2.x`), the upgrade process may become stuck on waiting for the `mcc-harvester` bundle CR to become ready.
+To resolve this issue, perform the following steps:
 
-```shell
-> kubectl get bundles -n fleet-local
-NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
-mcc-harvester                                 0/1                       Modified(1) [Cluster fleet-local/local]; kubevirt.kubevirt.io harvester-system/kubevirt modified {"spec":{"configuration":{"vmStateStorageClass":"vmstate-persistence"}}}
-```
+1. Temporarily remove the PVC webhook rule.
 
-The root cause is that the latest `dependency_charts` CRDs were not applied, which occurred because Helm does not manage CRDs for Harvester. To allow the upgrade to continue, run the following script:
+   ```bash
+   RULE_INDEX=$(kubectl get \
+     validatingwebhookconfiguration longhorn-webhook-validator -o json \
+     | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
+   
+   if [ -n "$RULE_INDEX" -a "$RULE_INDEX" != "null" ]; then
+     kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+       --type='json' \
+       -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   fi
+   ```
 
-```shell
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/kubevirt-operator/crds/crd-kubevirt.yaml
+1. Wait for the related PVC to be deleted.
 
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/csi-snapshotter/crds/volumesnapshotclasses.yaml
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/csi-snapshotter/crds/volumesnapshotcontents.yaml
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/csi-snapshotter/crds/volumesnapshots.yaml
+1. Restore the PVC webhook rule to re-enable validation.
 
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_ippools.yaml
-kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/whereabouts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
-```
+   ```bash
+   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+     --type='json' \
+     -p='[{"op": "add", "path": "/webhooks/0/rules/-", "value": {"apiGroups":[""],"apiVersions":["v1"],"operations":["UPDATE"],"resources":["persistentvolumeclaims"],"scope":"Namespaced"}}]'
+   ```
 
-After five minutes, check the status in the `mcc-harvester` bundle CR of `bundle.fleet.cattle.io/v1alpha1`. If the same error is still displayed, you must resync the bundle CR using the following script:
+The issue will be addressed in Longhorn v1.8.2, which will likely be included in Harvester v1.5.1.
 
-```shell
-#!/bin/bash
+Related issues:
+- Harvester: [Issue #8096](https://github.com/harvester/harvester/issues/8096)
+- Longhorn: [Issue #10741](https://github.com/longhorn/longhorn/issues/10741)
 
-patch_fleet_bundle() {
-  local bundleName=$1
-  local generation=$(kubectl get -n fleet-local bundle ${bundleName} -o jsonpath='{.spec.forceSyncGeneration}')
-  local new_generation=$((generation+1))
-  patch_manifest="$(mktemp)"
-  cat > "$patch_manifest" <<EOF
-{
-  "spec": {
-    "forceSyncGeneration": $new_generation
-  }
-}
-EOF
-  echo "patch bundle to new generation: $new_generation"
-  kubectl patch -n fleet-local bundle ${bundleName}  --type=merge --patch-file $patch_manifest
-  rm -f $patch_manifest
-}
-
-for bundle in mcc-harvester
-do
-  patch_fleet_bundle ${bundle}
-done
-```
-
-You must also ensure that the `cdi` CRD exists.
-
-```shell
-> kubectl get bundle -n fleet-local
-NAMESPACE     NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
-fleet-local   mcc-harvester                                 0/1                       Modified(1) [Cluster fleet-local/local]; cdi.cdi.kubevirt.io cdi missing
-```
-
-If the `cdi` CRD exists, run the `patch_fleet_bundle` script to resync the `mcc-harvester` bundle CR. Otherwise, run the following script to create the `cdi` CRD:
-
-  ```shell
-  kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags/v1.5.0/deploy/charts/harvester/dependency_charts/cdi/crds/cdi.yaml
-  ```
-
-Related issue: [#8163](https://github.com/harvester/harvester/issues/8163)

--- a/versioned_docs/version-v1.5/volume/create-volume.md
+++ b/versioned_docs/version-v1.5/volume/create-volume.md
@@ -42,9 +42,11 @@ To resolve this issue, perform the following steps:
      validatingwebhookconfiguration longhorn-webhook-validator -o json \
      | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
    
-   kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
-     --type='json' \
-     -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   if [ -n "$RULE_INDEX" -a "$RULE_INDEX" != "null" ]; then
+     kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
+       --type='json' \
+       -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
+   fi
    ```
 
 1. Wait for the related PVC to be deleted.

--- a/versioned_docs/version-v1.5/volume/create-volume.md
+++ b/versioned_docs/version-v1.5/volume/create-volume.md
@@ -38,9 +38,13 @@ To resolve this issue, perform the following steps:
 1. Temporarily remove the PVC webhook rule.
 
    ```bash
+   RULE_INDEX=$(kubectl get \
+     validatingwebhookconfiguration longhorn-webhook-validator -o json \
+     | jq '.webhooks[0].rules | map(.resources[0] == "persistentvolumeclaims") | index(true)')
+   
    kubectl patch validatingwebhookconfiguration longhorn-webhook-validator \
      --type='json' \
-     -p='[{"op": "remove", "path": "/webhooks/0/rules/17"}]'
+     -p="[{'op': 'remove', 'path': '/webhooks/0/rules/$RULE_INDEX'}]"
    ```
 
 1. Wait for the related PVC to be deleted.


### PR DESCRIPTION
#### Problem:
- Need to update the upgrade matrix to reflect that it's possible to go:
  - v1.4.2/v1.4.3 --> v1.5.0
  - v1.4.1/v1.4.2 --> v1.4.3
- As v1.4.3 adds Longhorn v1.7.3, we have a new known issue to document (https://github.com/harvester/harvester/issues/8096)

#### Solution:
This PR, but note that because v1.4.3 is not yet released, I have _not_ added the v1.4.3 upgrade docs to the versioned_docs yet. Once everyone's cool with the content here, I'll update the PR to add changes to versioned_docs and merge when v1.4.3 goes out.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8193
https://github.com/harvester/harvester/issues/8096