### PR TITLE
Add a note for the disk removal rejection

### DIFF
--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -268,13 +268,13 @@ Before removing a disk, you must first evict Longhorn replicas on the disk.
 
 :::note
 
-The replica data would be rebuilt to another disk automatically to keep the high availability. There is a known issue on v2 where single replicated volume will be attempted
+The replica data would be rebuilt to another disk automatically to keep the high availability.
 
 :::
 
 :::note
 
-If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. There is a known issue with multiple [Longhorn V2](https://github.com/longhorn/longhorn/issues/12189) disks where removal of the disk containing single replica blank volume will be rejected if it was once attached to another disk.
+If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. For a Longhorn v2 volume that has never been attached, if its last replica is deleted, Longhorn incorrectly triggers a rebuild on another disk. This rebuilt replica is then marked as healthy, causing the disk to become undeletable even though it contains no valid data tracked in [Issue #12189](https://github.com/longhorn/longhorn/issues/12189). In order to delete the disk, remove the volume first.
 
 :::
 

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -268,13 +268,14 @@ Before removing a disk, you must first evict Longhorn replicas on the disk.
 
 :::note
 
-The replica data would be rebuilt to another disk automatically to keep the high availability.
+The replica data would be rebuilt to another disk automatically to keep the high availability. There is a known issue on v2 where single replicated volume will be attempted
 
 :::
 
 :::note
 
-If the disk contains the last healthy replica of a volume or backing image, the disk removal is rejected. If only a single replica of those objects is configured, move the replica to another disk or remove the objects altogether to confirm that you don't need them. If there is a replication fault, fix the faulty replicas on the other disks before attempting to delete the current one.
+If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. There is a known
+issue with [Longhorn V2](https://github.com/longhorn/longhorn/issues/12189) where removal of the disk containing volume with single replica will be rejected as the controller is trying to rebuild the replica on the disk.
 
 :::
 

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -274,7 +274,7 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 :::note
 
-If the disc contains last healthy replica of volume or backing image, disk removal is rejected. In case a single replica of those objects is configured, move the replica to another disk or remove the objects altogether to acknowledge that you don't need them. In case there is a replication fault, fix the faulty replicas on the other disks before proceeding with the deletion of the current one.
+If the disk contains the last healthy replica of a volume or backing image, the disk removal is rejected. If only a single replica of those objects is configured, move the replica to another disk or remove the objects altogether to confirm that you don't need them. If there is a replication fault, fix the faulty replicas on the other disks before attempting to delete the current one.
 
 :::
 

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -274,7 +274,7 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 :::note
 
-If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one.
+If the disc contains last healthy replica of volume or backing image, disk removal is rejected. In case a single replica of those objects is configured, move the replica to another disk or remove the objects altogether to acknowledge that you don't need them. In case there is a replication fault, fix the faulty replicas on the other disks before proceeding with the deletion of the current one.
 
 :::
 

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -274,7 +274,7 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 :::note
 
-If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. For a Longhorn v2 volume that has never been attached, if its last replica is deleted, Longhorn incorrectly triggers a rebuild on another disk. This rebuilt replica is then marked as healthy, causing the disk to become undeletable even though it contains no valid data tracked in [Issue #12189](https://github.com/longhorn/longhorn/issues/12189). In order to delete the disk, remove the volume first.
+If the disk contains the last healthy replica of a volume or backing image, disk removal will be rejected. If a single replica of those objects was configured, move the replica to another disk or remove the objects altogether to acknowledge that you don't need them. If there was a fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. For a Longhorn v2 volume that has never been attached, if its last replica is deleted, Longhorn incorrectly triggers a rebuild on another disk. This rebuilt replica is then marked as healthy, causing the disk to become undeletable even though it contains no valid data tracked in [Issue #12189](https://github.com/longhorn/longhorn/issues/12189). To delete the disk, remove the volume first.
 
 :::
 

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -272,6 +272,12 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 :::
 
+:::note
+
+If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one.
+
+:::
+
 #### Identify the disk to remove (Harvester dashboard)
 1. Go to the **Hosts** page.
 2. On the node containing the disk, select the node name and go to the **Storage** tab.

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -274,7 +274,7 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 :::note
 
-If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. There is a known
+If disk contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. There is a known
 issue with [Longhorn V2](https://github.com/longhorn/longhorn/issues/12189) where removal of the disk containing volume with single replica will be rejected as the controller is trying to rebuild the replica on the disk.
 
 :::

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -274,8 +274,7 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 :::note
 
-If disk contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. There is a known
-issue with [Longhorn V2](https://github.com/longhorn/longhorn/issues/12189) where removal of the disk containing volume with single replica will be rejected as the controller is trying to rebuild the replica on the disk.
+If disc contains last healthy replica of volume or backing image, disk removal will be rejected. In case a single replica of those objects was configured, move the replica to another disk or remove the objects  altogether to acknowledge that you don't need them. In case there was fault in the replication, fix the faulty replicas on the other disks before proceeding with the deletion of the current one. There is a known issue with multiple [Longhorn V2](https://github.com/longhorn/longhorn/issues/12189) disks where removal of the disk containing single replica blank volume will be rejected if it was once attached to another disk.
 
 :::
 


### PR DESCRIPTION
Adding a note in the beginning of the Remove disks section to mention that in case the disk to be removed hosts the last replica, deletion of thedisk will be rejected

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
In 1.7 we no longer allow deletion of disks containing last healthy replicas and it can be confusing for the user.

#### Solution:
Add a note in the beginning of the `Remove disks` section to elaborate why the rejection might happen.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/3344#issuecomment-3540661397

#### Test plan:
N/A

#### Additional documentation or context
N/A