### PR TITLE
Add Note for VM Default Resource Limit issue #5449

### DIFF
--- a/docs/rancher/resource-quota.md
+++ b/docs/rancher/resource-quota.md
@@ -31,7 +31,9 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
   ![](/img/v1.4/rancher/create-project.png)
 
 :::note
-The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+The "VM Default Resource Limit" is used to set default request/limit on compute resources for pods running within the namespace, using the Kubernetes [`LimitRange` API](https://kubernetes.io/docs/concepts/policy/limit-range/). The resource "reservation" and "limit" values correspond to the `defaultRequest` and `default` limits of the namespace's `LimitRange` configuration. These settings are applied to pod workloads only.
+
+These configuration will be removed in the future. See issue https://github.com/harvester/harvester/issues/5652. 
 :::
 
 

--- a/docs/rancher/resource-quota.md
+++ b/docs/rancher/resource-quota.md
@@ -30,6 +30,11 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
 1. Specify the desired project **Name**. Next, go to the **Resource Quotas** tab and select the **Add Resource** option. Within the **Resource Type** field, select either **CPU Limit** or **Memory Limit** and define the **Project Limit** and **Namespace Default Limit** values.
   ![](/img/v1.4/rancher/create-project.png)
 
+:::note
+The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+:::
+
+
 You can configure the **Namespace** limits as follows: 
 
 1. Find the newly created project, and select **Create Namespace**.

--- a/versioned_docs/version-v1.2/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.2/rancher/resource-quota.md
@@ -25,6 +25,10 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
 1. Specify the desired project **Name**. Next, go to the **Resource Quotas** tab and select the **Add Resource** option. Within the **Resource Type** field, select either **CPU Limit** or **Memory Limit** and define the **Project Limit** and **Namespace Default Limit** values.
   ![](/img/v1.2/rancher/create-project.png)
 
+:::note
+The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+:::
+
 You can configure the **Namespace** limits as follows: 
 
 1. Find the newly created project, and select **Create Namespace**.

--- a/versioned_docs/version-v1.2/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.2/rancher/resource-quota.md
@@ -26,7 +26,9 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
   ![](/img/v1.2/rancher/create-project.png)
 
 :::note
-The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+The "VM Default Resource Limit" is used to set default request/limit on compute resources for pods running within the namespace, using the Kubernetes [`LimitRange` API](https://kubernetes.io/docs/concepts/policy/limit-range/). The resource "reservation" and "limit" values correspond to the `defaultRequest` and `default` limits of the namespace's `LimitRange` configuration. These settings are applied to pod workloads only.
+
+These configuration will be removed in the future. See issue https://github.com/harvester/harvester/issues/5652.
 :::
 
 You can configure the **Namespace** limits as follows: 

--- a/versioned_docs/version-v1.3/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.3/rancher/resource-quota.md
@@ -30,7 +30,9 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
   ![](/img/v1.3/rancher/create-project.png)
 
 :::note
-The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+The "VM Default Resource Limit" is used to set default request/limit on compute resources for pods running within the namespace, using the Kubernetes [`LimitRange` API](https://kubernetes.io/docs/concepts/policy/limit-range/). The resource "reservation" and "limit" values correspond to the `defaultRequest` and `default` limits of the namespace's `LimitRange` configuration. These settings are applied to pod workloads only.
+
+These configuration will be removed in the future. See issue https://github.com/harvester/harvester/issues/5652.
 :::
 
 You can configure the **Namespace** limits as follows: 

--- a/versioned_docs/version-v1.3/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.3/rancher/resource-quota.md
@@ -29,6 +29,10 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
 1. Specify the desired project **Name**. Next, go to the **Resource Quotas** tab and select the **Add Resource** option. Within the **Resource Type** field, select either **CPU Limit** or **Memory Limit** and define the **Project Limit** and **Namespace Default Limit** values.
   ![](/img/v1.3/rancher/create-project.png)
 
+:::note
+The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+:::
+
 You can configure the **Namespace** limits as follows: 
 
 1. Find the newly created project, and select **Create Namespace**.

--- a/versioned_docs/version-v1.4/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.4/rancher/resource-quota.md
@@ -30,6 +30,10 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
 1. Specify the desired project **Name**. Next, go to the **Resource Quotas** tab and select the **Add Resource** option. Within the **Resource Type** field, select either **CPU Limit** or **Memory Limit** and define the **Project Limit** and **Namespace Default Limit** values.
   ![](/img/v1.4/rancher/create-project.png)
 
+:::note
+The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+:::
+
 You can configure the **Namespace** limits as follows: 
 
 1. Find the newly created project, and select **Create Namespace**.

--- a/versioned_docs/version-v1.4/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.4/rancher/resource-quota.md
@@ -31,7 +31,9 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
   ![](/img/v1.4/rancher/create-project.png)
 
 :::note
-The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+The "VM Default Resource Limit" is used to set default request/limit on compute resources for pods running within the namespace, using the Kubernetes [`LimitRange` API](https://kubernetes.io/docs/concepts/policy/limit-range/). The resource "reservation" and "limit" values correspond to the `defaultRequest` and `default` limits of the namespace's `LimitRange` configuration. These settings are applied to pod workloads only.
+
+These configuration will be removed in the future. See issue https://github.com/harvester/harvester/issues/5652.
 :::
 
 You can configure the **Namespace** limits as follows: 

--- a/versioned_docs/version-v1.5/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.5/rancher/resource-quota.md
@@ -30,6 +30,10 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
 1. Specify the desired project **Name**. Next, go to the **Resource Quotas** tab and select the **Add Resource** option. Within the **Resource Type** field, select either **CPU Limit** or **Memory Limit** and define the **Project Limit** and **Namespace Default Limit** values.
   ![](/img/v1.4/rancher/create-project.png)
 
+:::note
+The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+:::
+
 You can configure the **Namespace** limits as follows: 
 
 1. Find the newly created project, and select **Create Namespace**.

--- a/versioned_docs/version-v1.5/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.5/rancher/resource-quota.md
@@ -31,7 +31,9 @@ In the Rancher UI, administrators can configure resource quotas for namespaces t
   ![](/img/v1.4/rancher/create-project.png)
 
 :::note
-The **VM Default Resource Limit** name is inaccurate and is scheduled to be removed or renamed in a future version. "VM Default Resource Limit", Rancher sets `LimitRange` to related namespace. The config is set as `default` and `defaultRequest`, not `max` and `min`, so it only takes effect if a pod doesn't set related limit and request. Since a VM can not be created without setting CPU and Memory, the `LimitRange` will only be applicable for non VM workloads if provided.
+The "VM Default Resource Limit" is used to set default request/limit on compute resources for pods running within the namespace, using the Kubernetes [`LimitRange` API](https://kubernetes.io/docs/concepts/policy/limit-range/). The resource "reservation" and "limit" values correspond to the `defaultRequest` and `default` limits of the namespace's `LimitRange` configuration. These settings are applied to pod workloads only.
+
+These configuration will be removed in the future. See issue https://github.com/harvester/harvester/issues/5652.
 :::
 
 You can configure the **Namespace** limits as follows: 


### PR DESCRIPTION
#### Problem:
The "VM Default Resource Limit" field is inaccurate and requires additional clarification. 

#### Solution:
Add note section to docs about the field and what it does. 

#### Related Issue(s):
Fixes [#5449](https://github.com/harvester/harvester/issues/5449#)

Addtional Context: [#5450](https://github.com/harvester/harvester/issues/5450) [#5652](https://github.com/harvester/harvester/issues/5652)
