### PR TITLE
align policy types in network policy yaml example

### DIFF
--- a/versioned_docs/version-v1.6/networking/kubeovn-vm-isolation.md
+++ b/versioned_docs/version-v1.6/networking/kubeovn-vm-isolation.md
@@ -191,9 +191,9 @@ The following virtual machines are created in the `default` namespace and are at
     - from:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - Ingress
-  - Egress
+    policyTypes:
+    - Ingress
+    - Egress
   ```
 
 - Example 2: VM1 and VM2 are allowed to communicate with each other and with other virtual machines in the subnet `172.20.10.0/24`. However, other virtual machines in that subnet cannot communicate with VM1, VM2, and each other. This is because the ingress policy only allows traffic originating from `172.20.10.0/30`.
@@ -209,8 +209,8 @@ The following virtual machines are created in the `default` namespace and are at
     - from:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - Ingress
+    policyTypes:
+    - Ingress
   ```
 
 - Example 3: VM1 and VM2 are allowed to communicate with each other, but not with other virtual machines in the subnet `172.20.10.0/24`. The other virtual machines in the same subnet can communicate with VM1 and VM2. This is because the egress policy allows traffic to be sent to `172.20.10.0/30`.
@@ -226,8 +226,8 @@ The following virtual machines are created in the `default` namespace and are at
     - to:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - egress
+    policyTypes:
+    - egress
   ```
 
 - Example 4: VM2 is allowed to communicate with VM1, but not with other virtual machines in the subnet `172.20.10.0/24`. This is because a pod selector label is applied to VM2. All other virtual machines in the same subnet can communicate with VM1 and each other.
@@ -250,7 +250,7 @@ The following virtual machines are created in the `default` namespace and are at
     - from:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - Ingress
-  - Egress
+    policyTypes:
+    - Ingress
+    - Egress
   ```


### PR DESCRIPTION

#### Problem:
policy types in network policy yaml example in harvester v1.6 not aligned 

#### Solution:
align the policy types under the spec in example

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7381

#### Test plan:


#### Additional documentation or context
