### PR TITLE
docs: add cluster-registration-url tls setting

### DIFF
--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -142,6 +142,8 @@ For more information, see [cluster-pod-security-standard](./cluster-pod-security
 
 **Definition**: URL used to import the Harvester cluster into Rancher for multi-cluster management.
 
+By default, the registration connection is secured via TLS. Harvester validates the server certificate using its trusted system CA certificates. If your environment uses custom CA certificates, they can be added to the list of Harvester's trusted CA using the [`additional-ca` setting](#additional-ca). In environments where the server certificate is self-signed or signed by an untrusted CA, you can set `insecureSkipTLSVerify` to `true` to skip the TLS verification. However, this is not recommended for production environments.
+
 When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the Harvester ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register Harvester to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see [Find the required assets for your Rancher version](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version) in the Rancher documentation.
 
 Depending on your Harvester settings, the image is downloaded from either of the following locations:
@@ -151,12 +153,12 @@ Depending on your Harvester settings, the image is downloaded from either of the
 
 Alternatively, you can obtain a copy of the image and manually upload it to all Harvester nodes.
 
-**Default value**: None
+**Default value**: `{ "url": "", "insecureSkipTLSVerify": false}`
 
 **Example**:
 
-```
-https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhrc7c_c-m-zxbbbck9.yaml
+```json
+{ "url": "https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhrc7c_c-m-zxbbbck9.yaml", "insecureSkipTLSVerify": false}
 ```
 
 ### `containerd-registry`

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -140,7 +140,7 @@ For more information, see [cluster-pod-security-standard](./cluster-pod-security
 
 ### `cluster-registration-url`
 
-**Definition**: URL used to import the Harvester cluster into Rancher for multi-cluster management.
+**Definition**: JSON object used to import the Harvester cluster into Rancher for multi-cluster management. The `url` field specifies the Rancher registration URL, and the `insecureSkipTLSVerify` field specifies whether TLS certificate verification is skipped when connecting to that URL.
 
 By default, the registration connection is secured via TLS. Harvester validates the server certificate using its trusted system CA certificates. If your environment uses custom CA certificates, they can be added to the list of Harvester's trusted CA using the [`additional-ca` setting](#additional-ca). In environments where the server certificate is self-signed or signed by an untrusted CA, you can set `insecureSkipTLSVerify` to `true` to skip the TLS verification. However, this is not recommended for production environments.
 

--- a/versioned_docs/version-v1.5/advanced/settings.md
+++ b/versioned_docs/version-v1.5/advanced/settings.md
@@ -105,6 +105,12 @@ For more information, see the [Longhorn documentation](https://longhorn.io/docs/
 
 **Definition**: URL used to import the Harvester cluster into Rancher for multi-cluster management.
 
+:::warning
+
+A vulnerability has been identified in the Harvester/Rancher integration mechanism where the registration client did not validate the certificate presented by the remote server while performing the TLS handshake. This security gap could allow an attacker with network-level access between the Harvester and Rancher Manager to execute a man-in-the-middle (MitM) attack against Harvester. You must either upgrade to v1.8 or ensure that only authorized cluster administrators can access and modify the `cluster-registration-url` setting. For more information, see the security advisory at [CVE-2025-71261](https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf).
+
+:::
+
 When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the Harvester ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register Harvester to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see [Find the required assets for your Rancher version](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version) in the Rancher documentation.
 
 Depending on your Harvester settings, the image is downloaded from either of the following locations:

--- a/versioned_docs/version-v1.5/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.5/rancher/rancher-integration.md
@@ -15,6 +15,12 @@ description: Rancher is an open source multi-cluster management platform. Harves
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
 </head>
 
+:::warning
+
+A vulnerability has been identified in the Harvester/Rancher integration mechanism where the registration client did not validate the certificate presented by the remote server while performing the TLS handshake. This security gap could allow an attacker with network-level access between the Harvester and Rancher Manager to execute a man-in-the-middle (MitM) attack against Harvester. You must either upgrade to v1.8 or ensure that only authorized cluster administrators can access and modify the `cluster-registration-url` setting. For more information, see the security advisory at [CVE-2025-71261](https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf).
+
+:::
+
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.
 
 Users can import and manage multiple Harvester clusters using the Rancher [Virtualization Management](virtualization-management.md) feature. Leveraging the Rancher's [authentication](https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/authentication-config) feature and [RBAC control](https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/manage-role-based-access-control-rbac) for [multi-tenancy](virtualization-management.md#multi-tenancy) support.

--- a/versioned_docs/version-v1.6/advanced/settings.md
+++ b/versioned_docs/version-v1.6/advanced/settings.md
@@ -105,6 +105,12 @@ For more information, see the [Longhorn documentation](https://longhorn.io/docs/
 
 **Definition**: URL used to import the Harvester cluster into Rancher for multi-cluster management.
 
+:::warning
+
+A vulnerability has been identified in the Harvester/Rancher integration mechanism where the registration client did not validate the certificate presented by the remote server while performing the TLS handshake. This security gap could allow an attacker with network-level access between the Harvester and Rancher Manager to execute a man-in-the-middle (MitM) attack against Harvester. You must either upgrade to v1.8 or ensure that only authorized cluster administrators can access and modify the `cluster-registration-url` setting. For more information, see the security advisory at [CVE-2025-71261](https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf).
+
+:::
+
 When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the Harvester ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register Harvester to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see [Find the required assets for your Rancher version](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version) in the Rancher documentation.
 
 Depending on your Harvester settings, the image is downloaded from either of the following locations:

--- a/versioned_docs/version-v1.6/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.6/rancher/rancher-integration.md
@@ -15,6 +15,12 @@ description: Rancher is an open source multi-cluster management platform. Harves
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
 </head>
 
+:::warning
+
+A vulnerability has been identified in the Harvester/Rancher integration mechanism where the registration client did not validate the certificate presented by the remote server while performing the TLS handshake. This security gap could allow an attacker with network-level access between the Harvester and Rancher Manager to execute a man-in-the-middle (MitM) attack against Harvester. You must either upgrade to v1.8 or ensure that only authorized cluster administrators can access and modify the `cluster-registration-url` setting. For more information, see the security advisory at [CVE-2025-71261](https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf).
+
+:::
+
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.
 
 Users can import and manage multiple Harvester clusters using the Rancher [Virtualization Management](virtualization-management.md) feature. Leveraging the Rancher's [authentication](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config) feature and [RBAC control](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac) for [multi-tenancy](virtualization-management.md#multi-tenancy) support.

--- a/versioned_docs/version-v1.7/advanced/settings.md
+++ b/versioned_docs/version-v1.7/advanced/settings.md
@@ -105,6 +105,12 @@ For more information, see the [Longhorn documentation](https://longhorn.io/docs/
 
 **Definition**: URL used to import the Harvester cluster into Rancher for multi-cluster management.
 
+:::warning
+
+A vulnerability has been identified in the Harvester/Rancher integration mechanism where the registration client did not validate the certificate presented by the remote server while performing the TLS handshake. This security gap could allow an attacker with network-level access between the Harvester and Rancher Manager to execute a man-in-the-middle (MitM) attack against Harvester. You must either upgrade to v1.8 or ensure that only authorized cluster administrators can access and modify the `cluster-registration-url` setting. For more information, see the security advisory at [CVE-2025-71261](https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf).
+
+:::
+
 When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the Harvester ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register Harvester to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see [Find the required assets for your Rancher version](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version) in the Rancher documentation.
 
 Depending on your Harvester settings, the image is downloaded from either of the following locations:

--- a/versioned_docs/version-v1.7/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.7/rancher/rancher-integration.md
@@ -15,6 +15,12 @@ description: Rancher is an open source multi-cluster management platform. Harves
   <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
 </head>
 
+:::warning
+
+A vulnerability has been identified in the Harvester/Rancher integration mechanism where the registration client did not validate the certificate presented by the remote server while performing the TLS handshake. This security gap could allow an attacker with network-level access between the Harvester and Rancher Manager to execute a man-in-the-middle (MitM) attack against Harvester. You must either upgrade to v1.8 or ensure that only authorized cluster administrators can access and modify the `cluster-registration-url` setting. For more information, see the security advisory at [CVE-2025-71261](https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf).
+
+:::
+
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.
 
 Users can import and manage multiple Harvester clusters using the Rancher [Virtualization Management](virtualization-management.md) feature. Leveraging the Rancher's [authentication](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config) feature and [RBAC control](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac) for [multi-tenancy](virtualization-management.md#multi-tenancy) support.


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Changes:

1.8: Update the `cluster-registration-url` setting section to describe the default TLS configuration
< 1.8: Update the Rancher integration and `cluster-registration-url` setting pages to include information on CVE-2025-71261.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/suse-virtualization-mgmt/issues/5