### PR TITLE
docs: add post-install steps to disable ssh password access

### DIFF
--- a/docs/install/post-install.md
+++ b/docs/install/post-install.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 11
+sidebar_label: Post-installation steps
+title: "Post-Installation Steps"
+keywords:
+  - Harvester
+  - Installation
+description: Post-installation steps.
+---
+
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.6/install/post-install"/>
+</head>
+
+These optional post-installation procedures describe how to enhance Harvester security and performance.
+
+## Disable SSH Password
+
+By default during installation, SSH password authentication is enabled on the Harvester nodes. This allows administrator to access the nodes for installation diagnosis. 
+
+Once the installation completed successfully, it's recommended to disable SSH password authentication.
+
+The following command uses `kubectl` to apply a [`CloudInit`](https://docs.harvesterhci.io/v1.6/advanced/cloudinitcrd/) configuration to disable SSH password authentication on all Harvester nodes:
+
+```sh
+cat <<EOF | kubectl apply -f -
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: ssh-config
+spec:
+  matchSelector: 
+    harvesterhci.io/managed: "true" # apply to all Harvester nodes
+  filename: 99-ssh-config
+  contents: |
+    stages:
+      network:
+      - name: "disable password login"
+        commands:
+        - sed -i -E 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config
+        - sed -i -E 's/^#?ChallengeResponseAuthentication .*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+        - sed -i -E 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
+        - systemctl restart sshd
+  paused: false
+EOF
+```
+
+   * The `matchSelector` field is used to select Harvester nodes with specific labels.
+   * All the affected nodes must be rebooted for the cloud-init configuration to take effect.
+
+Once the configuration is applied, any attempts to access the Harvester nodes with the SSH password will be denied:
+
+```sh
+$ ssh -o PreferredAuthentications=password rancher@<node-ip>
+rancher@<node-ip>: Permission denied (publickey,keyboard-interactive).
+```

--- a/docs/install/post-install.md
+++ b/docs/install/post-install.md
@@ -19,9 +19,7 @@ These optional post-installation procedures describe how to enhance Harvester se
 
 By default during installation, SSH password authentication is enabled on the Harvester nodes. This allows administrator to access the nodes for installation diagnosis. 
 
-Once the installation completed successfully, it's recommended to disable SSH password authentication.
-
-The following command uses `kubectl` to apply a [`CloudInit`](https://docs.harvesterhci.io/v1.6/advanced/cloudinitcrd/) configuration to disable SSH password authentication on all Harvester nodes:
+Once installation is completed, however, disabling SSH password authentication is recommended. You can run the following command, which uses `kubectl` to apply a [`CloudInit`](https://docs.harvesterhci.io/v1.6/advanced/cloudinitcrd/) configuration, to disable SSH password authentication on all Harvester nodes:
 
 ```sh
 cat <<EOF | kubectl apply -f -
@@ -46,10 +44,14 @@ spec:
 EOF
 ```
 
-   * The `matchSelector` field is used to select Harvester nodes with specific labels.
-   * All the affected nodes must be rebooted for the cloud-init configuration to take effect.
+:::note
 
-Once the configuration is applied, any attempts to access the Harvester nodes with the SSH password will be denied:
+- The `matchSelector` field is used to select Harvester nodes with specific labels.
+- All the affected nodes must be rebooted for the `CloudInit` configuration to take effect.
+
+:::
+
+Once the configuration is applied, any attempts to access the Harvester nodes with the SSH password are denied.
 
 ```sh
 $ ssh -o PreferredAuthentications=password rancher@<node-ip>

--- a/docs/install/post-install.md
+++ b/docs/install/post-install.md
@@ -13,7 +13,7 @@ description: Post-installation steps.
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.6/install/post-install"/>
 </head>
 
-These optional post-installation procedures describe how to enhance Harvester security and performance.
+You can enhance the security and performance of your Harvester cluster by performing the following procedures after installation is completed.
 
 ## Disable SSH Password
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

This PR adds post-installation steps to disable SSH password access.


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/4979

#### Test plan:

* Set up a 3-node Harvester nodes
* Follow the documentation in this PR to apply a `CloudInit` configuration to disable SSH password access on all the Harvester nodes
* Once the configuration is applied, reboot all the nodes
* Verify the content of the `/etc/ssh/ssh_config` file on each node to make sure the following properties are uncommented and set to `no`:
    * `PasswordAuthentication`
    * `ChallengeResponseAuthentication`
    * `UsePAM`  
   
* Any attempts to access the nodes using SSH password will be denied
