### PR TITLE
doc: Add Mention About RKE2 CoreDNS Restart

### DIFF
--- a/docs/install/update-harvester-configuration.md
+++ b/docs/install/update-harvester-configuration.md
@@ -44,6 +44,14 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
     ```
     cat /etc/resolv.conf
     ```
+1. Restart rke2-coredns:
+    ```
+    kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
+1. Confirm rke2-coredns was rolled out successfully:
+    ```
+    kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
 
 ### Configuration persistence
 

--- a/versioned_docs/version-v1.1/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.1/install/update-harvester-configuration.md
@@ -44,6 +44,14 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
     ```
     cat /etc/resolv.conf
     ```
+1. Restart rke2-coredns:
+    ```
+    kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
+1. Confirm rke2-coredns was rolled out successfully:
+    ```
+    kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
 
 ### Configuration persistence
 

--- a/versioned_docs/version-v1.2/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.2/install/update-harvester-configuration.md
@@ -44,6 +44,14 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
     ```
     cat /etc/resolv.conf
     ```
+1. Restart rke2-coredns:
+    ```
+    kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
+1. Confirm rke2-coredns was rolled out successfully:
+    ```
+    kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
 
 ### Configuration persistence
 

--- a/versioned_docs/version-v1.3/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.3/install/update-harvester-configuration.md
@@ -44,6 +44,14 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
     ```
     cat /etc/resolv.conf
     ```
+1. Restart rke2-coredns:
+    ```
+    kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
+1. Confirm rke2-coredns was rolled out successfully:
+    ```
+    kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
 
 ### Configuration persistence
 

--- a/versioned_docs/version-v1.4/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.4/install/update-harvester-configuration.md
@@ -44,6 +44,14 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
     ```
     cat /etc/resolv.conf
     ```
+1. Restart rke2-coredns:
+    ```
+    kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
+1. Confirm rke2-coredns was rolled out successfully:
+    ```
+    kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
 
 ### Configuration persistence
 

--- a/versioned_docs/version-v1.5/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.5/install/update-harvester-configuration.md
@@ -44,6 +44,14 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
     ```
     cat /etc/resolv.conf
     ```
+1. Restart rke2-coredns:
+    ```
+    kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
+1. Confirm rke2-coredns was rolled out successfully:
+    ```
+    kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+    ```
 
 ### Configuration persistence
 


### PR DESCRIPTION
* adds mentioning that it's beneficial to restart rke2-coredns-rke2-coredns when the DNS server runtime change is applied

Resolves: doc/fix-8590

Fixes: https://github.com/harvester/harvester/issues/8590


#### Problem:
https://github.com/harvester/harvester/issues/8590

#### Solution:
Restart rke2-coredns, it's good to mention that.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8590

#### Test plan:
N/A

#### Additional documentation or context
N/A