### PR TITLE
docs: clarify server_url on cluster creation

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: https://cluster-VIP:443
+server_url: https://cluster-VIP:443 # empty or absent in create mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:
@@ -147,6 +147,7 @@ Make sure that your custom configuration always has the correct scheme version.
 `server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
 
 This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `https://cluster-VIP:443`.
+In `CREATE` mode the parameter must be absent or with empty value (`""`). Otherwise the installation fails.
 
 :::note
 
@@ -155,6 +156,16 @@ To ensure a high availability (HA) Harvester cluster, please use either the Harv
 :::
 
 #### Example
+
+for cluster creation
+
+```yaml
+server_url: '' # or remove this line
+install:
+  mode: create
+```
+
+or to join a cluster
 
 ```yaml
 server_url: https://cluster-VIP:443

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: https://cluster-VIP:443 # empty or absent in create mode
+server_url: "" # empty or absent in create mode; set to https://cluster-VIP:443 in join mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:


### PR DESCRIPTION
the creating node may not have a server_url set
this is due to harvester-installer config validator the config-valudator needs to do this thus harvester checks the value


#### Problem:
when creating a harvester cluster via config (e.g. via ipxe) `server_url` must not be present (or with value)
the current docs are a bit unclear regarding this.

#### Solution:
extend documentation

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10325

#### Test plan:
not applicable

#### Additional documentation or context
see https://github.com/harvester/harvester-installer/blob/8317a66fd50b7954f8d1a87a957abbb11994bfbc/pkg/console/validator.go\#L422
see https://github.com/harvester/harvester-installer/blob/8317a66fd50b7954f8d1a87a957abbb11994bfbc/pkg/config/cos.go\#L377
