### PR TITLE
Use stage name "initramfs" when setting up multipathd

### DIFF
--- a/docs/advanced/csidriver.md
+++ b/docs/advanced/csidriver.md
@@ -293,7 +293,7 @@ This can also be executed by dropping an elemental cloud-init file such as `/oem
 
 ```
 stages:
-   default:
+   initramfs:
    - name: "start multipathd"
      systemctl:
        enable:
@@ -308,14 +308,14 @@ Users wishing to automate this further can leverage the `CloudInit CRD` to apply
 apiVersion: node.harvesterhci.io/v1beta1
 kind: CloudInit
 metadata:
-  name: start-mutlitpathd
+  name: start-multipathd
 spec:
   matchSelector:
     harvesterhci.io/managed: "true"
-  filename: 99-start-mutlitpathd
+  filename: 99-start-multipathd
   contents: |
     stages:
-      default:
+      initramfs:
         - name: "start multipathd"
           systemctl:
             enable:

--- a/versioned_docs/version-v1.4/advanced/csidriver.md
+++ b/versioned_docs/version-v1.4/advanced/csidriver.md
@@ -99,7 +99,7 @@ This can also be executed by dropping an elemental cloud-init file such as `/oem
 
 ```
 stages:
-   default:
+   initramfs:
    - name: "start multipathd"
      systemctl:
        enable:
@@ -114,14 +114,14 @@ Users wishing to automate this further can leverage the `CloudInit CRD` to apply
 apiVersion: node.harvesterhci.io/v1beta1
 kind: CloudInit
 metadata:
-  name: start-mutlitpathd
+  name: start-multipathd
 spec:
   matchSelector:
     harvesterhci.io/managed: "true"
-  filename: 99-start-mutlitpathd
+  filename: 99-start-multipathd
   contents: |
     stages:
-      default:
+      initramfs:
         - name: "start multipathd"
           systemctl:
             enable:

--- a/versioned_docs/version-v1.5/advanced/csidriver.md
+++ b/versioned_docs/version-v1.5/advanced/csidriver.md
@@ -274,7 +274,7 @@ This can also be executed by dropping an elemental cloud-init file such as `/oem
 
 ```
 stages:
-   default:
+   initramfs:
    - name: "start multipathd"
      systemctl:
        enable:
@@ -289,14 +289,14 @@ Users wishing to automate this further can leverage the `CloudInit CRD` to apply
 apiVersion: node.harvesterhci.io/v1beta1
 kind: CloudInit
 metadata:
-  name: start-mutlitpathd
+  name: start-multipathd
 spec:
   matchSelector:
     harvesterhci.io/managed: "true"
-  filename: 99-start-mutlitpathd
+  filename: 99-start-multipathd
   contents: |
     stages:
-      default:
+      initramfs:
         - name: "start multipathd"
           systemctl:
             enable:

--- a/versioned_docs/version-v1.6/advanced/csidriver.md
+++ b/versioned_docs/version-v1.6/advanced/csidriver.md
@@ -288,7 +288,7 @@ This can also be executed by dropping an elemental cloud-init file such as `/oem
 
 ```
 stages:
-   default:
+   initramfs:
    - name: "start multipathd"
      systemctl:
        enable:
@@ -303,14 +303,14 @@ Users wishing to automate this further can leverage the `CloudInit CRD` to apply
 apiVersion: node.harvesterhci.io/v1beta1
 kind: CloudInit
 metadata:
-  name: start-mutlitpathd
+  name: start-multipathd
 spec:
   matchSelector:
     harvesterhci.io/managed: "true"
-  filename: 99-start-mutlitpathd
+  filename: 99-start-multipathd
   contents: |
     stages:
-      default:
+      initramfs:
         - name: "start multipathd"
           systemctl:
             enable:

--- a/versioned_docs/version-v1.7/advanced/csidriver.md
+++ b/versioned_docs/version-v1.7/advanced/csidriver.md
@@ -293,7 +293,7 @@ This can also be executed by dropping an elemental cloud-init file such as `/oem
 
 ```
 stages:
-   default:
+   initramfs:
    - name: "start multipathd"
      systemctl:
        enable:
@@ -308,14 +308,14 @@ Users wishing to automate this further can leverage the `CloudInit CRD` to apply
 apiVersion: node.harvesterhci.io/v1beta1
 kind: CloudInit
 metadata:
-  name: start-mutlitpathd
+  name: start-multipathd
 spec:
   matchSelector:
     harvesterhci.io/managed: "true"
-  filename: 99-start-mutlitpathd
+  filename: 99-start-multipathd
   contents: |
     stages:
-      default:
+      initramfs:
         - name: "start multipathd"
           systemctl:
             enable:


### PR DESCRIPTION
#### Problem:
The `default` stage isn't actually a thing.

#### Solution:
Replace with `initramfs`. Also fixed a small typo.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/7469

#### Test plan:
N/A

#### Additional documentation or context
