### PR TITLE
docs: change cluster ready section for 1.8

### DIFF
--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -108,7 +108,17 @@ $ sudo yq eval .token /etc/rancher/rancherd/config.yaml
 
 ## Check the status of Harvester cluster
 
-Before checking the status of Harvester components, obtain a copy of Harvester cluster's `Cluster token` configured during installation in step 10 of [Installation Steps](../install/iso-install.md#installation-steps) and replace `$TOKEN` with its value.
+Harvester exposes a `readyz` endpoint that can be used to assess the health and readiness status of the control plane.
+
+To probe the endpoint, you will need the:
+
+* cluster token configured in step 10 of the [installation steps](../install/iso-install.md#installation-steps)
+* cluster real VIP following the steps described [here](../install/management-address.md#how-to-get-the-vip-mac-address) (use the value of `kube-vip.io/requestedIP` in the link)
+
+Then you can use a client network tool like `curl` to query the endpoint, replacing the `$TOKEN` and `$VIP` variables accordingly:
+
+```shell
+$ curl -H "Authorization: Bearer $TOKEN" https://$VIP/v1/harvester/readyz
 
 ```shell
 $ curl -H "Authorization: Bearer $TOKEN" https://$VIP/v1/harvester/readyz

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -125,6 +125,7 @@ For cluster using self-signed TLS certificate, run `curl` with the `-k` flag.
 :::note
 
 The endpoint should eventually return response:
+
 ```json
 {"ready":true,"timestamp":"2026-02-12T11:17:40Z"}
 ```

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -119,9 +119,6 @@ Then you can use a client network tool like `curl` to query the endpoint, replac
 
 ```shell
 $ curl -H "Authorization: Bearer $TOKEN" https://$VIP/v1/harvester/readyz
-
-```shell
-$ curl -H "Authorization: Bearer $TOKEN" https://$VIP/v1/harvester/readyz
 ```
 
 :::note
@@ -132,15 +129,11 @@ For cluster using self-signed TLS certificate, run `curl` with the `-k` flag.
 
 :::
 
-:::note
-
 The endpoint should eventually return response:
 
 ```json
 {"ready":true,"timestamp":"2026-02-12T11:17:40Z"}
 ```
-
-:::
 
 ## Collecting troubleshooting information
 

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -106,51 +106,28 @@ $ sudo yq eval .token /etc/rancher/rancherd/config.yaml
 
 :::
 
-## Check the status of Harvester components
+## Check the status of Harvester cluster
 
-Before checking the status of Harvester components, obtain a copy of the Harvester cluster's kubeconfig file following the [guide](../faq.md#how-can-i-access-the-kubeconfig-file-of-the-harvester-cluster).
+Before checking the status of Harvester components, obtain a copy of Harvester cluster's `Cluster token` configured during installation in step 10 of [Installation Steps](../install/iso-install.md#installation-steps) and replace `<TOKEN>` with it's value.
 
-After you obtain a copy of the kubeconfig file, run the following script against the cluster to check the readiness of each component.
+```shell
+$ curl -k -H "Authorization: Bearer <TOKEN>" https://<VIP>/v1/harvester/readyz
+```
 
-- Harvester components script
-  ```shell
-  #!/bin/bash
+:::note
 
-  cluster_ready() {
-    namespaces=("cattle-system" "kube-system" "harvester-system" "longhorn-system")
-    for ns in "${namespaces[@]}"; do
-      pod_statuses=($(kubectl -n "${ns}" get pods \
-        --field-selector=status.phase!=Succeeded \
-        -ojsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name},{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}'))
-      for status in "${pod_statuses[@]}"; do
-        name=$(echo "${status}" | cut -d ',' -f1)
-        ready=$(echo "${status}" | cut -d ',' -f2)
-        if [ "${ready}" != "True" ]; then
-          echo "pod ${name} is not ready"
-          false
-          return
-        fi
-      done
-    done
-  }
+You must replace `<VIP>` with the [real VIP](../install/management-address.md#how-to-get-the-vip-mac-address), which is the value of `kube-vip.io/requestedIP` in the link.
 
-  if cluster_ready; then
-    echo "cluster is ready"
-  else
-    echo "cluster is not ready"
-  fi
-  ```
+:::
 
-- API
-  ```shell
-  $ curl -fk https://<VIP>/version
-  ```
+:::note
 
-  :::note
-  
-  You must replace `<VIP>` with the [real VIP](../install/management-address.md#how-to-get-the-vip-mac-address), which is the value of `kube-vip.io/requestedIP` in the link.
+The endpoint should eventually return response:
+```
+{"ready":true,"timestamp":"2026-02-12T11:17:40Z"}
+```
 
-  :::
+:::
 
 ## Collecting troubleshooting information
 

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -118,6 +118,8 @@ $ curl -H "Authorization: Bearer $TOKEN" https://$VIP/v1/harvester/readyz
 
 You must replace `$VIP` with the [real VIP](../install/management-address.md#how-to-get-the-vip-mac-address), which is the value of `kube-vip.io/requestedIP` in the link.
 
+For cluster using self-signed TLS certificate, run `curl` with the `-k` flag.
+
 :::
 
 :::note

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -108,22 +108,22 @@ $ sudo yq eval .token /etc/rancher/rancherd/config.yaml
 
 ## Check the status of Harvester cluster
 
-Before checking the status of Harvester components, obtain a copy of Harvester cluster's `Cluster token` configured during installation in step 10 of [Installation Steps](../install/iso-install.md#installation-steps) and replace `<TOKEN>` with it's value.
+Before checking the status of Harvester components, obtain a copy of Harvester cluster's `Cluster token` configured during installation in step 10 of [Installation Steps](../install/iso-install.md#installation-steps) and replace `$TOKEN` with its value.
 
 ```shell
-$ curl -k -H "Authorization: Bearer <TOKEN>" https://<VIP>/v1/harvester/readyz
+$ curl -H "Authorization: Bearer $TOKEN" https://$VIP/v1/harvester/readyz
 ```
 
 :::note
 
-You must replace `<VIP>` with the [real VIP](../install/management-address.md#how-to-get-the-vip-mac-address), which is the value of `kube-vip.io/requestedIP` in the link.
+You must replace `$VIP` with the [real VIP](../install/management-address.md#how-to-get-the-vip-mac-address), which is the value of `kube-vip.io/requestedIP` in the link.
 
 :::
 
 :::note
 
 The endpoint should eventually return response:
-```
+```json
 {"ready":true,"timestamp":"2026-02-12T11:17:40Z"}
 ```
 


### PR DESCRIPTION
Changing cluster ready section to reflect the readyz endpoint introduced in 1.8 release

#### Problem:
For 1.8 we still use the component check with script while we actually have readyz endpoint in that release

#### Solution:
Change section from `Check the status of Harvester components` to `Check the status of Harvester cluster` and instead of using the scripts and version which have been used so far, rewrite the section to use the `/readyz` path along explanations what the Cluster Token is and expected response body.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/5303

#### Test plan:
`yarn start` resulted in:
<img width="1016" height="626" alt="image" src="https://github.com/user-attachments/assets/ae0a64eb-97f7-4050-a639-595dfab86f87" />

#### Additional documentation or context
This documents the usage of the readyz path introduced in this PR:
https://github.com/harvester/harvester/pull/9963