### PR TITLE
enhancement: drop BIOS support for new installs (PXE)

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -90,7 +90,6 @@ install:
   cluster_pod_cidr: 10.52.0.0/16
   cluster_service_cidr: 10.53.0.0/16
   cluster_dns: 10.53.0.10
-  force_mbr: false
   addons:
     harvester_vm_import_controller:
       enabled: false
@@ -587,21 +586,6 @@ When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` 
 **Definition**: Setting that forces EFI installation even when EFI is not detected.
 
 **Default value**: `false`
-
-### `install.force_mbr`
-
-**Definition**: Setting that forces usage of MBR partitioning on BIOS systems.
-
-Harvester uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
-
-If you specify the same storage device for both `install.device` and `install.data_disk`, Harvester creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
-
-**Example**:
-
-```yaml
-install:
-  force_mbr: true
-```
 
 ### `install.harvester.longhorn.default_settings.guaranteedInstanceManagerCPU`
 

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -19,7 +19,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.
 
 :::info important
-Support for legacy BIOS booting was deprecated in v1.7.0 and will be removed in a later release. Existing Harvester clusters that use this boot mode will continue to function, but upgrading to later versions may require re-installation in UEFI mode. Starting with Harvester v1.8.0, the installer ISO will not boot on legacy BIOS systems in order to ensure that UEFI is used for all new installations.
+Support for legacy BIOS booting was deprecated in v1.7.0 and will be removed in a later release. Existing Harvester clusters that use this boot mode will continue to function, but upgrading to later versions may require re-installation in UEFI mode. Starting with Harvester v1.8.0, the installer ISO will not boot on legacy BIOS systems in order to ensure that UEFI is used for all new deployments.
 :::
 
 During the installation, you can either choose to **create a new Harvester cluster** or **join the node to an existing Harvester cluster**.

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -24,6 +24,10 @@ We recommend using [iPXE](https://ipxe.org/) to perform the network boot. It has
 
 To see sample iPXE scripts, please visit [Harvester iPXE Examples](https://github.com/harvester/ipxe-examples).
 
+:::info important
+Support for legacy BIOS booting was deprecated in v1.7.0 and will be removed in a later release. Existing Harvester clusters that use this boot mode will continue to function, but upgrading to later versions may require re-installation in UEFI mode. Starting with Harvester v1.8.0, PXE boot installation will fail on legacy BIOS systems in order to ensure that UEFI is used for all new deployments.
+:::
+
 ## Prerequisite
 
 Nodes need to have at least **8 GiB** of RAM because the installer loads the full ISO file into tmpfs.


### PR DESCRIPTION
#### Problem:
We need to eventually remove support for legacy BIOS systems. Ensuring new installs can only be performed on UEFI systems is part of that journey.

#### Solution:
- Explain that PXE install is no longer possible on legacy BIOS systems
- Drop mention of the `install.force_mbr` config option
- A minor wording change to unify the notes with the ISO install

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9854
https://github.com/harvester/harvester/issues/9855

#### Test plan:
N/A

#### Additional documentation or context
This is a followup to https://github.com/harvester/docs/pull/952