### PR TITLE
Add upgrade-related information for v1.5.x

### DIFF
--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -16,21 +16,53 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/index"/>
 </head>
 
-## Upgrade support matrix
+Harvester is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
 
-The following table shows the upgrade path of all supported versions.
+- Four-month minor release cadence (April, August, and December)
+- Two-month patch release cadence (best effort)
+- Component adoption policy
 
-| Upgrade from version | Supported new version(s) |
-|----------------------|--------------------------|
-| [v1.4.2/v1.4.3](./v1-4-2-to-v1-5-0.md) | v1.5.0        |
-| [v1.4.1/v1.4.2](./v1-4-1-to-v1-4-3.md) | v1.4.3        |
-| [v1.4.1](./v1-4-1-to-v1-4-2.md) | v1.4.2        |
-| [v1.4.0](./v1-4-0-to-v1-4-1.md) | v1.4.1        |
-| [v1.3.2](./v1-3-2-to-v1-4-0.md) | v1.4.0        |
-| [v1.3.1](./v1-3-1-to-v1-3-2.md) | v1.3.2        |
-| [v1.2.2/v1.3.0](./v1-2-2-to-v1-3-1.md) | v1.3.1        |
-| [v1.2.1](./v1-2-1-to-v1-2-2.md) | v1.2.2        |
-| [v1.1.2/v1.1.3/v1.2.0](./v1-2-0-to-v1-2-1.md) | v1.2.1              |
+:::note
+
+Harvester does not support downgrades. This restriction helps prevent unexpected system behavior and issues associated with function incompatibility, deprecation, and removal.
+
+:::
+
+## Upgrade paths
+
+The following table outlines the supported upgrade paths.
+
+| Installed Version | Supported Upgrade Versions |
+| --- | --- |
+| v1.4.2/v1.4.3 | [v1.5.0](./v1-4-2-to-v1-5-0.md) and v1.5.1 |
+| v1.4.1/v1.4.2 | [v1.4.3](./v1-4-1-to-v1-4-3.md) |
+| v1.4.1 | [v1.4.2](./v1-4-1-to-v1-4-2.md) |
+| v1.4.0 | [v1.4.1](./v1-4-0-to-v1-4-1.md) |
+| v1.3.2 | [v1.4.0](./v1-3-2-to-v1-4-0.md) |
+| v1.3.1 | [v1.3.2](./v1-3-1-to-v1-3-2.md) |
+| v1.2.2/v1.3.0 | [v1.3.1](./v1-2-2-to-v1-3-1.md) |
+| v1.2.1 | [v1.2.2](./v1-2-1-to-v1-2-2.md) |
+| v1.1.2/v1.1.3/v1.2.0 | [v1.2.1](./v1-2-0-to-v1-2-1.md) |
+
+Harvester v1.5.x and later versions allow the following:
+
+- Upgrading from one minor version to the next (for example, from v1.4.2 to v1.5.1) without needing to install the patches released in between the two versions. This is possible because Harvester allows a maximum of one minor version upgrade for underlying components.
+- Upgrading to a later patch version (for example, from v1.5.0 to v1.5.1), assuming that the same component versions are used across the releases for a given minor version.
+
+The following table outlines the components used in these versions:
+
+| Components | Harvester v1.42 and v1.4.3 | Harvester v1.5.x |
+| --- | --- | --- |
+| KubeVirt | v1.3 | v1.4 |
+| Longhorn | v1.7 | v1.8 |
+| Rancher | v2.10 | v2.11 |
+| RKE2 | v1.31 | v1.32 |
+
+:::note
+
+Skipping multiple Kubernetes minor versions is not supported upstream and is a key reason behind the limited upgrade paths. For more information, see [Version Skew Policy](https://kubernetes.io/releases/version-skew-policy) in the Kubernetes documentation.
+
+:::
 
 ## Rancher upgrade
 

--- a/versioned_docs/version-v1.5/upgrade/automatic.md
+++ b/versioned_docs/version-v1.5/upgrade/automatic.md
@@ -16,21 +16,53 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.5/upgrade/index"/>
 </head>
 
-## Upgrade support matrix
+Harvester is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
 
-The following table shows the upgrade path of all supported versions.
+- Four-month minor release cadence (April, August, and December)
+- Two-month patch release cadence (best effort)
+- Component adoption policy
 
-| Upgrade from version | Supported new version(s) |
-|----------------------|--------------------------|
-| [v1.4.2/v1.4.3](./v1-4-2-to-v1-5-0.md) | v1.5.0        |
-| [v1.4.1/v1.4.2](./v1-4-1-to-v1-4-3.md) | v1.4.3        |
-| [v1.4.1](./v1-4-1-to-v1-4-2.md) | v1.4.2        |
-| [v1.4.0](./v1-4-0-to-v1-4-1.md) | v1.4.1        |
-| [v1.3.2](./v1-3-2-to-v1-4-0.md) | v1.4.0        |
-| [v1.3.1](./v1-3-1-to-v1-3-2.md) | v1.3.2        |
-| [v1.2.2/v1.3.0](./v1-2-2-to-v1-3-1.md) | v1.3.1        |
-| [v1.2.1](./v1-2-1-to-v1-2-2.md) | v1.2.2        |
-| [v1.1.2/v1.1.3/v1.2.0](./v1-2-0-to-v1-2-1.md) | v1.2.1              |
+:::note
+
+Harvester does not support downgrades. This restriction helps prevent unexpected system behavior and issues associated with function incompatibility, deprecation, and removal.
+
+:::
+
+## Upgrade paths
+
+The following table outlines the supported upgrade paths.
+
+| Installed Version | Supported Upgrade Versions |
+| --- | --- |
+| v1.4.2/v1.4.3 | [v1.5.0](./v1-4-2-to-v1-5-0.md) and v1.5.1 |
+| v1.4.1/v1.4.2 | [v1.4.3](./v1-4-1-to-v1-4-3.md) |
+| v1.4.1 | [v1.4.2](./v1-4-1-to-v1-4-2.md) |
+| v1.4.0 | [v1.4.1](./v1-4-0-to-v1-4-1.md) |
+| v1.3.2 | [v1.4.0](./v1-3-2-to-v1-4-0.md) |
+| v1.3.1 | [v1.3.2](./v1-3-1-to-v1-3-2.md) |
+| v1.2.2/v1.3.0 | [v1.3.1](./v1-2-2-to-v1-3-1.md) |
+| v1.2.1 | [v1.2.2](./v1-2-1-to-v1-2-2.md) |
+| v1.1.2/v1.1.3/v1.2.0 | [v1.2.1](./v1-2-0-to-v1-2-1.md) |
+
+Harvester v1.5.x and later versions allow the following:
+
+- Upgrading from one minor version to the next (for example, from v1.4.2 to v1.5.1) without needing to install the patches released in between the two versions. This is possible because Harvester allows a maximum of one minor version upgrade for underlying components.
+- Upgrading to a later patch version (for example, from v1.5.0 to v1.5.1), assuming that the same component versions are used across the releases for a given minor version.
+
+The following table outlines the components used in these versions:
+
+| Components | Harvester v1.42 and v1.4.3 | Harvester v1.5.x |
+| --- | --- | --- |
+| KubeVirt | v1.3 | v1.4 |
+| Longhorn | v1.7 | v1.8 |
+| Rancher | v2.10 | v2.11 |
+| RKE2 | v1.31 | v1.32 |
+
+:::note
+
+Skipping multiple Kubernetes minor versions is not supported upstream and is a key reason behind the limited upgrade paths. For more information, see [Version Skew Policy](https://kubernetes.io/releases/version-skew-policy) in the Kubernetes documentation.
+
+:::
 
 ## Rancher upgrade
 


### PR DESCRIPTION
Source: [v1.5.1 upgrade compatibility matrix](https://confluence.suse.com/pages/viewpage.action?pageId=1811939782) in Confluence

Changes:
- Added the following information: high-level description of the new lifecycle strategy, note about downgrades being unsupported, summary of upgrade actions possible in v1.5.x, table and note about components
- Updated and improved upgrade paths table
