### PR TITLE
docs: update workaround note

### DIFF
--- a/docs/upgrade/v1-6-x-to-v1-7-x.md
+++ b/docs/upgrade/v1-6-x-to-v1-7-x.md
@@ -227,11 +227,17 @@ To resolve this issue, apply kernel arguments that restore the original names of
 
 :::note
 
-This workaround is only necessary when upgrading to v1.7.0. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+This workaround is only necessary when upgrading to v1.7.0 or if using bonded interfaces. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+
+| Version | Interface | Workaround |
+| --- | --- | --- |
+| v1.7.0 | Any | Required |
+| v1.7.1+ | Standalone | Automated (No action) |
+| v1.7.1+ | Bonded | Required |
 
 :::
 
-Related issues: [#9815](https://github.com/harvester/harvester/issues/9815) and [#9802](https://github.com/harvester/harvester/issues/9802)
+Related issues: [#9815](https://github.com/harvester/harvester/issues/9815), [#9802](https://github.com/harvester/harvester/issues/9802), and [#10397](https://github.com/harvester/harvester/issues/10397)
 
 ### 4. After upgrade the running VMs show message "Restart action is required ..."
 

--- a/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-7-x.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-7-x.md
@@ -227,11 +227,17 @@ To resolve this issue, apply kernel arguments that restore the original names of
 
 :::note
 
-This workaround is only necessary when upgrading to v1.7.0. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+This workaround is only necessary when upgrading to v1.7.0 or if using bonded interfaces. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+
+| Version | Interface | Workaround |
+| --- | --- | --- |
+| v1.7.0 | Any | Required |
+| v1.7.1+ | Standalone | Automated (No action) |
+| v1.7.1+ | Bonded | Required |
 
 :::
 
-Related issues: [#9815](https://github.com/harvester/harvester/issues/9815) and [#9802](https://github.com/harvester/harvester/issues/9802)
+Related issues: [#9815](https://github.com/harvester/harvester/issues/9815), [#9802](https://github.com/harvester/harvester/issues/9802), and [#10397](https://github.com/harvester/harvester/issues/10397)
 
 ### 4. After upgrade the running VMs show message "Restart action is required ..."
 

--- a/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-7-x.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-7-x.md
@@ -227,11 +227,17 @@ To resolve this issue, apply kernel arguments that restore the original names of
 
 :::note
 
-This workaround is only necessary when upgrading to v1.7.0. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+This workaround is only necessary when upgrading to v1.7.0 or if using bonded interfaces. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+
+| Version | Interface | Workaround |
+| --- | --- | --- |
+| v1.7.0 | Any | Required |
+| v1.7.1+ | Standalone | Automated (No action) |
+| v1.7.1+ | Bonded | Required |
 
 :::
 
-Related issues: [#9815](https://github.com/harvester/harvester/issues/9815) and [#9802](https://github.com/harvester/harvester/issues/9802)
+Related issues: [#9815](https://github.com/harvester/harvester/issues/9815), [#9802](https://github.com/harvester/harvester/issues/9802), and [#10397](https://github.com/harvester/harvester/issues/10397)
 
 ### 4. After upgrade the running VMs show message "Restart action is required ..."
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Note in [workaround#3](https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-7-x#3-persistent-names-of-certain-network-interfaces-may-change-during-upgrade) for Harvester upgrade from 1.6.x to 1.7.x does not cover the case with bonded interfaces, leading to ambiguities and possible issues after upgrade.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add clarification on interface renaming workaround, specifying cases where workaround is required vs automated.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10397

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context