### PR TITLE
enhancement: don't use internal storageclasses

### DIFF
--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -95,6 +95,12 @@ spec:
   volumeName: pvc-my-vol
 ```
 
+:::caution
+
+Do not use the `vmstate-persistence` and `longhorn-static` StorageClasses when creating new volumes. `vmstate-persistence` is used for TPM and UEFI persistence, while `longhorn-static` is used for for management of existing Longhorn volumes.
+
+:::
+
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 

--- a/versioned_docs/version-v1.6/volume/create-volume.md
+++ b/versioned_docs/version-v1.6/volume/create-volume.md
@@ -95,6 +95,12 @@ spec:
   volumeName: pvc-my-vol
 ```
 
+:::caution
+
+Do not use the `vmstate-persistence` and `longhorn-static` StorageClasses when creating new volumes. `vmstate-persistence` is used for TPM and UEFI persistence, while `longhorn-static` is used for for management of existing Longhorn volumes.
+
+:::
+
 </TabItem>
 <TabItem value="terraform" label="Terraform">
 


### PR DESCRIPTION
#### Problem:
Creating volumes from the two StorageClasses, `vmstate-persistence` and `longhorn-static`, and attaching them to existing VMs causes the VMs to run incorrectly.

#### Solution:
An Important info has been added in the Create an Empty Volume API tab to describe that `vmstate-persistence` and `longhorn-static `are internal StorageClasses and so an user shouldn't use them.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8561
