### PR TITLE
feat: remove ignore openapi script in pr review phase

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,10 +26,6 @@ jobs:
         run: |
           PUPPETEER_DOWNLOAD_BASE_URL=https://storage.googleapis.com/chrome-for-testing-public yarn install --frozen-lockfile
 
-      - name: Ignore OpenAPI
-        run: |
-          ./scripts/ignore-openapi
-
       - name: Build
         env:
           NODE_OPTIONS: "--max_old_space_size=7168"


### PR DESCRIPTION
Since the script ignore-openapi will change the api category setting, let's remove it.

https://github.com/harvester/docs/blob/34d9ba1671ce553f3718d0b11dbc8ed1b2f7eaf8/scripts/ignore-openapi#L49-L56

In the ancient drone CI version, the release pipeline didn't call any ignore-openapi script.

https://github.com/harvester/docs/blob/8986431f6f425c91194ea748656c7878d838edf6/.drone.yml#L51 

Besides, we had speeded up the building time before. Last one, we had ignored those files since https://github.com/harvester/docs/pull/545 . So, I don't think we need that script anymore.

**Let's test wth pull request review first. If it's okay, I'll open another PR to remove it in release.yaml.**