### PR TITLE
fix(networking): remove backticks in cloud-config yaml

### DIFF
--- a/docs/networking/kubeovn-vpc.md
+++ b/docs/networking/kubeovn-vpc.md
@@ -250,11 +250,11 @@ Perform the following steps to create and configure a VPC.
     - **Advanced Options** tab
       ```
       users:
-      `  `- name: ubuntu
-      `    `groups: [ sudo ]
-      `    `shell: /bin/bash
-      `    `sudo: ALL=(ALL) NOPASSWD:ALL
-      `    `lock\_passwd: false
+          - name: ubuntu
+            groups: [ sudo ]
+            shell: /bin/bash
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            lock\_passwd: false
       ```
 
     :::note
@@ -354,11 +354,11 @@ The `natOutgoing` setting enables network address translation (NAT) for traffic 
     - **Advanced Options** tab
       ```
       users:
-      `  `- name: ubuntu
-      `    `groups: [ sudo ]
-      `    `shell: /bin/bash
-      `    `sudo: ALL=(ALL) NOPASSWD:ALL
-      `    `lock\_passwd: false
+          - name: ubuntu
+            groups: [ sudo ]
+            shell: /bin/bash
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            lock\_passwd: false
       ```
 
 1. Open the serial console of `vm-external` (`172.20.30.2`), and then ping `8.8.8.8`.

--- a/versioned_docs/version-v1.6/networking/kubeovn-vpc.md
+++ b/versioned_docs/version-v1.6/networking/kubeovn-vpc.md
@@ -250,11 +250,11 @@ Perform the following steps to create and configure a VPC.
     - **Advanced Options** tab
       ```
       users:
-      `  `- name: ubuntu
-      `    `groups: [ sudo ]
-      `    `shell: /bin/bash
-      `    `sudo: ALL=(ALL) NOPASSWD:ALL
-      `    `lock\_passwd: false
+          - name: ubuntu
+            groups: [ sudo ]
+            shell: /bin/bash
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            lock\_passwd: false
       ```
 
     :::note
@@ -354,11 +354,11 @@ The `natOutgoing` setting enables network address translation (NAT) for traffic 
     - **Advanced Options** tab
       ```
       users:
-      `  `- name: ubuntu
-      `    `groups: [ sudo ]
-      `    `shell: /bin/bash
-      `    `sudo: ALL=(ALL) NOPASSWD:ALL
-      `    `lock\_passwd: false
+          - name: ubuntu
+            groups: [ sudo ]
+            shell: /bin/bash
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            lock\_passwd: false
       ```
 
 1. Open the serial console of `vm-external` (`172.20.30.2`), and then ping `8.8.8.8`.

--- a/versioned_docs/version-v1.7/networking/kubeovn-vpc.md
+++ b/versioned_docs/version-v1.7/networking/kubeovn-vpc.md
@@ -250,11 +250,11 @@ Perform the following steps to create and configure a VPC.
     - **Advanced Options** tab
       ```
       users:
-      `  `- name: ubuntu
-      `    `groups: [ sudo ]
-      `    `shell: /bin/bash
-      `    `sudo: ALL=(ALL) NOPASSWD:ALL
-      `    `lock\_passwd: false
+          - name: ubuntu
+            groups: [ sudo ]
+            shell: /bin/bash
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            lock\_passwd: false
       ```
 
     :::note
@@ -354,11 +354,11 @@ The `natOutgoing` setting enables network address translation (NAT) for traffic 
     - **Advanced Options** tab
       ```
       users:
-      `  `- name: ubuntu
-      `    `groups: [ sudo ]
-      `    `shell: /bin/bash
-      `    `sudo: ALL=(ALL) NOPASSWD:ALL
-      `    `lock\_passwd: false
+          - name: ubuntu
+            groups: [ sudo ]
+            shell: /bin/bash
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            lock\_passwd: false
       ```
 
 1. Open the serial console of `vm-external` (`172.20.30.2`), and then ping `8.8.8.8`.


### PR DESCRIPTION
Correct the YAML format for better copy-and-paste usability.