### PR TITLE
doc: add document for vm image clone action

### DIFF
--- a/docs/image/upload-image.md
+++ b/docs/image/upload-image.md
@@ -29,6 +29,7 @@ To import virtual machine images in the **Images** page, enter a URL that can be
 
 - The image name will be auto-filled using the URL address's filename. You can customize the image name at any time.
 - Avoid using a daily build URL (for example, the [Ubuntu Jammy daily build](https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img)). When all replicas of a Longhorn backing image are lost, Longhorn attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
+- VM image cloning is supported only for images imported via URL.
 
 :::
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Added notes for the clone vm image `Clone` action to help users understand the cloning limitations

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue harvester/harvester#7207

#### Test plan:
<!-- Describe the test plan by steps. -->
- Navigate to `Image Management -> Upload Images`
- Verify that the note `VM image cloning is supported only for images imported via URL.` is clearly displayed in the `Upload Images via URL` section.

#### Additional documentation or context
N/A
