### PR TITLE
fix: Host Management: update "ISO Installation" link

### DIFF
--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -175,7 +175,7 @@ Hardware issues may force you to replace the management node. In earlier Harvest
 Harvester currently allows only one witness node in the cluster.
 :::
 
-For more information about assigning roles to nodes, see [ISO Installation](/v1.3/install/index).
+For more information about assigning roles to nodes, see [ISO Installation](../install/iso-install.md).
 
 ## Multi-disk Management
 

--- a/versioned_docs/version-v1.3/host/host.md
+++ b/versioned_docs/version-v1.3/host/host.md
@@ -195,7 +195,7 @@ Hardware issues may force you to replace the management node. In earlier Harvest
 Harvester currently allows only one witness node in the cluster.
 :::
 
-For more information about assigning roles to nodes, see [ISO Installation](/v1.3/install/index).
+For more information about assigning roles to nodes, see [ISO Installation](../install/iso-install.md).
 
 ## Multi-disk Management
 

--- a/versioned_docs/version-v1.4/host/host.md
+++ b/versioned_docs/version-v1.4/host/host.md
@@ -211,7 +211,7 @@ Hardware issues may force you to replace the management node. In earlier Harvest
 Harvester currently allows only one witness node in the cluster.
 :::
 
-For more information about assigning roles to nodes, see [ISO Installation](/v1.3/install/index).
+For more information about assigning roles to nodes, see [ISO Installation](../install/iso-install.md).
 
 ## Multi-disk Management
 

--- a/versioned_docs/version-v1.5/host/host.md
+++ b/versioned_docs/version-v1.5/host/host.md
@@ -179,7 +179,7 @@ Hardware issues may force you to replace the management node. In earlier Harvest
 Harvester currently allows only one witness node in the cluster.
 :::
 
-For more information about assigning roles to nodes, see [ISO Installation](/v1.3/install/index).
+For more information about assigning roles to nodes, see [ISO Installation](../install/iso-install.md).
 
 ## Multi-disk Management
 

--- a/versioned_docs/version-v1.6/host/host.md
+++ b/versioned_docs/version-v1.6/host/host.md
@@ -175,7 +175,7 @@ Hardware issues may force you to replace the management node. In earlier Harvest
 Harvester currently allows only one witness node in the cluster.
 :::
 
-For more information about assigning roles to nodes, see [ISO Installation](/v1.3/install/index).
+For more information about assigning roles to nodes, see [ISO Installation](../install/iso-install.md).
 
 ## Multi-disk Management
 

--- a/versioned_docs/version-v1.7/host/host.md
+++ b/versioned_docs/version-v1.7/host/host.md
@@ -175,7 +175,7 @@ Hardware issues may force you to replace the management node. In earlier Harvest
 Harvester currently allows only one witness node in the cluster.
 :::
 
-For more information about assigning roles to nodes, see [ISO Installation](/v1.3/install/index).
+For more information about assigning roles to nodes, see [ISO Installation](../install/iso-install.md).
 
 ## Multi-disk Management
 


### PR DESCRIPTION
#### Problem:
The existing links to ISO Installation in the Role Management section of the Host Management page  are hard coded to point to the v1.3 docs, which don't appear to be published anymore, so the links are broken. 

#### Solution:
Replace with relative links.

#### Related Issue(s):
N/A

#### Test plan:
N/A

#### Additional documentation or context
