### PR TITLE
docs: mention the serviceCIDR setting for managed dhcp add-on

### DIFF
--- a/docs/advanced/addons/managed-dhcp.md
+++ b/docs/advanced/addons/managed-dhcp.md
@@ -39,7 +39,11 @@ kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons
 
 :::note
 
-The vm-dhcp-controller add-on defaults to service CIDR `10.53.0.0/16` and cannot dynamically detect cluster-specific service CIDRs. When your cluster uses a different service CIDR, configure it explicitly in the Addon CR `valuesContent` section:
+The vm-dhcp-controller add-on cannot dynamically detect cluster-specific service CIDRs and uses `10.53.0.0/16` by default.
+
+When your cluster uses a different service CIDR, you must configure it explicitly in the `valuesContent` section of the `Addon` CR to prevent issues. Specifically, attempts to create IP pool resources (IPPools) can fail when CIDRs overlap with the default `10.53.0.0/16` service CIDR.
+
+Example:
 
 ```yaml
 apiVersion: harvesterhci.io/v1beta1
@@ -54,13 +58,11 @@ spec:
     serviceCIDR: <your-cluster-service-cidr> # for instance, 10.96.0.0/16
 ```
 
-Check your cluster's service CIDR with:
+You can check your cluster's service CIDR using the following command:
 
 ```bash
 kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "service-cluster-ip-range"
 ```
-
-This prevents IPPool creation failures when CIDRs overlap with the default `10.53.0.0/16` assumption.
 
 :::
 

--- a/docs/advanced/addons/managed-dhcp.md
+++ b/docs/advanced/addons/managed-dhcp.md
@@ -37,6 +37,33 @@ The vm-dhcp-controller add-on is not packed into the Harvester ISO, but you can 
 kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/main/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
 ```
 
+:::note
+
+The vm-dhcp-controller add-on defaults to service CIDR `10.53.0.0/16` and cannot dynamically detect cluster-specific service CIDRs. When your cluster uses a different service CIDR, configure it explicitly in the Addon CR `valuesContent` section:
+
+```yaml
+apiVersion: harvesterhci.io/v1beta1
+kind: Addon
+metadata:
+  ...
+  name: harvester-vm-dhcp-controller
+  namespace: harvester-system
+spec:
+  ...
+  valuesContent: |
+    serviceCIDR: <your-cluster-service-cidr> # for instance, 10.96.0.0/16
+```
+
+Check your cluster's service CIDR with:
+
+```bash
+kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "service-cluster-ip-range"
+```
+
+This prevents IPPool creation failures when CIDRs overlap with the default `10.53.0.0/16` assumption.
+
+:::
+
 After installation, enable the add-on on the **Dashboard** screen of the Harvester UI or using the command-line tool kubectl.
 
 ![](/img/v1.3/vm-dhcp-controller/enable-addon.png)

--- a/versioned_docs/version-v1.4/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.4/advanced/addons/managed-dhcp.md
@@ -39,7 +39,11 @@ kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons
 
 :::note
 
-The vm-dhcp-controller add-on defaults to service CIDR `10.53.0.0/16` and cannot dynamically detect cluster-specific service CIDRs. When your cluster uses a different service CIDR, configure it explicitly in the Addon CR `valuesContent` section:
+The vm-dhcp-controller add-on cannot dynamically detect cluster-specific service CIDRs and uses `10.53.0.0/16` by default.
+
+When your cluster uses a different service CIDR, you must configure it explicitly in the `valuesContent` section of the `Addon` CR to prevent issues. Specifically, attempts to create IP pool resources (IPPools) can fail when CIDRs overlap with the default `10.53.0.0/16` service CIDR.
+
+Example:
 
 ```yaml
 apiVersion: harvesterhci.io/v1beta1
@@ -54,13 +58,11 @@ spec:
     serviceCIDR: <your-cluster-service-cidr> # for instance, 10.96.0.0/16
 ```
 
-Check your cluster's service CIDR with:
+You can check your cluster's service CIDR using the following command:
 
 ```bash
 kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "service-cluster-ip-range"
 ```
-
-This prevents IPPool creation failures when CIDRs overlap with the default `10.53.0.0/16` assumption.
 
 :::
 

--- a/versioned_docs/version-v1.4/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.4/advanced/addons/managed-dhcp.md
@@ -37,6 +37,33 @@ The vm-dhcp-controller add-on is not packed into the Harvester ISO, but you can 
 kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/main/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
 ```
 
+:::note
+
+The vm-dhcp-controller add-on defaults to service CIDR `10.53.0.0/16` and cannot dynamically detect cluster-specific service CIDRs. When your cluster uses a different service CIDR, configure it explicitly in the Addon CR `valuesContent` section:
+
+```yaml
+apiVersion: harvesterhci.io/v1beta1
+kind: Addon
+metadata:
+  ...
+  name: harvester-vm-dhcp-controller
+  namespace: harvester-system
+spec:
+  ...
+  valuesContent: |
+    serviceCIDR: <your-cluster-service-cidr> # for instance, 10.96.0.0/16
+```
+
+Check your cluster's service CIDR with:
+
+```bash
+kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "service-cluster-ip-range"
+```
+
+This prevents IPPool creation failures when CIDRs overlap with the default `10.53.0.0/16` assumption.
+
+:::
+
 After installation, enable the add-on on the **Dashboard** screen of the Harvester UI or using the command-line tool kubectl.
 
 ![](/img/v1.3/vm-dhcp-controller/enable-addon.png)

--- a/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
@@ -39,7 +39,11 @@ kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons
 
 :::note
 
-The vm-dhcp-controller add-on defaults to service CIDR `10.53.0.0/16` and cannot dynamically detect cluster-specific service CIDRs. When your cluster uses a different service CIDR, configure it explicitly in the Addon CR `valuesContent` section:
+The vm-dhcp-controller add-on cannot dynamically detect cluster-specific service CIDRs and uses `10.53.0.0/16` by default.
+
+When your cluster uses a different service CIDR, you must configure it explicitly in the `valuesContent` section of the `Addon` CR to prevent issues. Specifically, attempts to create IP pool resources (IPPools) can fail when CIDRs overlap with the default `10.53.0.0/16` service CIDR.
+
+Example:
 
 ```yaml
 apiVersion: harvesterhci.io/v1beta1
@@ -54,13 +58,11 @@ spec:
     serviceCIDR: <your-cluster-service-cidr> # for instance, 10.96.0.0/16
 ```
 
-Check your cluster's service CIDR with:
+You can check your cluster's service CIDR using the following command:
 
 ```bash
 kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "service-cluster-ip-range"
 ```
-
-This prevents IPPool creation failures when CIDRs overlap with the default `10.53.0.0/16` assumption.
 
 :::
 

--- a/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
@@ -37,6 +37,33 @@ The vm-dhcp-controller add-on is not packed into the Harvester ISO, but you can 
 kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/main/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
 ```
 
+:::note
+
+The vm-dhcp-controller add-on defaults to service CIDR `10.53.0.0/16` and cannot dynamically detect cluster-specific service CIDRs. When your cluster uses a different service CIDR, configure it explicitly in the Addon CR `valuesContent` section:
+
+```yaml
+apiVersion: harvesterhci.io/v1beta1
+kind: Addon
+metadata:
+  ...
+  name: harvester-vm-dhcp-controller
+  namespace: harvester-system
+spec:
+  ...
+  valuesContent: |
+    serviceCIDR: <your-cluster-service-cidr> # for instance, 10.96.0.0/16
+```
+
+Check your cluster's service CIDR with:
+
+```bash
+kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "service-cluster-ip-range"
+```
+
+This prevents IPPool creation failures when CIDRs overlap with the default `10.53.0.0/16` assumption.
+
+:::
+
 After installation, enable the add-on on the **Dashboard** screen of the Harvester UI or using the command-line tool kubectl.
 
 ![](/img/v1.3/vm-dhcp-controller/enable-addon.png)


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

If the Harvester cluster is configured with a non-default service CIDR, the Managed DHCP add-on will behave incorrectly when the user create an IPPool that covers the default service CIDR `10.53.0.0/16`. Though we had a flag/setting exposed to address this issue, we didn't mention it on the documentation.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add a note to the documentation.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

harvester/harvester#8448

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
