### PR TITLE
SURE-11209 - CPU Feature Appears During Upgrade

### DIFF
--- a/docs/upgrade/v1-5-x-to-v1-6-x.md
+++ b/docs/upgrade/v1-5-x-to-v1-6-x.md
@@ -267,6 +267,7 @@ Related issue: [#9739](https://github.com/harvester/harvester/issues/9739)
 Harvester live migrates virtual machines to ensure zero downtime during node upgrades. If your cluster uses any of the following CPU models, you may notice a temporary feature flag (`cpu-feature.node.kubevirt.io/ipred-ctrl=true`) appear while the upgrade is in progress.
 
 - Intel(R) Xeon(R) Gold 5418Y
+- Intel(R) Xeon(R) Gold 6542Y
 - Intel(R) Xeon(R) Silver 4509Y
 
 While this feature flag is automatically removed from nodes after the upgrade, the corresponding node selector is retained in the virtual machine configuration. This mismatch between the virtual machine's requirements and the node's labels causes subsequent live migrations to fail.

--- a/versioned_docs/version-v1.6/upgrade/v1-5-x-to-v1-6-x.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-5-x-to-v1-6-x.md
@@ -267,6 +267,7 @@ Related issue: [#9739](https://github.com/harvester/harvester/issues/9739)
 Harvester live migrates virtual machines to ensure zero downtime during node upgrades. If your cluster uses any of the following CPU models, you may notice a temporary feature flag (`cpu-feature.node.kubevirt.io/ipred-ctrl=true`) appear while the upgrade is in progress.
 
 - Intel(R) Xeon(R) Gold 5418Y
+- Intel(R) Xeon(R) Gold 6542Y
 - Intel(R) Xeon(R) Silver 4509Y
 
 While this feature flag is automatically removed from nodes after the upgrade, the corresponding node selector is retained in the virtual machine configuration. This mismatch between the virtual machine's requirements and the node's labels causes subsequent live migrations to fail.

--- a/versioned_docs/version-v1.7/upgrade/v1-5-x-to-v1-6-x.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-5-x-to-v1-6-x.md
@@ -267,6 +267,7 @@ Related issue: [#9739](https://github.com/harvester/harvester/issues/9739)
 Harvester live migrates virtual machines to ensure zero downtime during node upgrades. If your cluster uses any of the following CPU models, you may notice a temporary feature flag (`cpu-feature.node.kubevirt.io/ipred-ctrl=true`) appear while the upgrade is in progress.
 
 - Intel(R) Xeon(R) Gold 5418Y
+- Intel(R) Xeon(R) Gold 6542Y
 - Intel(R) Xeon(R) Silver 4509Y
 
 While this feature flag is automatically removed from nodes after the upgrade, the corresponding node selector is retained in the virtual machine configuration. This mismatch between the virtual machine's requirements and the node's labels causes subsequent live migrations to fail.


### PR DESCRIPTION
#### Problem:
We found another CPU that appears to suffer from [this](https://docs.harvesterhci.io/v1.8/upgrade/v1-5-x-to-v1-6-x#8-cpu-featurenodekubevirtioipred-ctrltrue-cpu-feature-appears-during-upgrade) issue when upgrading from 1.5.x to 1.6.x.

#### Solution:
The solution is already described in the KB. It's just a matter of making the model known.

#### Related Issue(s):
Issue https://github.com/harvester/harvester/issues/3015 
Fix https://github.com/harvester/harvester/issues/8797

#### Additional documentation or context
CC @ihcsim 