### PR TITLE
Add description of new longhorn storage value

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -551,9 +551,7 @@ For more information about how to set the correct value, see [Guaranteed Instanc
 
 **Definition**: Percentage of disk space that will not be allocated to the default disk on each new Longhorn node.
 
-Harvester creates a separate partition on the boot disk for the Longhorn default disk. Reserving space on the default root disk for longhorn is redundant in that case.
-
-For more information, see [Storage Reserved Percentage For Default Disk](https://longhorn.io/docs/1.9.1/references/settings/#storage-reserved-percentage-for-default-disk) in the Longhorn documentation.
+Harvester creates a dedicated partition on the boot disk for the Longhorn default disk, so you do not need to reserve any space for it on the root disk.
 
 **Default value**: 0
 


### PR DESCRIPTION
Adding description of the new longhorn default setting: storageReservedPercentageForDefaultDisk

The documentation is for 1.7 only as only on that
version the configuration is present.

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
We always use default longhorn percentage reservation value of 30 and this is not configurable as described here:
https://github.com/harvester/harvester/issues/8200

#### Solution:
Making the longhorn storage reservation on default disk configurable

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8200

#### Test plan:
Spin up local harvester doc and this is how it looks like:
<img width="1919" height="1029" alt="image" src="https://github.com/user-attachments/assets/2fe4f053-67c6-4206-8496-d2c488532480" />


#### Additional documentation or context
