### PR TITLE
Remove note about disks requiring WWNs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,10 +50,6 @@ New password for default administrator (user-xxxxx):
 <new_password>
 ```
 
-### I added an additional disk with partitions. Why is it not getting detected?
-
-As of Harvester v1.0.2, we no longer support adding additional partitioned disks, so be sure to delete all partitions first (e.g., using `fdisk`).
-
 ### Why are there some Harvester pods that become ErrImagePull/ImagePullBackOff?
 
 This is likely because your Harvester cluster is an air-gapped setup, and some pre-loaded container images are missing. Kubernetes has a mechanism that does garbage collection against bloated image stores. When the partition which stores container images is over 85% full, `kubelet` tries to prune the images based on the last time they were used, starting with the oldest, until the occupancy is lower than 80%. These numbers (85% and 80%) are default High/Low thresholds that come with Kubernetes.

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -192,12 +192,6 @@ Users can view and add multiple disks as additional data volumes from the edit h
 
 ![Add Disks](/img/v1.4/host/multidisk-mgmt-02.png)
 
-:::caution
-
-As of Harvester v1.0.2, we no longer support adding partitions as additional disks. If you want to add it as an additional disk, be sure to delete all partitions first (e.g., using `fdisk`).
-
-:::
-
 4. Select a provisioner for the disk.
 
   - **LonghornV1 (CSI)**: This is the default provisioner.
@@ -226,16 +220,10 @@ You can also add [storage tags](#storage-tags) if you want Longhorn volume data 
 
 ![disk tag 02](/img/v1.4/host/multidisk-mgmt-07.png)
 
-:::note
-
-In order for Harvester to identify the disks, each disk needs to have a unique [WWN](https://en.wikipedia.org/wiki/World_Wide_Name). Otherwise, Harvester will refuse to add the disk.
-If your disk does not have a WWN, you can format it with the `EXT4` filesystem to help Harvester recognize the disk.
-
-:::
 
 :::note
 
-If you are testing Harvester in a QEMU environment, you'll need to use QEMU v6.0 or later. Previous versions of QEMU will always generate the same WWN for NVMe disks emulation. This will cause Harvester to not add the additional disks, as explained above. However, you can still add a virtual disk with the SCSI controller. The WWN information could be added manually along with the disk attach operation. For more details, please refer to the [script](https://github.com/harvester/vagrant-rancherd/blob/2782981b6017754d016f5b72d630dff4895f7ad6/scripts/attach-disk.sh#L75).
+If you are testing Harvester in a QEMU environment, you'll need to use QEMU v6.0 or later. Previous versions of QEMU will always generate the same WWN for NVMe disks emulation. This will cause Harvester to not add the additional disks. However, you can still add a virtual disk with the SCSI controller. The WWN information could be added manually along with the disk attach operation. For more details, please refer to the [script](https://github.com/harvester/vagrant-rancherd/blob/2782981b6017754d016f5b72d630dff4895f7ad6/scripts/attach-disk.sh#L75).
 
 :::
 


### PR DESCRIPTION
#### Problem:
Harvester no longer requires extra disks to have a WWN in order to be recognised.

#### Solution:
Remove the note about disks requiring a WWN.

I've also removed mention of disks with partitions not being detected, because while we don't support carving up disks into partitions, we can still provision those disks, they'll just be wiped first.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/6261

#### Test plan:
N/A

#### Additional documentation or context
I wondered if, instead of deleting the note, I should have updated it to say "since v1.8, Harvester no longer requires disks have WWNs", but thought that might just be weird at this point in the docs, because this change is an internal implementation detail and new users of Harvester won't notice/realise there was a problem in the first place.  For existing users reading the release notes when upgrading, they'll see the enhancement listed there, and there's also the showcase video on this topic. Is this sufficient?