### PR TITLE
adj: Remove instructions for deploying Rancher server

### DIFF
--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -31,7 +31,7 @@ For the network requirements, please refer to the doc [here](../install/requirem
 
 ## Deploying Rancher server
 
-To use Rancher with Harvester, please install Rancher on a separate server. If you want to try out the integration features, you can create a VM in Harvester and install the Rancher server by following the [Helm CLI quick start](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli).
+To use Rancher with Harvester, you can create a VM in Harvester and install the Rancher server by following the [Helm CLI quick start](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli).
 
 For production setup, please follow [Deploying Rancher Server document](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager) to  deploy and provision Rancher and a Kubernetes cluster with the provider of your choice.
 

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -31,7 +31,7 @@ For the network requirements, please refer to the doc [here](../install/requirem
 
 ## Deploying Rancher server
 
-To use Rancher with Harvester, you can create a VM in Harvester and install the Rancher server by following the [Helm CLI quick start](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli).
+To use Rancher with Harvester, you can create a HA setup with three VMs in Harvester and install the Rancher server by following the [Helm CLI quick start](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli).
 
 For production setup, please follow [Deploying Rancher Server document](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager) to  deploy and provision Rancher and a Kubernetes cluster with the provider of your choice.
 

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -31,9 +31,9 @@ For the network requirements, please refer to the doc [here](../install/requirem
 
 ## Deploying Rancher server
 
-To use Rancher with Harvester, you can create a HA setup with three VMs in Harvester and install the Rancher server by following the [Helm CLI quick start](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli).
+For production setups, you must install the Rancher server on a dedicated, high-availability Kubernetes cluster (with three or more nodes) deployed on infrastructure external to the Harvester cluster. Ensure that the cluster nodes meet the [software, hardware, and networking requirements](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements) outlined in the Rancher documentation. For more information, see [Deploying Rancher Server](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager).
 
-For production setup, please follow [Deploying Rancher Server document](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager) to  deploy and provision Rancher and a Kubernetes cluster with the provider of your choice.
+If you want to test the integration features, you can create a virtual machine in Harvester and then install the Rancher server using Helm. For more information, see the [Helm CLI Quick Start](https://ranchermanager.docs.rancher.com/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli).
 
 If you prefer, the following guide will take you through the same process in individual steps. Use this if you want to run Rancher with a different provider, on prem, or if you want to see how easy it is.
 


### PR DESCRIPTION
Removing "please install Rancher on a separate server" as it is confusing for users

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Currently, the Intergrating with Rancher section in the documentation is contradicting itself and leaving readers confused.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Remove the first sentence and combine with the following one to ensure readers are not confused when trying to intergrate Rancher with Harvester.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Related issue: https://github.com/harvester/harvester/issues/9969

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
