### PR TITLE
GHA: update upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload static files as artifact
         id: deployment
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: ./build
           


### PR DESCRIPTION
CI failed https://github.com/harvester/docs/actions/runs/24170775101/job/70541863106, 
more details please refer to https://github.com/harvester/harvesterhci.io/pull/106