### PR TITLE
Add known issue for RWX non-root user permission issues in v1.4.3

### DIFF
--- a/docs/upgrade/v1-4-1-to-v1-4-3.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-3.md
@@ -147,3 +147,56 @@ Related issues:
 - Harvester: [Issue #8096](https://github.com/harvester/harvester/issues/8096)
 - Longhorn: [Issue #10741](https://github.com/longhorn/longhorn/issues/10741)
 
+### 3. Non-Root Users on Guest Clusters Unable to Access RWX Volumes
+
+Non-root users on guest clusters encounter unexpected "Permission denied" errors when accessing RWX volumes. This is caused by a [regression issue](https://github.com/nfs-ganesha/nfs-ganesha/issues/1132) in nfs-ganesha v6.0+, which affects v1.7.3 of the `longhorn-share-manager` image.
+
+You can resolve the issue by replacing `longhorn-share-manager:v1.7.3` with the hotfixed image `longhorn-share-manager:v1.7.3-hotfix-1`.
+
+1. Edit the `longhorn-manager` DaemonSet by running the following command:
+
+  ```bash
+  kubectl -n longhorn-system edit daemonset/longhorn-manager
+  ```
+
+1. In the `spec.containers.command` field, change the `--share-manager-image` to `longhornio/longhorn-share-manager:v1.7.3-hotfix-1`.
+  ```yaml
+  ...
+    spec:
+      containers:
+      - command:
+        - longhorn-manager
+        - -d
+        - daemon
+        - --engine-image
+        - longhornio/longhorn-engine:v1.7.3
+        - --instance-manager-image
+        - longhornio/longhorn-instance-manager:v1.7.3
+        - --share-manager-image
+        - longhornio/longhorn-share-manager:v1.7.3-hotfix-1
+        - --backing-image-manager-image
+        - longhornio/backing-image-manager:v1.7.3
+        - --support-bundle-manager-image
+        - longhornio/support-bundle-kit:v0.0.51
+        - --manager-image
+        - longhornio/longhorn-manager:v1.7.3
+        - --service-account
+        - longhorn-service-account
+        - --upgrade-version-check
+  ...
+  ```
+
+1. Once the update is applied, restart workloads that are using RWX volumes.
+
+:::caution
+
+- Do not use the hotfixed image if you are not affected by the issue.
+
+- If you are using the hotfixed image and want to upgrade Harvester v1.5.x, you must edit the `longhorn-manager` DaemonSet and revert to the `longhorn-share-manager:v1.7.3` image before starting the upgrade.
+
+:::
+
+Related issues:
+- Harvester: [Issue 8354](https://github.com/harvester/harvester/issues/8354)
+- Longhorn: [10621](https://github.com/longhorn/longhorn/issues/10621)
+

--- a/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-3.md
@@ -147,3 +147,56 @@ Related issues:
 - Harvester: [Issue #8096](https://github.com/harvester/harvester/issues/8096)
 - Longhorn: [Issue #10741](https://github.com/longhorn/longhorn/issues/10741)
 
+### 3. Non-Root Users on Guest Clusters Unable to Access RWX Volumes
+
+Non-root users on guest clusters encounter unexpected "Permission denied" errors when accessing RWX volumes. This is caused by a [regression issue](https://github.com/nfs-ganesha/nfs-ganesha/issues/1132) in nfs-ganesha v6.0+, which affects v1.7.3 of the `longhorn-share-manager` image.
+
+You can resolve the issue by replacing `longhorn-share-manager:v1.7.3` with the hotfixed image `longhorn-share-manager:v1.7.3-hotfix-1`.
+
+1. Edit the `longhorn-manager` DaemonSet by running the following command:
+
+  ```bash
+  kubectl -n longhorn-system edit daemonset/longhorn-manager
+  ```
+
+1. In the `spec.containers.command` field, change the `--share-manager-image` to `longhornio/longhorn-share-manager:v1.7.3-hotfix-1`.
+  ```yaml
+  ...
+    spec:
+      containers:
+      - command:
+        - longhorn-manager
+        - -d
+        - daemon
+        - --engine-image
+        - longhornio/longhorn-engine:v1.7.3
+        - --instance-manager-image
+        - longhornio/longhorn-instance-manager:v1.7.3
+        - --share-manager-image
+        - longhornio/longhorn-share-manager:v1.7.3-hotfix-1
+        - --backing-image-manager-image
+        - longhornio/backing-image-manager:v1.7.3
+        - --support-bundle-manager-image
+        - longhornio/support-bundle-kit:v0.0.51
+        - --manager-image
+        - longhornio/longhorn-manager:v1.7.3
+        - --service-account
+        - longhorn-service-account
+        - --upgrade-version-check
+  ...
+  ```
+
+1. Once the update is applied, restart workloads that are using RWX volumes.
+
+:::caution
+
+- Do not use the hotfixed image if you are not affected by the issue.
+
+- If you are using the hotfixed image and want to upgrade Harvester v1.5.x, you must edit the `longhorn-manager` DaemonSet and revert to the `longhorn-share-manager:v1.7.3` image before starting the upgrade.
+
+:::
+
+Related issues:
+- Harvester: [Issue 8354](https://github.com/harvester/harvester/issues/8354)
+- Longhorn: [10621](https://github.com/longhorn/longhorn/issues/10621)
+

--- a/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-3.md
@@ -147,3 +147,56 @@ Related issues:
 - Harvester: [Issue #8096](https://github.com/harvester/harvester/issues/8096)
 - Longhorn: [Issue #10741](https://github.com/longhorn/longhorn/issues/10741)
 
+### 3. Non-Root Users on Guest Clusters Unable to Access RWX Volumes
+
+Non-root users on guest clusters encounter unexpected "Permission denied" errors when accessing RWX volumes. This is caused by a [regression issue](https://github.com/nfs-ganesha/nfs-ganesha/issues/1132) in nfs-ganesha v6.0+, which affects v1.7.3 of the `longhorn-share-manager` image.
+
+You can resolve the issue by replacing `longhorn-share-manager:v1.7.3` with the hotfixed image `longhorn-share-manager:v1.7.3-hotfix-1`.
+
+1. Edit the `longhorn-manager` DaemonSet by running the following command:
+
+  ```bash
+  kubectl -n longhorn-system edit daemonset/longhorn-manager
+  ```
+
+1. In the `spec.containers.command` field, change the `--share-manager-image` to `longhornio/longhorn-share-manager:v1.7.3-hotfix-1`.
+  ```yaml
+  ...
+    spec:
+      containers:
+      - command:
+        - longhorn-manager
+        - -d
+        - daemon
+        - --engine-image
+        - longhornio/longhorn-engine:v1.7.3
+        - --instance-manager-image
+        - longhornio/longhorn-instance-manager:v1.7.3
+        - --share-manager-image
+        - longhornio/longhorn-share-manager:v1.7.3-hotfix-1
+        - --backing-image-manager-image
+        - longhornio/backing-image-manager:v1.7.3
+        - --support-bundle-manager-image
+        - longhornio/support-bundle-kit:v0.0.51
+        - --manager-image
+        - longhornio/longhorn-manager:v1.7.3
+        - --service-account
+        - longhorn-service-account
+        - --upgrade-version-check
+  ...
+  ```
+
+1. Once the update is applied, restart workloads that are using RWX volumes.
+
+:::caution
+
+- Do not use the hotfixed image if you are not affected by the issue.
+
+- If you are using the hotfixed image and want to upgrade Harvester v1.5.x, you must edit the `longhorn-manager` DaemonSet and revert to the `longhorn-share-manager:v1.7.3` image before starting the upgrade.
+
+:::
+
+Related issues:
+- Harvester: [Issue 8354](https://github.com/harvester/harvester/issues/8354)
+- Longhorn: [10621](https://github.com/longhorn/longhorn/issues/10621)
+


### PR DESCRIPTION
Note that here I'm deliberately suggesting the user directly edit the longhorn-manager daemonset.  This means that if the user attempts to later upgrade to v1.5.x _without_ reverting the change, upgrade will be prevented with the following error:

```
  admission webhook "validator.harvesterhci.io" denied the request:
  managed chart harvester is not ready, please wait for it to be ready
```

This is a safety measure, to make really sure the hotfix image is removed before subsequent upgrade, because if we _don't_ remove it (e.g. if we made a nice clean patch to the managedchart itself to apply the hotfix image, which would avoid the above error), then proceeded to upgrade to Harvester v1.5.x, then all of Longhorn would be updated to v1.8.x _except_ for the share manager, which would remain using the old v1.7.3-hotfix-1 image!

I figured it would be too confusing to add all that detail to the docs, so instead have recorded it here for posterity.

Related issue: https://github.com/harvester/harvester/issues/8354
