### PR TITLE
Enhance descriptions in "Cluster Network Details" section and add note about ARP settings

### DIFF
--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -70,24 +70,29 @@ Overall, this diagram provides a clear visualization of the relationship between
 
 ## Cluster Network Details
 
+Cluster networks are traffic-isolated forwarding paths for transmission of network traffic within a Harvester cluster.
+
+A cluster network called `mgmt` is automatically created when a Harvester cluster is deployed. You can also create custom cluster networks that can be dedicated to virtual machine traffic.
+
 ### Built-in Cluster Network
 
-Harvester provides a built-in cluster network called `mgmt`. It's different from the custom cluster network. The `mgmt` cluster network:
+When a Harvester cluster is deployed, a cluster network named `mgmt` is automatically created for intra-cluster communications. `mgmt` consists of the same bridge, bond, and NICs as the external infrastructure network to which each Harvester host attaches with management NICs. Because of this design, `mgmt` also allows virtual machines to be accessed from the external infrastructure network for cluster management purposes.
 
-- Cannot be deleted.
-- Does not need any network configuration.
-- Is enabled on all hosts and cannot be disabled.
-- Shares the same traffic egress with the management network.
+`mgmt` does not require a network configuration and is always enabled on all hosts. You cannot disable and delete `mgmt`.
 
-If there is no need for traffic separation, you can put all your network under the mgmt cluster network.
+:::caution
+
+Certain [ARP settings](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt) can break cluster communications. With `arp_ignore=2`, for example, replies are sent only if the sender IP is in the same subnet as the target IP for which the MAC address is requested. This is not the case in a Harvester cluster, so using `arp_ignore=2` on all interfaces results in failed connectivity checks and prevents Longhorn pods (specifically, `backing-image` and `instance-manager`) from transitioning to the `Ready` state. Volumes cannot be attached to virtual machines if these Longhorn pods are not ready.
+
+:::
 
 ### Custom Cluster Network
 
-You are allowed to add the custom cluster network, which will not be available until it's enabled on some hosts by adding a network configuration.
+If more than one network interface is attached to each host, you can create custom cluster networks for better traffic isolation. Each cluster network must have at least one network configuration with a defined scope and bonding mode.
+
+Before creating a cluster network, ensure that the [hardware requirements](../install/requirements.md#hardware-requirements) are met.
 
 :::note
-
-Before creating a new cluster network, ensure that the [hardware requirements](../install/requirements.md#hardware-requirements) are met.
 
 The [witness node](../advanced/witness.md) is generally not involved in the custom cluster network.
 

--- a/versioned_docs/version-v1.4/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.4/networking/clusternetwork.md
@@ -70,24 +70,29 @@ Overall, this diagram provides a clear visualization of the relationship between
 
 ## Cluster Network Details
 
+Cluster networks are traffic-isolated forwarding paths for transmission of network traffic within a Harvester cluster.
+
+A cluster network called `mgmt` is automatically created when a Harvester cluster is deployed. You can also create custom cluster networks that can be dedicated to virtual machine traffic.
+
 ### Built-in Cluster Network
 
-Harvester provides a built-in cluster network called `mgmt`. It's different from the custom cluster network. The `mgmt` cluster network:
+When a Harvester cluster is deployed, a cluster network named `mgmt` is automatically created for intra-cluster communications. `mgmt` consists of the same bridge, bond, and NICs as the external infrastructure network to which each Harvester host attaches with management NICs. Because of this design, `mgmt` also allows virtual machines to be accessed from the external infrastructure network for cluster management purposes.
 
-- Cannot be deleted.
-- Does not need any network configuration.
-- Is enabled on all hosts and cannot be disabled.
-- Shares the same traffic egress with the management network.
+`mgmt` does not require a network configuration and is always enabled on all hosts. You cannot disable and delete `mgmt`.
 
-If there is no need for traffic separation, you can put all your network under the mgmt cluster network.
+:::caution
+
+Certain [ARP settings](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt) can break cluster communications. With `arp_ignore=2`, for example, replies are sent only if the sender IP is in the same subnet as the target IP for which the MAC address is requested. This is not the case in a Harvester cluster, so using `arp_ignore=2` on all interfaces results in failed connectivity checks and prevents Longhorn pods (specifically, `backing-image` and `instance-manager`) from transitioning to the `Ready` state. Volumes cannot be attached to virtual machines if these Longhorn pods are not ready.
+
+:::
 
 ### Custom Cluster Network
 
-You are allowed to add the custom cluster network, which will not be available until it's enabled on some hosts by adding a network configuration.
+If more than one network interface is attached to each host, you can create custom cluster networks for better traffic isolation. Each cluster network must have at least one network configuration with a defined scope and bonding mode.
+
+Before creating a cluster network, ensure that the [hardware requirements](../install/requirements.md#hardware-requirements) are met.
 
 :::note
-
-Before creating a new cluster network, ensure that the [hardware requirements](../install/requirements.md#hardware-requirements) are met.
 
 The [witness node](../advanced/witness.md) is generally not involved in the custom cluster network.
 

--- a/versioned_docs/version-v1.5/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.5/networking/clusternetwork.md
@@ -70,24 +70,29 @@ Overall, this diagram provides a clear visualization of the relationship between
 
 ## Cluster Network Details
 
+Cluster networks are traffic-isolated forwarding paths for transmission of network traffic within a Harvester cluster.
+
+A cluster network called `mgmt` is automatically created when a Harvester cluster is deployed. You can also create custom cluster networks that can be dedicated to virtual machine traffic.
+
 ### Built-in Cluster Network
 
-Harvester provides a built-in cluster network called `mgmt`. It's different from the custom cluster network. The `mgmt` cluster network:
+When a Harvester cluster is deployed, a cluster network named `mgmt` is automatically created for intra-cluster communications. `mgmt` consists of the same bridge, bond, and NICs as the external infrastructure network to which each Harvester host attaches with management NICs. Because of this design, `mgmt` also allows virtual machines to be accessed from the external infrastructure network for cluster management purposes.
 
-- Cannot be deleted.
-- Does not need any network configuration.
-- Is enabled on all hosts and cannot be disabled.
-- Shares the same traffic egress with the management network.
+`mgmt` does not require a network configuration and is always enabled on all hosts. You cannot disable and delete `mgmt`.
 
-If there is no need for traffic separation, you can put all your network under the mgmt cluster network.
+:::caution
+
+Certain [ARP settings](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt) can break cluster communications. With `arp_ignore=2`, for example, replies are sent only if the sender IP is in the same subnet as the target IP for which the MAC address is requested. This is not the case in a Harvester cluster, so using `arp_ignore=2` on all interfaces results in failed connectivity checks and prevents Longhorn pods (specifically, `backing-image` and `instance-manager`) from transitioning to the `Ready` state. Volumes cannot be attached to virtual machines if these Longhorn pods are not ready.
+
+:::
 
 ### Custom Cluster Network
 
-You are allowed to add the custom cluster network, which will not be available until it's enabled on some hosts by adding a network configuration.
+If more than one network interface is attached to each host, you can create custom cluster networks for better traffic isolation. Each cluster network must have at least one network configuration with a defined scope and bonding mode.
+
+Before creating a cluster network, ensure that the [hardware requirements](../install/requirements.md#hardware-requirements) are met.
 
 :::note
-
-Before creating a new cluster network, ensure that the [hardware requirements](../install/requirements.md#hardware-requirements) are met.
 
 The [witness node](../advanced/witness.md) is generally not involved in the custom cluster network.
 


### PR DESCRIPTION
Related issue: [#6316](https://github.com/harvester/harvester/issues/6316)

Changes:
- Add a high-level intro to cluster networks under the "Cluster Network Details" heading (in preparation for future enhancements to the "Networking" section)
- Enhance "Built-in Cluster Network" and "Custom Cluster Network" descriptions
- Add note about ARP settings that might break intra-cluster communications