### PR TITLE
fix: update longhorn instance manager pod name

### DIFF
--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -109,7 +109,7 @@ The following occur once the `storage-network` setting is applied:
 
 - Harvester stops all pods that are related to Longhorn volumes, Prometheus, Grafana, Alertmanager, and the VM Import Controller.
 - Harvester creates a new `NetworkAttachmentDefinition` and updates the Longhorn Storage Network setting.
-- Longhorn restarts all `instance-manager-r`, `instance-manager-e`, and `backing-image-manager` pods to apply the new network configuration.
+- Longhorn restarts all `instance-manager` and `backing-image-manager` pods to apply the new network configuration.
 
 ### Configuration Steps
 
@@ -238,7 +238,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
         type: configured
     ```
 
-1. Verify that the Longhorn pods (`instance-manager-e`, `instance-manager-r`, and `backing-image-manager`) are ready and that their networks are correctly configured.
+1. Verify that the Longhorn pods (`instance-manager` and `backing-image-manager`) are ready and that their networks are correctly configured.
 
     You can inspect each pod using the following command:
 
@@ -324,15 +324,15 @@ Harvester does not start virtual machines automatically. You must ensure that th
 
     To test the communication between Longhorn pods, perform the following steps:
 
-    1. Obtain the storage network IP of each Longhorn Instance Manager pod identified in the previous step.
+    1. Obtain the storage network IP of each Longhorn Instance Manager pod (we have one per node) identified in the previous step.
 
       Example:
 
       ```
-      instance-manager-r-43f1624d14076e1d95cd72371f0316e2
+      instance-manager-43f1624d14076e1d95cd72371f0316e2
       storage network IP: 10.0.16.8
 
-      instance-manager-e-ba38771e483008ce61249acf9948322f
+      instance-manager-ba38771e483008ce61249acf9948322f
       storage network IP: 10.0.16.14
       ```
 
@@ -343,7 +343,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
       Example:
 
       ```
-      $ kubectl exec -i -t -n longhorn-system instance-manager-e-ba38771e483008ce61249acf9948322f -- /bin/sh
+      $ kubectl exec -i -t -n longhorn-system instance-manager-ba38771e483008ce61249acf9948322f -- /bin/sh
       
       $ ip addr
       1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
@@ -386,7 +386,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
       Example:
 
       ```
-      From instance-manager-r-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
+      From instance-manager-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
 
       $ curl http://10.0.16.14:8000
       ```

--- a/versioned_docs/version-v1.4/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.4/advanced/storagenetwork.md
@@ -199,7 +199,7 @@ After applying Harvester's Storage Network setting, Harvester will stop all pods
 
 Harvester will also create a new NetworkAttachmentDefinition and update the Longhorn Storage Network setting.
 
-Once the Longhorn setting is updated, Longhorn will restart all `instance-manager-r`, `instance-manager-e`, and `backing-image-manager` pods to apply the new network configuration, and Harvester will restart the pods.
+Once the Longhorn setting is updated, Longhorn will restart all `instance-manager` and `backing-image-manager` pods to apply the new network configuration, and Harvester will restart the pods.
 
 :::note
 
@@ -242,7 +242,7 @@ status:
 
 #### Step 2
 
-Verify the readiness of all Longhorn `instance-manager-e`, `instance-manager-r`, and `backing-image-manager` pods, and confirm that their networks are correctly configured.
+Verify the readiness of all Longhorn `instance-manager` and `backing-image-manager` pods, and confirm that their networks are correctly configured.
 
 Execute the following command to inspect a pod's details:
 
@@ -354,15 +354,15 @@ longhorn-manager-j6dhh/longhorn-manager.log:2024-03-20T16:25:24.662251001Z time=
 
 To test the communication between Longhorn pods, perform the following steps:
 
-4.1 Obtain the storage network IP of each Longhorn Instance Manager pod identified in the previous step.
+4.1 Obtain the storage network IP of each Longhorn Instance Manager pod (we have one per node) identified in the previous step.
 
 Example:
 
 ```
-instance-manager-r-43f1624d14076e1d95cd72371f0316e2
+instance-manager-43f1624d14076e1d95cd72371f0316e2
 storage network IP: 10.0.16.8
 
-instance-manager-e-ba38771e483008ce61249acf9948322f
+instance-manager-ba38771e483008ce61249acf9948322f
 storage network IP: 10.0.16.14
 ```
 
@@ -373,7 +373,7 @@ When you run the command `ip addr`, the output includes IPs that are identical t
 Example:
 
 ```
-$ kubectl exec -i -t -n longhorn-system instance-manager-e-ba38771e483008ce61249acf9948322f -- /bin/sh
+$ kubectl exec -i -t -n longhorn-system instance-manager-ba38771e483008ce61249acf9948322f -- /bin/sh
 
 $ ip addr
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
@@ -420,7 +420,7 @@ Explicitly bind the simple HTTP server to the storage network IP.
 Example:
 
 ```
-From instance-manager-r-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
+From instance-manager-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
 
 $ curl http://10.0.16.14:8000
 ```

--- a/versioned_docs/version-v1.5/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.5/advanced/storagenetwork.md
@@ -109,7 +109,7 @@ The following occur once the `storage-network` setting is applied:
 
 - Harvester stops all pods that are related to Longhorn volumes, Prometheus, Grafana, Alertmanager, and the VM Import Controller.
 - Harvester creates a new `NetworkAttachmentDefinition` and updates the Longhorn Storage Network setting.
-- Longhorn restarts all `instance-manager-r`, `instance-manager-e`, and `backing-image-manager` pods to apply the new network configuration.
+- Longhorn restarts all `instance-manager` and `backing-image-manager` pods to apply the new network configuration.
 
 ### Configuration Steps
 
@@ -238,7 +238,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
         type: configured
     ```
 
-1. Verify that the Longhorn pods (`instance-manager-e`, `instance-manager-r`, and `backing-image-manager`) are ready and that their networks are correctly configured.
+1. Verify that the Longhorn pods (`instance-manager` and `backing-image-manager`) are ready and that their networks are correctly configured.
 
     You can inspect each pod using the following command:
 
@@ -324,15 +324,15 @@ Harvester does not start virtual machines automatically. You must ensure that th
 
     To test the communication between Longhorn pods, perform the following steps:
 
-    1. Obtain the storage network IP of each Longhorn Instance Manager pod identified in the previous step.
+    1. Obtain the storage network IP of each Longhorn Instance Manager pod (we have one per node) identified in the previous step.
 
       Example:
 
       ```
-      instance-manager-r-43f1624d14076e1d95cd72371f0316e2
+      instance-manager-43f1624d14076e1d95cd72371f0316e2
       storage network IP: 10.0.16.8
 
-      instance-manager-e-ba38771e483008ce61249acf9948322f
+      instance-manager-ba38771e483008ce61249acf9948322f
       storage network IP: 10.0.16.14
       ```
 
@@ -343,7 +343,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
       Example:
 
       ```
-      $ kubectl exec -i -t -n longhorn-system instance-manager-e-ba38771e483008ce61249acf9948322f -- /bin/sh
+      $ kubectl exec -i -t -n longhorn-system instance-manager-ba38771e483008ce61249acf9948322f -- /bin/sh
       
       $ ip addr
       1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
@@ -386,7 +386,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
       Example:
 
       ```
-      From instance-manager-r-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
+      From instance-manager-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
 
       $ curl http://10.0.16.14:8000
       ```

--- a/versioned_docs/version-v1.6/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.6/advanced/storagenetwork.md
@@ -109,7 +109,7 @@ The following occur once the `storage-network` setting is applied:
 
 - Harvester stops all pods that are related to Longhorn volumes, Prometheus, Grafana, Alertmanager, and the VM Import Controller.
 - Harvester creates a new `NetworkAttachmentDefinition` and updates the Longhorn Storage Network setting.
-- Longhorn restarts all `instance-manager-r`, `instance-manager-e`, and `backing-image-manager` pods to apply the new network configuration.
+- Longhorn restarts all `instance-manager` and `backing-image-manager` pods to apply the new network configuration.
 
 ### Configuration Steps
 
@@ -238,7 +238,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
         type: configured
     ```
 
-1. Verify that the Longhorn pods (`instance-manager-e`, `instance-manager-r`, and `backing-image-manager`) are ready and that their networks are correctly configured.
+1. Verify that the Longhorn pods (`instance-manager` and `backing-image-manager`) are ready and that their networks are correctly configured.
 
     You can inspect each pod using the following command:
 
@@ -324,15 +324,15 @@ Harvester does not start virtual machines automatically. You must ensure that th
 
     To test the communication between Longhorn pods, perform the following steps:
 
-    1. Obtain the storage network IP of each Longhorn Instance Manager pod identified in the previous step.
+    1. Obtain the storage network IP of each Longhorn Instance Manager pod (we have one per node) identified in the previous step.
 
       Example:
 
       ```
-      instance-manager-r-43f1624d14076e1d95cd72371f0316e2
+      instance-manager-43f1624d14076e1d95cd72371f0316e2
       storage network IP: 10.0.16.8
 
-      instance-manager-e-ba38771e483008ce61249acf9948322f
+      instance-manager-ba38771e483008ce61249acf9948322f
       storage network IP: 10.0.16.14
       ```
 
@@ -343,7 +343,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
       Example:
 
       ```
-      $ kubectl exec -i -t -n longhorn-system instance-manager-e-ba38771e483008ce61249acf9948322f -- /bin/sh
+      $ kubectl exec -i -t -n longhorn-system instance-manager-ba38771e483008ce61249acf9948322f -- /bin/sh
       
       $ ip addr
       1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
@@ -386,7 +386,7 @@ Harvester does not start virtual machines automatically. You must ensure that th
       Example:
 
       ```
-      From instance-manager-r-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
+      From instance-manager-43f1624d14076e1d95cd72371f0316e2 (IP 10.0.16.8)
 
       $ curl http://10.0.16.14:8000
       ```


### PR DESCRIPTION
#### Problem:
In Longhorn, since 1.5 release, engine instance manager and replica instance manager have been consolidated.

#### Solution:
Update longhorn instance manager pod name

#### Related Issue(s):
Issue https://github.com/harvester/harvester/issues/7446
