### PR TITLE
doc: correct the storage network note

### DIFF
--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -33,7 +33,6 @@ Every node with an active Longhorn V2 Data Engine requires the following dedicat
 The Longhorn V2 Data Engine currently does not support the following operations:
 
 - Backing image creation and usage
-- Storage network
 - Volume cloning
 - Volume encryption
 - Volume expansion

--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -15,7 +15,6 @@ For more information, see [Longhorn Storage Network](https://longhorn.io/docs/1.
 :::note
 
 - Avoid configuring Longhorn settings directly, as this can result in unexpected or unwanted system behavior.
-- You can only use the Longhorn storage network with the Longhorn V1 Data Engine. Usage with the V2 Data Engine is not yet supported.
 
 :::
 

--- a/versioned_docs/version-v1.6/advanced/longhorn-v2.md
+++ b/versioned_docs/version-v1.6/advanced/longhorn-v2.md
@@ -33,7 +33,6 @@ Every node with an active Longhorn V2 Data Engine requires the following dedicat
 The Longhorn V2 Data Engine currently does not support the following operations:
 
 - Backing image creation and usage
-- Storage network
 - Volume cloning
 - Volume encryption
 - Volume expansion

--- a/versioned_docs/version-v1.6/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.6/advanced/storagenetwork.md
@@ -15,7 +15,6 @@ For more information, see [Longhorn Storage Network](https://longhorn.io/docs/1.
 :::note
 
 - Avoid configuring Longhorn settings directly, as this can result in unexpected or unwanted system behavior.
-- You can only use the Longhorn storage network with the Longhorn V1 Data Engine. Usage with the V2 Data Engine is not yet supported.
 
 :::
 


### PR DESCRIPTION
    - Longhorn v2 data engine can use Storage Network after v1.6.0

    REF: https://github.com/harvester/harvester/issues/7829

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
Longhorn v2 data engine can use Storage Network after v1.6.0, correct the document.

#### Solution:
Longhorn v2 data engine can use Storage Network after v1.6.0, correct the document.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
