### PR TITLE
chore: fix puppeteer building issue with PUPPETEER_DOWNLOAD_BASE_URL

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn install --frozen-lockfile
+          PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public yarn install --frozen-lockfile
 
       - name: Ignore OpenAPI
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g yarn
-          yarn install --frozen-lockfile
+          PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public yarn install --frozen-lockfile
 
       - name: Ignore OpenAPI
         run: |


### PR DESCRIPTION
It seems it's a puppeteer issue. I tried in my personal repository, and it works. 

![image](https://github.com/user-attachments/assets/1daa69ce-545e-4822-9b58-f4d77226cedf)

Since we're using pull_request_target, so we must merge this PR, then we're able to test it.

Reference: https://github.com/puppeteer/puppeteer/issues/12833
