### PR TITLE
[docs] Fix yaml Spacing in Rancher Terraform

### DIFF
--- a/docs/rancher/rancher-terraform.md
+++ b/docs/rancher/rancher-terraform.md
@@ -76,7 +76,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
-            version = "4.2.0"
+            version = "13.1.4"
             }
         }
     }
@@ -148,7 +148,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
-        kubernetes_version = "v1.28.10+rke2r1"
+        kubernetes_version = "v1.34.6+rke2r1"
         rke_config {
             machine_pools {
                 name = "pool1"
@@ -188,8 +188,8 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
             chart_values = <<EOF
             harvester-cloud-provider:
-            clusterName: rke2-demo
-            cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+              clusterName: rke2-demo
+              cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
             EOF
         }
     }

--- a/versioned_docs/version-v1.3/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.3/rancher/rancher-terraform.md
@@ -40,7 +40,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
-            version = "4.2.0"
+            version = "5.2.0"
             }
         }
     }
@@ -144,7 +144,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 
     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
-        kubernetes_version = "v1.28.10+rke2r1"
+        kubernetes_version = "v1.30.14+rke2r4"
         rke_config {
             machine_pools {
                 name = "pool1"
@@ -184,8 +184,8 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 
             chart_values = <<EOF
             harvester-cloud-provider:
-            clusterName: rke2-demo
-            cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+              clusterName: rke2-demo
+              cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
             EOF
         }
     }

--- a/versioned_docs/version-v1.4/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.4/rancher/rancher-terraform.md
@@ -76,7 +76,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
-            version = "4.2.0"
+            version = "6.8.0"
             }
         }
     }
@@ -148,7 +148,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
-        kubernetes_version = "v1.28.10+rke2r1"
+        kubernetes_version = "v1.31.6+rke2r1"
         rke_config {
             machine_pools {
                 name = "pool1"
@@ -188,8 +188,8 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
             chart_values = <<EOF
             harvester-cloud-provider:
-            clusterName: rke2-demo
-            cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+              clusterName: rke2-demo
+              cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
             EOF
         }
     }

--- a/versioned_docs/version-v1.5/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.5/rancher/rancher-terraform.md
@@ -76,7 +76,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
-            version = "4.2.0"
+            version = "7.6.1"
             }
         }
     }
@@ -148,7 +148,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
-        kubernetes_version = "v1.28.10+rke2r1"
+        kubernetes_version = "v1.32.5+rke2r1"
         rke_config {
             machine_pools {
                 name = "pool1"
@@ -188,8 +188,8 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
             chart_values = <<EOF
             harvester-cloud-provider:
-            clusterName: rke2-demo
-            cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+              clusterName: rke2-demo
+              cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
             EOF
         }
     }

--- a/versioned_docs/version-v1.6/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.6/rancher/rancher-terraform.md
@@ -76,7 +76,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
-            version = "4.2.0"
+            version = "8.2.1"
             }
         }
     }
@@ -148,7 +148,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
-        kubernetes_version = "v1.28.10+rke2r1"
+        kubernetes_version = "v1.33.3+rke2r1"
         rke_config {
             machine_pools {
                 name = "pool1"
@@ -188,8 +188,8 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
             chart_values = <<EOF
             harvester-cloud-provider:
-            clusterName: rke2-demo
-            cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+              clusterName: rke2-demo
+              cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
             EOF
         }
     }

--- a/versioned_docs/version-v1.7/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.7/rancher/rancher-terraform.md
@@ -76,7 +76,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
-            version = "4.2.0"
+            version = "13.1.4"
             }
         }
     }
@@ -148,7 +148,7 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
-        kubernetes_version = "v1.28.10+rke2r1"
+        kubernetes_version = "v1.34.6+rke2r1"
         rke_config {
             machine_pools {
                 name = "pool1"
@@ -188,8 +188,8 @@ The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher
 
             chart_values = <<EOF
             harvester-cloud-provider:
-            clusterName: rke2-demo
-            cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+              clusterName: rke2-demo
+              cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
             EOF
         }
     }


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->
#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR fixes the incorrect yaml spacing in the Rancher Terraform doc, as well as updates the K8s/terraform versions per the Harvester support matrix.

Current:
```hcl
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
             version = "4.2.0"
             }
         }
     }

     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
         kubernetes_version = "v1.28.10+rke2r1"
         rke_config {
             machine_pools {
                 name = "pool1"

        chart_values = <<EOF
        harvester-cloud-provider:
        clusterName: rke2-demo
        cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
        EOF
```
#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Updated:
```hcl
     required_providers {
         rancher2 = {
             source  = "rancher/rancher2"
-            version = "4.2.0"
+            version = "13.1.4"
             }
         }
     }

     resource "rancher2_cluster_v2" "rke2-demo" {
         name = "rke2-demo"
-        kubernetes_version = "v1.28.10+rke2r1"
+        kubernetes_version = "v1.34.6+rke2r1"
         rke_config {
             machine_pools {
                 name = "pool1"

             chart_values = <<EOF
             harvester-cloud-provider:
-            clusterName: rke2-demo
-            cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
+              clusterName: rke2-demo
+              cloudConfigPath: /var/lib/rancher/rke2/etc/config-files/cloud-provider-config
             EOF
```
#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # https://github.com/harvester/harvester/issues/10331

#### Test plan:
<!-- Describe the test plan by steps. -->
N/A
#### Additional documentation or context
N/A