### PR TITLE
Remove outdated screenshots and references to EOL versions in add-on pages

### DIFF
--- a/docs/advanced/addons/kubeovn-operator.md
+++ b/docs/advanced/addons/kubeovn-operator.md
@@ -26,8 +26,6 @@ You must enable `kubeovn-operator` to deploy Kube-OVN to a Harvester cluster for
 
 1. Select **kubeovn-operator (Experimental)**, and then select **⋮** > **Enable**.
 
-  ![](/img/kubeovn-operator.png)
-
 The add-on deploys `kubeovn-operator` and creates the default `Configuration` object named `configuration.kubeovn.io`, which uses sane Harvester-specific defaults for configuring the Kube-OVN CNI.
 
 The following is an example of a `Configuration` object:

--- a/docs/advanced/addons/lvm-local-storage.md
+++ b/docs/advanced/addons/lvm-local-storage.md
@@ -32,8 +32,6 @@ If you are using the Harvester kubeconfig file, you can install the add-on by pe
 
 1. Select **harvester-csi-driver-lvm (Experimental)**, and then select **⋮** > **Enable**.
 
-    ![](/img/v1.4/csi-driver-lvm/enable-lvm-addon.png)
-
 ## Creating a Volume Group for LVM
 
 A volume group combines physical volumes to create a single storage structure that can be divided into logical volumes.

--- a/docs/advanced/addons/managed-dhcp.md
+++ b/docs/advanced/addons/managed-dhcp.md
@@ -74,8 +74,6 @@ kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "serv
 
 After installation, enable the add-on on the **Dashboard** screen of the Harvester UI or using the command-line tool kubectl.
 
-![](/img/v1.3/vm-dhcp-controller/enable-addon.png)
-
 ## Using the Add-on
 
 1. On the **Dashboard** screen of the Harvester UI, [create a VM Network](../../networking/harvester-network.md#create-a-vm-network).

--- a/docs/advanced/addons/nvidiadrivertoolkit.md
+++ b/docs/advanced/addons/nvidiadrivertoolkit.md
@@ -8,8 +8,6 @@ title: "NVIDIA Driver Toolkit"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
-_Available as of v1.3.0_
-
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.
 
 :::note

--- a/docs/advanced/addons/pcidevices.md
+++ b/docs/advanced/addons/pcidevices.md
@@ -8,8 +8,6 @@ title: "PCI Devices"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
 </head>
 
-_Available as of v1.1.0_
-
 A `PCIDevice` in Harvester represents a host device with a PCI address. 
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, 
 or by using the UI to enable passthrough. Passing a device through the hypervisor means that 
@@ -20,10 +18,8 @@ This is accomplished by using the `pcidevices-controller` addon.
 
 To use the PCI devices feature, users need to enable the `pcidevices-controller` addon first.
 
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
-
 Once the `pcidevices-controller` addon is deployed successfully, it can take a few minutes for it to scan and the PCIDevice CRDs to become available.
-![](/img/v1.2/pcidevices/PcideviceEnabled.png)
+
 ## Enabling Passthrough on a PCI Device
 
 1. Now go to the `Advanced -> PCI Devices` page:
@@ -76,7 +72,6 @@ The pcidevices-controller add-on currently uses unique resource descriptors to p
 ![](/img/v1.4/vm/vm-scheduling.png)
 
 ## SRIOV Network Devices
-_Available as of v1.2.0_
 
 ![](/img/v1.2/pcidevices/SriovNetworkDevicesLink.png)
 
@@ -105,8 +100,6 @@ The newly created PCI device can be passed through to virtual machines like any 
 ![](/img/v1.2/pcidevices/SriovNetworkDevicesFilterResult.png)
 
 ## USB Devices
-
-_Available as of v1.4.0_
 
 A `USBDevice` resource in Harvester represents a USB device on the node. USB devices can be "passed through" by the hypervisor to allow direct access from VMs. This is accomplished through the `pcidevices-controller` add-on. To use USB passthrough, you can either create a `USBDeviceClaim` resource or enable the feature on the Harvester UI. 
 

--- a/docs/advanced/addons/rancher-vcluster.md
+++ b/docs/advanced/addons/rancher-vcluster.md
@@ -36,8 +36,6 @@ After installation, configure the add-on using the Harvester UI.
 
 1. Locate the **rancher-vcluster** add-on, and then select **⋮** > **Edit Config**.
 
-    ![](/img/v1.2/rancher-vcluster/VclusterConfig.png)
-
 1. In the **Hostname** field, enter a valid DNS record pointing to the Harvester VIP. This is essential as the vcluster ingress is synced to the parent Harvester cluster. A valid hostname is used to filter ingress traffic to the vcluster workload.
 
 1. In the **Bootstrap Password** field, enter the bootstrap password for the new Rancher deployed on the vcluster.

--- a/docs/advanced/addons/seeder.md
+++ b/docs/advanced/addons/seeder.md
@@ -53,8 +53,6 @@ Ensure that the following requirements are met before enabling the add-on.
 
     After a few seconds, the value of **State** changes to **DeploySuccessful**.
 
-    ![](/img/v1.2/vm-import-controller/EnableAddon.png)
-
 1. Go to the **Hosts** screen.
 
     You must edit the configuration of each host listed on this screen.

--- a/docs/advanced/addons/virtual-machine-auto-balance.md
+++ b/docs/advanced/addons/virtual-machine-auto-balance.md
@@ -26,6 +26,8 @@ When enabled, the add-on deploys the Descheduler in the `kube-system` namespace 
 
 1. Select **virtual-machine-auto-balance  (Experimental)**, and then select **⋮** > **Enable**.
 
+  ![](/img/v1.7/descheduler/descheduler-enable.png)
+
 ## Descheduler Policies
 
 The configuration contains the following plugins:

--- a/docs/advanced/addons/virtual-machine-auto-balance.md
+++ b/docs/advanced/addons/virtual-machine-auto-balance.md
@@ -26,8 +26,6 @@ When enabled, the add-on deploys the Descheduler in the `kube-system` namespace 
 
 1. Select **virtual-machine-auto-balance  (Experimental)**, and then select **⋮** > **Enable**.
 
-  ![](/img/v1.7/descheduler/descheduler-enable.png)
-
 ## Descheduler Policies
 
 The configuration contains the following plugins:
@@ -40,8 +38,6 @@ With the default configuration, the Descheduler only evicts virtual machine pods
 ### Customizing Descheduler Policies
 
 Select **⋮** > **Edit YAML** to customize the Descheduler policies according to your requirements. The configuration is defined in YAML format.
-
-  ![](/img/v1.7/descheduler/descheduler-edit-yaml.png)
 
   ![](/img/v1.7/descheduler/descheduler-policy.png)
 

--- a/docs/advanced/addons/vmimport.md
+++ b/docs/advanced/addons/vmimport.md
@@ -8,21 +8,15 @@ title: "VM Import"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
 </head>
 
-_Available as of v1.1.0_
-
 With the vm-import-controller add-on, you can import virtual machines from VMware, OpenStack, and Open Virtual Appliance (OVA) packages.
 
 To use the VM import feature, users need to enable the vm-import-controller addon.
-
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
 
 By default, vm-import-controller leverages ephemeral storage, which is mounted from /var/lib/kubelet.  
 
 During the migration, a large VM's node could run out of space on this mount, resulting in subsequent scheduling failures. 
 
 To avoid this, users are advised to enable PVC-backed storage and customize the amount of storage needed. According to the best practice, the PVC size should be twice the size of the largest VM being migrated. This is essential as the PVC is used as scratch space to download the VM, and convert the disks into raw image files.
-
-![](/img/v1.2/vm-import-controller/ConfigureAddon.png)
 
 ## vm-import-controller
 

--- a/versioned_docs/version-v1.5/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.5/advanced/addons/lvm-local-storage.md
@@ -32,8 +32,6 @@ If you are using the Harvester kubeconfig file, you can install the add-on by pe
 
 1. Select **harvester-csi-driver-lvm (Experimental)**, and then select **⋮** > **Enable**.
 
-    ![](/img/v1.4/csi-driver-lvm/enable-lvm-addon.png)
-
 ## Creating a Volume Group for LVM
 
 A volume group combines physical volumes to create a single storage structure that can be divided into logical volumes.

--- a/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
@@ -74,8 +74,6 @@ kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "serv
 
 After installation, enable the add-on on the **Dashboard** screen of the Harvester UI or using the command-line tool kubectl.
 
-![](/img/v1.3/vm-dhcp-controller/enable-addon.png)
-
 ## Using the Add-on
 
 1. On the **Dashboard** screen of the Harvester UI, [create a VM Network](../../networking/harvester-network.md#create-a-vm-network).

--- a/versioned_docs/version-v1.5/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.5/advanced/addons/nvidiadrivertoolkit.md
@@ -8,8 +8,6 @@ title: "NVIDIA Driver Toolkit"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
-_Available as of v1.3.0_
-
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.
 
 :::note
@@ -30,6 +28,6 @@ To enable the addon, users need to perform the following:
 
 Once the addon is enabled, a nvidia-driver-toolkit daemonset is deployed to the cluster.
 
-On pod startup, the entrypoint script will download the nvidia driver from the speificied `Driver Location`, install the driver and load the kernel drivers.
+On pod startup, the ENTRYPOINT script will download the NVIDIA driver from the specified `Driver Location`. Install the driver and load the kernel drivers.
 
 The `PCIDevices` addon can now leverage this addon to manage the lifecycle of the vGPU devices on nodes containing supported GPU [devices](../vgpusupport.md).

--- a/versioned_docs/version-v1.5/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.5/advanced/addons/pcidevices.md
@@ -8,8 +8,6 @@ title: "PCI Devices"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
 </head>
 
-_Available as of v1.1.0_
-
 A `PCIDevice` in Harvester represents a host device with a PCI address. 
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, 
 or by using the UI to enable passthrough. Passing a device through the hypervisor means that 
@@ -20,10 +18,8 @@ This is accomplished by using the `pcidevices-controller` addon.
 
 To use the PCI devices feature, users need to enable the `pcidevices-controller` addon first.
 
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
-
 Once the `pcidevices-controller` addon is deployed successfully, it can take a few minutes for it to scan and the PCIDevice CRDs to become available.
-![](/img/v1.2/pcidevices/PcideviceEnabled.png)
+
 ## Enabling Passthrough on a PCI Device
 
 1. Now go to the `Advanced -> PCI Devices` page:
@@ -76,7 +72,6 @@ The pcidevices-controller add-on currently uses unique resource descriptors to p
 ![](/img/v1.4/vm/vm-scheduling.png)
 
 ## SRIOV Network Devices
-_Available as of v1.2.0_
 
 ![](/img/v1.2/pcidevices/SriovNetworkDevicesLink.png)
 
@@ -105,8 +100,6 @@ The newly created PCI device can be passed through to virtual machines like any 
 ![](/img/v1.2/pcidevices/SriovNetworkDevicesFilterResult.png)
 
 ## USB Devices
-
-_Available as of v1.4.0_
 
 A `USBDevice` resource in Harvester represents a USB device on the node. USB devices can be "passed through" by the hypervisor to allow direct access from VMs. This is accomplished through the `pcidevices-controller` add-on. To use USB passthrough, you can either create a `USBDeviceClaim` resource or enable the feature on the Harvester UI. 
 

--- a/versioned_docs/version-v1.5/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.5/advanced/addons/rancher-vcluster.md
@@ -36,8 +36,6 @@ After installation, configure the add-on using the Harvester UI.
 
 1. Locate the **rancher-vcluster** add-on, and then select **⋮** > **Edit Config**.
 
-    ![](/img/v1.2/rancher-vcluster/VclusterConfig.png)
-
 1. In the **Hostname** field, enter a valid DNS record pointing to the Harvester VIP. This is essential as the vcluster ingress is synced to the parent Harvester cluster. A valid hostname is used to filter ingress traffic to the vcluster workload.
 
 1. In the **Bootstrap Password** field, enter the bootstrap password for the new Rancher deployed on the vcluster.

--- a/versioned_docs/version-v1.5/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.5/advanced/addons/seeder.md
@@ -45,15 +45,13 @@ Ensure that the following requirements are met before enabling the add-on.
 
     Some hardware vendors may require that you enable alerts.
 
-## Enable the Add-On and Configure Hosts
+## Enabling the Add-On and Configuring Hosts
 
-1. On the Harvester UI, go to **Advanced** > **Addons**.
+1. On the Harvester UI, go to **Advanced** > **Add-ons**.
 
 1. Select **harvester-seeder**, and then select **⋮** > **Enable**.
 
     After a few seconds, the value of **State** changes to **DeploySuccessful**.
-
-    ![](/img/v1.2/vm-import-controller/EnableAddon.png)
 
 1. Go to the **Hosts** screen.
 

--- a/versioned_docs/version-v1.5/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.5/advanced/addons/vmimport.md
@@ -8,21 +8,15 @@ title: "VM Import"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
 </head>
 
-_Available as of v1.1.0_
-
-With the vm-import-controller addon users can import their virtual machines from VMware and OpenStack into Harvester.
+With the vm-import-controller add-on, you can import virtual machines from VMware and OpenStack.
 
 To use the VM import feature, users need to enable the vm-import-controller addon.
-
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
 
 By default, vm-import-controller leverages ephemeral storage, which is mounted from /var/lib/kubelet.  
 
 During the migration, a large VM's node could run out of space on this mount, resulting in subsequent scheduling failures. 
 
 To avoid this, users are advised to enable PVC-backed storage and customize the amount of storage needed. According to the best practice, the PVC size should be twice the size of the largest VM being migrated. This is essential as the PVC is used as scratch space to download the VM, and convert the disks into raw image files.
-
-![](/img/v1.2/vm-import-controller/ConfigureAddon.png)
 
 ## vm-import-controller
 
@@ -71,7 +65,7 @@ Once this check is passed, the source is marked as ready and can be used for VM 
 
 ```shell
 $ kubectl get vmwaresource.migration 
-NAME      STATUS
+NAME    STATUS
 vcsim   clusterReady
 ```
 
@@ -144,7 +138,7 @@ spec:
 
 This will trigger the controller to export the VM named "alpine-export-test" on the VMware source cluster to be exported, processed and recreated into the Harvester cluster.
 
-This can take a while based on the size of the virtual machine, but users should see `VirtualMachineImages` created for each disk in the defined virtual machine.
+The duration of the import process depends on the size of the virtual machine. While the import process may take some time, you should see `VirtualMachineImages` created for each disk in the defined virtual machine.
 
 If the source virtual machine is placed in a folder, you can specify the folder name in the optional `folder` field.
 
@@ -161,7 +155,6 @@ $ kubectl get virtualmachineimport.migration
 NAME                    STATUS
 alpine-export-test      virtualMachineRunning
 openstack-cirros-test   virtualMachineRunning
-
 ```
 
 Similarly, users can define a VirtualMachineImport for an OpenStack source as well:
@@ -190,5 +183,8 @@ spec:
 OpenStack allows users to have multiple instances with the same name. In such a scenario, users are advised to use the Instance ID. The reconciliation logic tries to perform a name-to-ID lookup when a name is used.
 :::
 
-#### Known issues
-* **Source virtual machine name is not RFC1123 compliant**: When creating a virtual machine object, the vm-import-controller add-on uses the name of the source virtual machine, which may not meet the Kubernetes object [naming criteria](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names). You may need to rename the source virtual machine to allow successful completion of the import.
+#### Known Issues
+
+##### Source Virtual Machine Name Is Not RFC1123-Compliant
+
+When creating a virtual machine object, the vm-import-controller add-on uses the name of the source virtual machine, which may not meet the Kubernetes object [naming criteria](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names). You may need to rename the source virtual machine to allow successful completion of the import.

--- a/versioned_docs/version-v1.6/advanced/addons/kubeovn-operator.md
+++ b/versioned_docs/version-v1.6/advanced/addons/kubeovn-operator.md
@@ -26,8 +26,6 @@ You must enable `kubeovn-operator` to deploy Kube-OVN to a Harvester cluster for
 
 1. Select **kubeovn-operator (Experimental)**, and then select **⋮** > **Enable**.
 
-  ![](/img/kubeovn-operator.png)
-
 The add-on deploys `kubeovn-operator` and creates the default `Configuration` object named `configuration.kubeovn.io`, which uses sane Harvester-specific defaults for configuring the Kube-OVN CNI.
 
 The following is an example of a `Configuration` object:

--- a/versioned_docs/version-v1.6/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.6/advanced/addons/lvm-local-storage.md
@@ -32,8 +32,6 @@ If you are using the Harvester kubeconfig file, you can install the add-on by pe
 
 1. Select **harvester-csi-driver-lvm (Experimental)**, and then select **⋮** > **Enable**.
 
-    ![](/img/v1.4/csi-driver-lvm/enable-lvm-addon.png)
-
 ## Creating a Volume Group for LVM
 
 A volume group combines physical volumes to create a single storage structure that can be divided into logical volumes.

--- a/versioned_docs/version-v1.6/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.6/advanced/addons/managed-dhcp.md
@@ -74,8 +74,6 @@ kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "serv
 
 After installation, enable the add-on on the **Dashboard** screen of the Harvester UI or using the command-line tool kubectl.
 
-![](/img/v1.3/vm-dhcp-controller/enable-addon.png)
-
 ## Using the Add-on
 
 1. On the **Dashboard** screen of the Harvester UI, [create a VM Network](../../networking/harvester-network.md#create-a-vm-network).

--- a/versioned_docs/version-v1.6/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.6/advanced/addons/nvidiadrivertoolkit.md
@@ -8,8 +8,6 @@ title: "NVIDIA Driver Toolkit"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
-_Available as of v1.3.0_
-
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.
 
 :::note
@@ -30,6 +28,6 @@ To enable the addon, users need to perform the following:
 
 Once the addon is enabled, a nvidia-driver-toolkit daemonset is deployed to the cluster.
 
-On pod startup, the entrypoint script will download the nvidia driver from the speificied `Driver Location`, install the driver and load the kernel drivers.
+On pod startup, the ENTRYPOINT script will download the NVIDIA driver from the specified `Driver Location`. Install the driver and load the kernel drivers.
 
 The `PCIDevices` addon can now leverage this addon to manage the lifecycle of the vGPU devices on nodes containing supported GPU [devices](../vgpusupport.md).

--- a/versioned_docs/version-v1.6/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.6/advanced/addons/pcidevices.md
@@ -8,8 +8,6 @@ title: "PCI Devices"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
 </head>
 
-_Available as of v1.1.0_
-
 A `PCIDevice` in Harvester represents a host device with a PCI address. 
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, 
 or by using the UI to enable passthrough. Passing a device through the hypervisor means that 
@@ -20,10 +18,8 @@ This is accomplished by using the `pcidevices-controller` addon.
 
 To use the PCI devices feature, users need to enable the `pcidevices-controller` addon first.
 
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
-
 Once the `pcidevices-controller` addon is deployed successfully, it can take a few minutes for it to scan and the PCIDevice CRDs to become available.
-![](/img/v1.2/pcidevices/PcideviceEnabled.png)
+
 ## Enabling Passthrough on a PCI Device
 
 1. Now go to the `Advanced -> PCI Devices` page:

--- a/versioned_docs/version-v1.6/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.6/advanced/addons/rancher-vcluster.md
@@ -36,8 +36,6 @@ After installation, configure the add-on using the Harvester UI.
 
 1. Locate the **rancher-vcluster** add-on, and then select **⋮** > **Edit Config**.
 
-    ![](/img/v1.2/rancher-vcluster/VclusterConfig.png)
-
 1. In the **Hostname** field, enter a valid DNS record pointing to the Harvester VIP. This is essential as the vcluster ingress is synced to the parent Harvester cluster. A valid hostname is used to filter ingress traffic to the vcluster workload.
 
 1. In the **Bootstrap Password** field, enter the bootstrap password for the new Rancher deployed on the vcluster.

--- a/versioned_docs/version-v1.6/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.6/advanced/addons/seeder.md
@@ -53,8 +53,6 @@ Ensure that the following requirements are met before enabling the add-on.
 
     After a few seconds, the value of **State** changes to **DeploySuccessful**.
 
-    ![](/img/v1.2/vm-import-controller/EnableAddon.png)
-
 1. Go to the **Hosts** screen.
 
     You must edit the configuration of each host listed on this screen.

--- a/versioned_docs/version-v1.6/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.6/advanced/addons/vmimport.md
@@ -8,21 +8,15 @@ title: "VM Import"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
 </head>
 
-_Available as of v1.1.0_
-
-With the vm-import-controller addon users can import their virtual machines from VMware and OpenStack into Harvester.
+With the vm-import-controller add-on, you can import virtual machines from VMware and OpenStack.
 
 To use the VM import feature, users need to enable the vm-import-controller addon.
-
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
 
 By default, vm-import-controller leverages ephemeral storage, which is mounted from /var/lib/kubelet.  
 
 During the migration, a large VM's node could run out of space on this mount, resulting in subsequent scheduling failures. 
 
 To avoid this, users are advised to enable PVC-backed storage and customize the amount of storage needed. According to the best practice, the PVC size should be twice the size of the largest VM being migrated. This is essential as the PVC is used as scratch space to download the VM, and convert the disks into raw image files.
-
-![](/img/v1.2/vm-import-controller/ConfigureAddon.png)
 
 ## vm-import-controller
 
@@ -71,7 +65,7 @@ Once this check is passed, the source is marked as ready and can be used for VM 
 
 ```shell
 $ kubectl get vmwaresource.migration 
-NAME      STATUS
+NAME    STATUS
 vcsim   clusterReady
 ```
 
@@ -232,7 +226,7 @@ OpenStack allows users to have multiple instances with the same name. In such a 
 When creating a virtual machine object, the vm-import-controller add-on uses the name of the source virtual machine, which may not meet the Kubernetes object [naming criteria](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names). You may need to rename the source virtual machine to allow successful completion of the import.
 ##### VMware-Based Virtual Machine Without VMware Tools Is Not Migrated
 
-When you attempt to import a VMware-based virtual machine in Harvester v1.6.0, the following occur if [VMware Tools](https://knowledge.broadcom.com/external/article/315382/overview-of-vmware-tools.html) is not installed on the virtual machine:
+When you attempt to import a VMware-based virtual machine in Harvester v1.6.0, the following issues occur if [VMware Tools](https://knowledge.broadcom.com/external/article/315382/overview-of-vmware-tools.html) is not installed on the virtual machine:
 
 - The vm-import-controller does not gracefully shut down the guest operating system.
 - When the graceful shutdown period (`gracefulShutdownTimeoutSeconds`) lapses, the vm-import-controller does not force a hard poweroff.

--- a/versioned_docs/version-v1.7/advanced/addons/kubeovn-operator.md
+++ b/versioned_docs/version-v1.7/advanced/addons/kubeovn-operator.md
@@ -26,8 +26,6 @@ You must enable `kubeovn-operator` to deploy Kube-OVN to a Harvester cluster for
 
 1. Select **kubeovn-operator (Experimental)**, and then select **⋮** > **Enable**.
 
-  ![](/img/kubeovn-operator.png)
-
 The add-on deploys `kubeovn-operator` and creates the default `Configuration` object named `configuration.kubeovn.io`, which uses sane Harvester-specific defaults for configuring the Kube-OVN CNI.
 
 The following is an example of a `Configuration` object:

--- a/versioned_docs/version-v1.7/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.7/advanced/addons/lvm-local-storage.md
@@ -32,8 +32,6 @@ If you are using the Harvester kubeconfig file, you can install the add-on by pe
 
 1. Select **harvester-csi-driver-lvm (Experimental)**, and then select **⋮** > **Enable**.
 
-    ![](/img/v1.4/csi-driver-lvm/enable-lvm-addon.png)
-
 ## Creating a Volume Group for LVM
 
 A volume group combines physical volumes to create a single storage structure that can be divided into logical volumes.

--- a/versioned_docs/version-v1.7/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.7/advanced/addons/managed-dhcp.md
@@ -74,8 +74,6 @@ kubectl -n kube-system get pods -l component=kube-apiserver -o yaml | grep "serv
 
 After installation, enable the add-on on the **Dashboard** screen of the Harvester UI or using the command-line tool kubectl.
 
-![](/img/v1.3/vm-dhcp-controller/enable-addon.png)
-
 ## Using the Add-on
 
 1. On the **Dashboard** screen of the Harvester UI, [create a VM Network](../../networking/harvester-network.md#create-a-vm-network).

--- a/versioned_docs/version-v1.7/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.7/advanced/addons/nvidiadrivertoolkit.md
@@ -8,8 +8,6 @@ title: "NVIDIA Driver Toolkit"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
-_Available as of v1.3.0_
-
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.
 
 :::note

--- a/versioned_docs/version-v1.7/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.7/advanced/addons/pcidevices.md
@@ -8,8 +8,6 @@ title: "PCI Devices"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
 </head>
 
-_Available as of v1.1.0_
-
 A `PCIDevice` in Harvester represents a host device with a PCI address. 
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, 
 or by using the UI to enable passthrough. Passing a device through the hypervisor means that 
@@ -20,10 +18,8 @@ This is accomplished by using the `pcidevices-controller` addon.
 
 To use the PCI devices feature, users need to enable the `pcidevices-controller` addon first.
 
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
-
 Once the `pcidevices-controller` addon is deployed successfully, it can take a few minutes for it to scan and the PCIDevice CRDs to become available.
-![](/img/v1.2/pcidevices/PcideviceEnabled.png)
+
 ## Enabling Passthrough on a PCI Device
 
 1. Now go to the `Advanced -> PCI Devices` page:

--- a/versioned_docs/version-v1.7/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.7/advanced/addons/rancher-vcluster.md
@@ -36,8 +36,6 @@ After installation, configure the add-on using the Harvester UI.
 
 1. Locate the **rancher-vcluster** add-on, and then select **⋮** > **Edit Config**.
 
-    ![](/img/v1.2/rancher-vcluster/VclusterConfig.png)
-
 1. In the **Hostname** field, enter a valid DNS record pointing to the Harvester VIP. This is essential as the vcluster ingress is synced to the parent Harvester cluster. A valid hostname is used to filter ingress traffic to the vcluster workload.
 
 1. In the **Bootstrap Password** field, enter the bootstrap password for the new Rancher deployed on the vcluster.

--- a/versioned_docs/version-v1.7/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.7/advanced/addons/seeder.md
@@ -53,8 +53,6 @@ Ensure that the following requirements are met before enabling the add-on.
 
     After a few seconds, the value of **State** changes to **DeploySuccessful**.
 
-    ![](/img/v1.2/vm-import-controller/EnableAddon.png)
-
 1. Go to the **Hosts** screen.
 
     You must edit the configuration of each host listed on this screen.

--- a/versioned_docs/version-v1.7/advanced/addons/virtual-machine-auto-balance.md
+++ b/versioned_docs/version-v1.7/advanced/addons/virtual-machine-auto-balance.md
@@ -41,9 +41,78 @@ With the default configuration, the Descheduler only evicts virtual machine pods
 
 Select **⋮** > **Edit YAML** to customize the Descheduler policies according to your requirements. The configuration is defined in YAML format.
 
-  ![](/img/v1.7/descheduler/descheduler-edit-yaml.png)
-
-  ![](/img/v1.7/descheduler/descheduler-policy.png)
+```yaml
+apiVersion: harvesterhci.io/v1beta1
+kind: Addon
+metadata:
+  name: descheduler
+  namespace: kube-system
+  labels:
+    addon.harvesterhci.io/displayName: "virtual-machine-auto-balance"
+    addon.harvesterhci.io/experimental: "true"
+spec:
+  repo: http://harvester-cluster-repo.cattle-system.svc/charts
+  version: << .DESCHEDULER_CHART_VERSION >>
+  chart: descheduler
+  {{- if and .Addons .Addons.descheduler }}
+  enabled: {{ .Addons.descheduler.Enabled }}
+  {{- else }}
+  enabled: false
+  {{- end }}
+  valuesContent: |
+    kind: Deployment
+    image:
+      repository: registry.k8s.io/descheduler/descheduler
+      pullPolicy: IfNotPresent
+    deschedulingInterval: 5m
+    replicas: 1
+    cmdOptions:
+      v: 3
+      feature-gates: EvictionsInBackground=true
+    deschedulerPolicy:
+      maxNoOfPodsToEvictPerNode: 5
+      profiles:
+      - name: default
+        pluginConfig:
+        - name: DefaultEvictor
+          args:
+            nodeFit: true
+            ignorePvcPods: false
+            evictLocalStoragePods: true
+            labelSelector:
+              matchExpressions:
+                - key: "kubevirt.io"
+                  operator: "In"
+                  values:
+                    - "virt-launcher"
+        - name: LowNodeUtilization
+          args:
+            evictableNamespaces:
+              exclude:
+              - cattle-dashboards
+              - cattle-fleet-clusters-system
+              - cattle-fleet-local-system
+              - cattle-fleet-system
+              - cattle-logging-system
+              - cattle-monitoring-system
+              - cattle-provisioning-capi-system
+              - cattle-system
+              - fleet-local
+              - harvester-system
+              - kube-system
+              - local
+              - longhorn-system
+            thresholds:
+              cpu: 30
+              memory: 30
+            targetThresholds:
+              cpu: 50
+              memory: 50
+        plugins:
+          balance:
+            enabled:
+            - LowNodeUtilization
+```
 
 - `deschedulingInterval`: How often the Descheduler runs. The default value is `5m` (5 minutes).
 - `maxNoOfPodsToEvictPerNode`: Maximum number of pods that can be evicted during a single descheduling cycle. The default is value is `5`.

--- a/versioned_docs/version-v1.7/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.7/advanced/addons/vmimport.md
@@ -8,13 +8,9 @@ title: "VM Import"
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
 </head>
 
-_Available as of v1.1.0_
-
 With the vm-import-controller add-on, you can import virtual machines from VMware, OpenStack, and Open Virtual Appliance (OVA) packages.
 
 To use the VM import feature, users need to enable the vm-import-controller addon.
-
-![](/img/v1.2/vm-import-controller/EnableAddon.png)
 
 By default, vm-import-controller leverages ephemeral storage, which is mounted from /var/lib/kubelet.  
 


### PR DESCRIPTION
Related issue: [#9796](https://github.com/harvester/harvester/issues/9796)

Scope: v1.5, v1.6, v1.7, v1.8
- `advanced/addons/kubeovn-operator.md`
- `advanced/addons/lvm-local-storage.md`
- `advanced/addons/managed-dhcp.md`
- `advanced/addons/nvidiadrivertoolkit.md`
- `advanced/addons/pcidevices.md`
- `advanced/addons/rancher-vcluster.md`
- `advanced/addons/seeder.md`
- `advanced/addons/virtual-machine-auto-balance.md`
- `advanced/addons/vmimport.md`

Changes:
- Removed outdated screenshots of **Addons** UI
- Removed references to EOL versions (Example: _Available as of v1.2.0_)
- `virtual-machine-auto-balance.md`: Replaced screenshot of YAML config with actual [sample code](https://github.com/harvester/addons/blob/083cd36f687a51377e969512bf917b0f8c5ff65a/pkg/templates/rancherd-22-addons.yaml#L355-L424)