### PR TITLE
Update how MTU is changed and ensured on v160

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -591,8 +591,10 @@ Harvester uses the [systemd net naming scheme](https://www.freedesktop.org/softw
 - `bond_options`: Options for [bonded interfaces](https://www.kernel.org/doc/Documentation/networking/bonding.txt). When unspecified, the following options are used:
   - `mode`: balance-tlb
   - `miimon`: 100
-- `mtu`: Maximum transmission unit (MTU) for the interface.
-- `vlan_id`: VLAN ID for the interface.
+- `mtu`: Maximum transmission unit (MTU) for the interface. Defaults to 1500.
+- `vlan_id`: VLAN ID for the interface. Defaults to 0, means it works in un-tag mode.
+
+See [Change the MTU value of mgmt Network after Installation](../networking/clusternetwork.md#change-the-mtu-value-of-mgmt-network-after-installation) for additional information.
 
 **Example**:
 

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -590,7 +590,7 @@ Harvester uses the [systemd net naming scheme](https://www.freedesktop.org/softw
   - `interfaces.hwAddr`: Hardware MAC address of a slave interface. This field is optional.
 - `bond_options`: Options for [bonded interfaces](https://www.kernel.org/doc/Documentation/networking/bonding.txt). When unspecified, the following options are used:
   - `mode`: Bond mode. The default value is `active-backup`.
-  - `miimon`: Specifies the MII link monitoring frequency in milliseconds. The default value is `100`.
+  - `miimon`: MII link monitoring frequency in milliseconds. The default value is `100`.
 - `mtu`: Maximum transmission unit (MTU) for the interface. The default value is `1500`.
 - `vlan_id`: VLAN ID for the interface. The default value is `0`, which means that the interface is in untagged mode.
 

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -589,12 +589,12 @@ Harvester uses the [systemd net naming scheme](https://www.freedesktop.org/softw
   - `interfaces.name`: Name of a slave interface.
   - `interfaces.hwAddr`: Hardware MAC address of a slave interface. This field is optional.
 - `bond_options`: Options for [bonded interfaces](https://www.kernel.org/doc/Documentation/networking/bonding.txt). When unspecified, the following options are used:
-  - `mode`: balance-tlb
-  - `miimon`: 100
-- `mtu`: Maximum transmission unit (MTU) for the interface. Defaults to 1500.
-- `vlan_id`: VLAN ID for the interface. Defaults to 0, means it works in un-tag mode.
+  - `mode`: Bond mode. The default value is `active-backup`.
+  - `miimon`: Specifies the MII link monitoring frequency in milliseconds. The default value is `100`.
+- `mtu`: Maximum transmission unit (MTU) for the interface. The default value is `1500`.
+- `vlan_id`: VLAN ID for the interface. The default value is `0`, which means that the interface is in untagged mode.
 
-See [Change the MTU value of mgmt Network after Installation](../networking/clusternetwork.md#change-the-mtu-value-of-mgmt-network-after-installation) for additional information.
+For more information, see [Change the MTU Value of `mgmt` After Installation](../networking/clusternetwork.md#change-the-mtu-value-of-mgmt-after-installation).
 
 **Example**:
 

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -85,6 +85,8 @@ The following [video](https://youtu.be/X0VIGZ_lExQ) shows a quick overview of an
 	default via 192.168.122.1 dev mgmt-br proto dhcp
 	```
 	For more information, see [DHCP Server Configuration](./pxe-boot-install.md#dhcp-server-configuration).
+
+	The MTU of the bonded nic defaults to 1500. If you need to customize the MTU value, set the [management interface](./harvester-configuration.md#installmanagement_interface) on a Harvester configuration file.
 	:::
 
 1. (Optional) Configure the CIDRs for the cluster pods and services.

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -86,7 +86,7 @@ The following [video](https://youtu.be/X0VIGZ_lExQ) shows a quick overview of an
 	```
 	For more information, see [DHCP Server Configuration](./pxe-boot-install.md#dhcp-server-configuration).
 
-	The MTU of the bonded nic defaults to 1500. If you need to customize the MTU value, set the [management interface](./harvester-configuration.md#installmanagement_interface) on a Harvester configuration file.
+	The default MTU value of the bonded NIC is `1500`. If you require a different MTU value, configure the [`install.management_interface`](./harvester-configuration.md#installmanagement_interface) setting in a Harvester configuration file per following step.
 	:::
 
 1. (Optional) Configure the CIDRs for the cluster pods and services.

--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -78,13 +78,110 @@ A cluster network called `mgmt` is automatically created when a Harvester cluste
 
 When a Harvester cluster is deployed, a cluster network named `mgmt` is automatically created for intra-cluster communications. `mgmt` consists of the same bridge, bond, and NICs as the external infrastructure network to which each Harvester host attaches with management NICs. Because of this design, `mgmt` also allows virtual machines to be accessed from the external infrastructure network for cluster management purposes.
 
-`mgmt` does not require a network configuration and is always enabled on all hosts. You cannot disable and delete `mgmt`.
+The `mgmt` network does not require a network configuration and is always enabled on all hosts. You cannot disable and delete `mgmt`.
+
+The `mgmt` network uses the default MTU 1500 when you do not input another value other than 0 or 1500 for [management interface](../install/harvester-configuration.md#installmanagement_interface) while installing the cluster.
+
+When a non-default MTU value is set, follow [Annotate the non-default MTU value on mgmt Network after Installation](#annotate-the-non-default-mtu-value-on-mgmt-network-after-installation) right after the cluster is up.
 
 :::caution
 
-Certain [ARP settings](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt) can break cluster communications. With `arp_ignore=2`, for example, replies are sent only if the sender IP address is in the same subnet as the target IP address for which the MAC address is requested. This is not the case in a Harvester cluster, so using `arp_ignore=2` on all interfaces results in failed connectivity checks and prevents Longhorn pods (specifically, `backing-image` and `instance-manager`) from transitioning to the `Ready` state. Volumes cannot be attached to virtual machines if these Longhorn pods are not ready.
+- Certain [ARP settings](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt) can break cluster communications. With `arp_ignore=2`, for example, replies are sent only if the sender IP address is in the same subnet as the target IP address for which the MAC address is requested. This is not the case in a Harvester cluster, so using `arp_ignore=2` on all interfaces results in failed connectivity checks and prevents Longhorn pods (specifically, `backing-image` and `instance-manager`) from transitioning to the `Ready` state. Volumes cannot be attached to virtual machines if these Longhorn pods are not ready.
+
+- Due to the limitations on installation stage, you need to ensure each node to have the same MTU value, Harvester is not able to detect the differences on MTU values when a new node is joining the cluster. Different MTU values might cause unexpected results.
 
 :::
+
+#### Annotate the non-default MTU value on mgmt Network after Installation
+
+_Available as of v1.6.0_
+
+When your cluster is installed with a non-default MTU value like 9000, you need to annotate this value to the `mgmt` clusternetwork object. All the following created [VM network](./harvester-network.md#create-a-vm-network) inheriates this annotated MTU value automatically. Without it, the created `VM network` still defaults the MTU value to 1500.
+
+```
+
+$ kubectl annotate clusternetwork mgmt network.harvesterhci.io/uplink-mtu="9000"
+
+```
+
+:::caution
+
+- You need to ensure the annotation MTU value is same with the MTU value on [management interface](../install/harvester-configuration.md#installmanagement_interface) while installing the cluster.
+
+- You need to ensure all nodes are having the same MTU values.
+
+- For the default MTU value 1500, it does not matter to annotate or not.
+
+:::
+
+#### Change the MTU value of mgmt Network after Installation
+
+The MTU of the mgmt network is saved on an internal file `/oem/90_custom.yaml` on each node. The file stores a lot of basic configuration of the system.
+
+:::caution
+
+- Backup the file first.
+
+- Be very carefuly to change this file.
+
+- Don't touch unrelated contents. Don't remove blank lines.
+
+- Don't change the formats of this yaml file to avoid breaking the system accidentally.
+
+- Run `yq -e /oem/90_custom.yaml` to check the format is valid after the change, fix or restore the file if any error is reported.
+
+- Restore the backup file when the node cannot reboot successfully.
+
+:::
+
+
+1. Stop all virtual machines that are attached to the `mgmt` network.
+
+1. (optional) Disable the [storage network](../advanced/storagenetwork.md#disable-the-storage-network) when it is enabled and locates on `mgmt` network.
+
+1. Change the MTU value via edit below file on each node, and reboot the node to apply the updated change.
+
+    Search the `path: /etc/sysconfig/network/ifcfg-mgmt-bo` and `path: /etc/sysconfig/network/ifcfg-mgmt-br` on `/oem/90_custom.yaml`, change their `MTU=1500` to the target value.
+
+    ```
+    - path: /etc/sysconfig/network/ifcfg-mgmt-bo
+    permissions: 384
+    owner: 0
+    group: 0
+    content: |+
+      MTU=1500     // MTU is the last under the content, and might be a blank line, add or change it
+    encoding: ""
+    ownerstring: ""
+    - path: /etc/sysconfig/network/ifcfg-mgmt-br
+    permissions: 384
+    owner: 0
+    group: 0
+    content: |+
+      MTU=1500     // MTU is the last under the content, and might be a blank line, add or change it
+    encoding: ""
+    ownerstring: ""
+
+    ```
+
+1. After all nodes are rebooted, check the MTU values via `ip link` command.
+
+1. Annotate the `mgmt` clusternetwork object with new MTU value.
+
+    ```
+
+    $ kubectl annotate clusternetwork mgmt network.harvesterhci.io/uplink-mtu="9000"
+
+    ```
+
+1. All virtual machine networks that are attached to the target cluster network are updated automatically with the new MTU.
+
+1. (optional) Enable the [storage network](../advanced/storagenetwork.md#disable-the-storage-network) when it is previously enabled and locates on `mgmt` network.
+
+1. Start all virtual machines that are attached to the `mgmt` network.
+
+1. Verify that the virtual machine workloads are running normally.
+
+For more detailed steps and validations, see [Change the MTU of a Network Configuration with an Attached Storage Network](#change-the-mtu-of-a-network-configuration-with-an-attached-storage-network).
 
 ### Custom Cluster Network
 
@@ -135,7 +232,7 @@ To simplify cluster maintenance, create one network configuration for each node 
 
     - **NICs**: The list contains NICs that are common to all selected nodes. NICs that cannot be selected are unavailable on one or more nodes and must be configured. Once troubleshooting is completed, refresh the screen and verify that the NICs can be selected.
     - **Bond Options**: The default bonding mode is **active-backup**.
-    - **Attributes**: You must use the same MTU across all network configurations of a custom cluster network. If you do not specify an MTU, the default value **1500** is used.
+    - **Attributes**: You must use the same MTU across all network configurations of a custom cluster network. If you do not specify an MTU, the default value **1500** is used. Harvester webhook denies the new network configuration when it has a different MTU with the existing ones.
 
    ![](/img/v1.2/networking/config-uplink.png)
 
@@ -188,7 +285,7 @@ In this scenario, the [storage network](../advanced/storagenetwork.md#harvester-
 :::caution
 
 - The MTU affects Harvester nodes and networking devices such as switches and routers. Careful planning and testing are required to ensure that changing the MTU does not adversely affect the system. For more information, see [Network Topology](./deep-dive.md#network-topology).
-- You must use the same MTU across all network configurations of a custom cluster network. You must also manually update the MTU on existing virtual machine networks.
+- You must use the same MTU across all network configurations of a custom cluster network.
 - Cluster operations are interrupted during the configuration change.
 - The information in this section does not apply to the built-in `mgmt` cluster network.
 
@@ -282,25 +379,13 @@ If you must change the MTU, perform the following steps:
 
     :::info important
 
-    You must change the MTU in each one, and verify that the new MTU was applied.
+    You must change the MTU in each one, and verify that the new MTU was applied. Harvester webhook denies the new network configuration when it has a different MTU with the existing ones.
 
     :::
 
-1. Edit the YAML of all virtual machine networks that are attached to the target cluster network.
+1. All virtual machine networks that are attached to the target cluster network are updated automatically with the new MTU value.
 
-    On the Harvester UI **Virtual Machine Networks** screen, perform the following steps for each attached network:
-
-    1. Select **⋮ > Edit YAML**.
-
-        ![](/img/v1.4/networking/edit-vm-networks.png)
-
-    1. Change the MTU.
-
-        ![](/img/v1.4/networking/edit-vm-network-mtu.png)
-
-    1. Click **Save**.
-
-    You can also use `kubectl` to change the MTU. In the following example, the network name is `vm100`. To edit the YAML of this network, run the command `kubectl edit NetworkAttachmentDefinition.k8s.cni.cncf.io vm100`.
+    In the following example, the network name is `vm100`. Run the command `kubectl get NetworkAttachmentDefinition.k8s.cni.cncf.io vm100 -oyaml` to see that the MTU value is updated.
 
     ```
     apiVersion: k8s.cni.cncf.io/v1
@@ -324,7 +409,7 @@ If you must change the MTU, perform the following steps:
       uid: 8dacf415-ce90-414a-a11b-48f041d46b42
     spec:
       config: >-
-        {"cniVersion":"0.3.1","name":"vm100","type":"bridge","bridge":"cn-data-br","promiscMode":true,"vlan":100,"ipam":{},"mtu":1500}
+        {"cniVersion":"0.3.1","name":"vm100","type":"bridge","bridge":"cn-data-br","promiscMode":true,"vlan":100,"ipam":{},"mtu":9000}
     ```
 
 1. Start all virtual machines that are attached to the target cluster network.
@@ -348,7 +433,7 @@ The storage network is used by `driver.longhorn.io`, which is Harvester's defaul
 :::caution
 
 - The MTU affects Harvester nodes and networking devices such as switches and routers. Careful planning and testing are required to ensure that changing the MTU does not adversely affect the system. For more information, see [Network Topology](./deep-dive.md#network-topology).
-- You must use the same MTU across all network configurations of a custom cluster network. You must also manually update the MTU on existing virtual machine networks.
+- You must use the same MTU across all network configurations of a custom cluster network.
 - All cluster operations are interrupted during the configuration change.
 - The information in this section does not apply to the built-in `mgmt` cluster network.
 
@@ -446,29 +531,17 @@ If you must change the MTU, perform the following steps:
 
     :::info important
 
-    You must change the MTU in each one, and verify that the new MTU was applied.
+    You must change the MTU in each one, and verify that the new MTU was applied. Harvester webhook denies the new network configuration when it has a different MTU with the existing ones.
 
     :::
 
 1. Enable and configure the Harvester [storage network setting](../advanced/storagenetwork.md#enable-the-storage-network), ensuring that the [prerequisites](../advanced/storagenetwork.md#prerequisites) are met.
 
-1. Allow some time for the setting to be enabled, and then [verify that the change was applied](../advanced/storagenetwork.md#verify-configuration-is-completed).
+1. Allow some time for the setting to be enabled, and then [verify that the change was applied](../advanced/storagenetwork.md#verify-configuration-is-completed). It runs with the new MTU.
 
-1. Edit the YAML of all virtual machine networks that are attached to the target cluster network.
+1. All virtual machine networks that are attached to the target cluster network are updated automatically with the new MTU value.
 
-    On the Harvester UI **Virtual Machine Networks** screen, perform the following steps for each attached network:
-
-    1. Select **⋮ > Edit YAML**.
-
-        ![](/img/v1.4/networking/edit-vm-networks.png)
-
-    1. Change the MTU.
-
-        ![](/img/v1.4/networking/edit-vm-network-mtu.png)
-
-    1. Click **Save**.
-
-    You can also use `kubectl` to change the MTU. In the following example, the network name is `vm100`. To edit the YAML of this network, run the command `kubectl edit NetworkAttachmentDefinition.k8s.cni.cncf.io vm100`.
+    In the following example, the network name is `vm100`. Run the command `kubectl get NetworkAttachmentDefinition.k8s.cni.cncf.io vm100 -oyaml` to see that the MTU value is updated.
 
     ```
     apiVersion: k8s.cni.cncf.io/v1
@@ -492,7 +565,7 @@ If you must change the MTU, perform the following steps:
       uid: 8dacf415-ce90-414a-a11b-48f041d46b42
     spec:
       config: >-
-        {"cniVersion":"0.3.1","name":"vm100","type":"bridge","bridge":"cn-data-br","promiscMode":true,"vlan":100,"ipam":{},"mtu":1500}
+        {"cniVersion":"0.3.1","name":"vm100","type":"bridge","bridge":"cn-data-br","promiscMode":true,"vlan":100,"ipam":{},"mtu":9000}
     ```
 
 1. Start all virtual machines that are attached to the target cluster network.

--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -163,7 +163,7 @@ Exercise extreme caution when editing `/oem/90_custom.yaml`. Do not change other
 
     ```
 
-1. Verify that the file's formatting is still valid using the `yq -e /oem/90_custom.yaml` command. The command prints the file's content if no error happens.
+1. Verify that the file's formatting is still valid using the `yq -e /oem/90_custom.yaml` command. This command prints the file's contents unless an error occurs.
 
 1. Reboot each node to apply the change.
 
@@ -238,7 +238,7 @@ To simplify cluster maintenance, create one network configuration for each node 
 
     - **NICs**: The list contains NICs that are common to all selected nodes. NICs that cannot be selected are unavailable on one or more nodes and must be configured. Once troubleshooting is completed, refresh the screen and verify that the NICs can be selected.
     - **Bond Options**: The default bonding mode is **active-backup**.
-    - **Attributes**: You must use the same MTU across all network configurations of a custom cluster network. If you do not specify an MTU, the default value **1500** is used. The Harvester webhook rejects a new network configuration if it's MTU does not match the MTU of existing network configurations.
+    - **Attributes**: You must use the same MTU across all network configurations of a custom cluster network. If you do not specify an MTU, the default value **1500** is used. The Harvester webhook rejects a new network configuration if its MTU does not match the MTU of existing network configurations.
 
    ![](/img/v1.2/networking/config-uplink.png)
 
@@ -385,7 +385,7 @@ If you must change the MTU, perform the following steps:
 
     :::info important
 
-    You must change the MTU in each one, and verify that the new MTU was applied. The Harvester webhook rejects a new network configuration if it's MTU does not match the MTU of existing network configurations.
+    You must change the MTU in each one, and verify that the new MTU was applied. The Harvester webhook rejects a new network configuration if its MTU does not match the MTU of existing network configurations.
 
     :::
 
@@ -537,7 +537,7 @@ If you must change the MTU, perform the following steps:
 
     :::info important
 
-    You must change the MTU in each one, and verify that the new MTU was applied. The Harvester webhook rejects a new network configuration if it's MTU does not match the MTU of existing network configurations.
+    You must change the MTU in each one, and verify that the new MTU was applied. The Harvester webhook rejects a new network configuration if its MTU does not match the MTU of existing network configurations.
 
     :::
 

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -40,7 +40,7 @@ Since the management network is built-in and doesn't require extra operations, y
 
 :::info important
 
-The management network is using the default MTU 1500 when you do not input another value other than 0 or 1500 for [management interface](../install/harvester-configuration.md#installmanagement_interface) while installing the cluster. Then the network interfaces of VMs connected to the management network have an [MTU value of `1450`](https://docs.tigera.io/calico/latest/networking/configuring/mtu#determine-mtu-size). This is because a VXLAN overlay network typically has a slightly higher per-packet overhead.
+`mgmt` uses the default MTU value `1500` if you do not specify a value other than `0` or `1500` in the [`install.management_interface`](../install/harvester-configuration.md#installmanagement_interface) setting during installation. However, the network interfaces of virtual machines connected to `mgmt` have a MTU value of [`1450`](https://docs.tigera.io/calico/latest/networking/configuring/mtu#determine-mtu-size). This is because Harvester adopts `Calico & Flannel CNI` which has a 50-byte per-packet overhead to carry the in-cluster overlay network, and hence the VM has the MTU value `1450`.
 
 ![](/img/v1.3/networking/management-network-mtu.png)
 
@@ -78,7 +78,7 @@ The [Harvester network-controller](https://github.com/harvester/harvester-networ
 
   When you change the MTU on the physical NICs of cluster network uplink, the newly created virtual machine networks automatically inherit the new MTU. The existing virtual machine networks are also updated automatically. For more information, see [Change the MTU of a Network Configuration with an Attached Storage Network](./clusternetwork.md#change-the-mtu-of-a-network-configuration-with-an-attached-storage-network) and [Change the MTU of a Network Configuration with No Attached Storage Network](./clusternetwork.md#change-the-mtu-of-a-network-configuration-with-no-attached-storage-network).
 
-  You cann't change the MTU on the virtual machine networks directly, the operation is denied by webhook.
+  The Harvester webhook does not allow you to directly change the MTU on VM networks.
 
   :::
 
@@ -88,7 +88,7 @@ The [Harvester network-controller](https://github.com/harvester/harvester-networ
 
     ![](/img/v1.2/networking/create-network-auto.png)
 
-    - Manual: Specify the CIDR and gateway addresses. 
+    - Manual: Specify the CIDR and gateway addresses.
 
     ![](/img/v1.2/networking/create-network-manual.png)
 

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -25,19 +25,22 @@ Harvester also introduced storage networking to separate the storage traffic fro
 
 
 ## Management Network
+
 Harvester uses [Canal](https://projectcalico.docs.tigera.io/getting-started/kubernetes/flannel/flannel) as its default management network. It is a built-in network that can be used directly from the cluster.
+
 By default, the management network IP of a VM can only be accessed within the cluster nodes, and the management network IP will change after the VM reboot. This is non-typical behaviour that needs to be taken note of since VM IPs are expected to remain unchanged after a reboot.
 
 However, you can leverage the Kubernetes [service object](https://kubevirt.io/user-guide/virtual_machines/service_objects/) to create a stable IP for your VMs with the management network.
 
 ### How to use management network
+
 Since the management network is built-in and doesn't require extra operations, you can add it directly when configuring the VM network.
 
 ![](/img/v1.2/networking/management-network.png)
 
 :::info important
 
-Network interfaces of VMs connected to the management network have an [MTU value of `1450`](https://docs.tigera.io/calico/latest/networking/configuring/mtu#determine-mtu-size). This is because a VXLAN overlay network typically has a slightly higher per-packet overhead.
+The management network is using the default MTU 1500 when you do not input another value other than 0 or 1500 for [management interface](../install/harvester-configuration.md#installmanagement_interface) while installing the cluster. Then the network interfaces of VMs connected to the management network have an [MTU value of `1450`](https://docs.tigera.io/calico/latest/networking/configuring/mtu#determine-mtu-size). This is because a VXLAN overlay network typically has a slightly higher per-packet overhead.
 
 ![](/img/v1.3/networking/management-network-mtu.png)
 
@@ -73,7 +76,9 @@ The [Harvester network-controller](https://github.com/harvester/harvester-networ
 
   Virtual machine networks inherit the MTU from the network configuration of the associated cluster network. This ensures that virtual machines benefit from the best possible hardware performance. You cannot set a different MTU for virtual machine networks.
 
-  When you change the MTU on the physical NICs, the newly created virtual machine networks automatically inherit the new MTU. The existing virtual machine networks need to be updated manually. For more information, see [Change the MTU of a Network Configuration with an Attached Storage Network](./clusternetwork.md#change-the-mtu-of-a-network-configuration-with-an-attached-storage-network) and [Change the MTU of a Network Configuration with No Attached Storage Network](./clusternetwork.md#change-the-mtu-of-a-network-configuration-with-no-attached-storage-network).
+  When you change the MTU on the physical NICs of cluster network uplink, the newly created virtual machine networks automatically inherit the new MTU. The existing virtual machine networks are also updated automatically. For more information, see [Change the MTU of a Network Configuration with an Attached Storage Network](./clusternetwork.md#change-the-mtu-of-a-network-configuration-with-an-attached-storage-network) and [Change the MTU of a Network Configuration with No Attached Storage Network](./clusternetwork.md#change-the-mtu-of-a-network-configuration-with-no-attached-storage-network).
+
+  You cann't change the MTU on the virtual machine networks directly, the operation is denied by webhook.
 
   :::
 

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -40,7 +40,7 @@ Since the management network is built-in and doesn't require extra operations, y
 
 :::info important
 
-`mgmt` uses the default MTU value `1500` if you do not specify a value other than `0` or `1500` in the [`install.management_interface`](../install/harvester-configuration.md#installmanagement_interface) setting during installation. However, the network interfaces of virtual machines connected to `mgmt` have a MTU value of [`1450`](https://docs.tigera.io/calico/latest/networking/configuring/mtu#determine-mtu-size). This is because Harvester adopts `Calico & Flannel CNI` which has a 50-byte per-packet overhead to carry the in-cluster overlay network, and hence the VM has the MTU value `1450`.
+`mgmt` uses the default MTU value `1500` if you do not specify a value other than `0` or `1500` in the [`install.management_interface`](../install/harvester-configuration.md#installmanagement_interface) setting during installation. However, the network interfaces of virtual machines connected to `mgmt` have an MTU value of [`1450`](https://docs.tigera.io/calico/latest/networking/configuring/mtu#determine-mtu-size). This is because Harvester uses the **Calico and Flannel CNI**, which has an overhead of 50 bytes per packet, to carry the in-cluster overlay network.
 
 ![](/img/v1.3/networking/management-network-mtu.png)
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

After issue https://github.com/harvester/harvester/issues/4355 is fixed, the MTU solution on Harvester has been changed.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Update the document.

1. vlanconfig under a cluster network must have same MTU value
2. vm networks are updated automatically with changed MTU value
3. explain how to change MTU of `mgmt` network

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

Issue: https://github.com/harvester/harvester/issues/4355, 
PR: https://github.com/harvester/network-controller-harvester/pull/149

#### Test plan:
<!-- Describe the test plan by steps. -->

not-required

#### Additional documentation or context
