### PR TITLE
ci: use concurreny to avoid multiple actions in one PR

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,10 @@ name: Pull Request Preview
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/7983

If we push commit too quickly on a pull request, it triggers a lot of preview actions. However, we just need the latest one. So, we can cancel others.