### PR TITLE
Update canonical links for v1.8.0 release

### DIFF
--- a/docs/advanced/addons.md
+++ b/docs/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Add-ons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons"/>
 </head>
 
 Harvester provides optional features as add-ons to maintain a minimal installation footprint. This design allows you to easily enable or disable functionality based strictly on your use case and requirements. You can customize the settings of each add-on, though the level of customization depends on the underlying software.

--- a/docs/advanced/addons/kubeovn-operator.md
+++ b/docs/advanced/addons/kubeovn-operator.md
@@ -5,7 +5,7 @@ title: "Kube-OVN Operator (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/kubeovn-operator"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/kubeovn-operator"/>
 </head>
 
 _Available as of v1.6.0_

--- a/docs/advanced/addons/lvm-local-storage.md
+++ b/docs/advanced/addons/lvm-local-storage.md
@@ -5,7 +5,7 @@ title: "Local Storage Support (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/lvm-local-storage"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/lvm-local-storage"/>
 </head>
 
 :::note

--- a/docs/advanced/addons/managed-dhcp.md
+++ b/docs/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/managed-dhcp"/>
 </head>
 
 :::note

--- a/docs/advanced/addons/nvidiadrivertoolkit.md
+++ b/docs/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "NVIDIA Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.

--- a/docs/advanced/addons/pcidevices.md
+++ b/docs/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/pcidevices"/>
 </head>
 
 A `PCIDevice` in Harvester represents a host device with a PCI address. 

--- a/docs/advanced/addons/rancher-vcluster.md
+++ b/docs/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/rancher-vcluster"/>
 </head>
 
 :::note

--- a/docs/advanced/addons/seeder.md
+++ b/docs/advanced/addons/seeder.md
@@ -12,7 +12,7 @@ Description: Perform out-of-band operations on Harvester hosts via IPMI and disc
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/seeder"/>
 </head>
 
 :::note

--- a/docs/advanced/addons/virtual-machine-auto-balance.md
+++ b/docs/advanced/addons/virtual-machine-auto-balance.md
@@ -5,7 +5,7 @@ title: "Virtual Machine Auto Balance (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/virtual-machine-auto-balance"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/virtual-machine-auto-balance"/>
 </head>
 
 _Available as of v1.7.0_

--- a/docs/advanced/addons/vmimport.md
+++ b/docs/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/vmimport"/>
 </head>
 
 With the vm-import-controller add-on, you can import virtual machines from VMware, OpenStack, and Open Virtual Appliance (OVA) packages.

--- a/docs/advanced/cloudinitcrd.md
+++ b/docs/advanced/cloudinitcrd.md
@@ -5,7 +5,7 @@ title: "CloudInit CRD"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/cloudinitcrd"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/cloudinitcrd"/>
 </head>
 
 _Available as of v1.3.0_

--- a/docs/advanced/csidriver.md
+++ b/docs/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/csidriver"/>
 </head>
 
 _Available as of v1.5.0_

--- a/docs/advanced/customsuseimages.md
+++ b/docs/advanced/customsuseimages.md
@@ -9,7 +9,7 @@ Description: How to create custom SLES and openSUSE guest virtual machine images
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/customsuseimages"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/customsuseimages"/>
 </head>
 
 SUSE provides [SUSE Linux Enterprise (SLE)](https://www.suse.com/download/sles/) and [openSUSE Leap](https://get.opensuse.org/leap/) virtual machine (VM) images suitable for use in Harvester. These images are built on the [openSUSE Build Service](https://build.opensuse.org/) (OBS) using the [Kiwi](https://osinside.github.io/kiwi/) image building tool, and can be used immediately after downloading.

--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -7,7 +7,7 @@ Description: How to enable and use the Longhorn V2 Data Engine
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/longhorn-v2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/longhorn-v2"/>
 </head>
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/index"/>
 </head>
 
 The following is a list of advanced settings that you can use in Harvester. You can modify the `settings.harvesterhci.io` custom resource using both the Harvester UI and the `kubectl` command.

--- a/docs/advanced/singlenodeclusters.md
+++ b/docs/advanced/singlenodeclusters.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/singlenodeclusters"/>
 </head>
 
 Harvester supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods ([ISO](../install/iso-install.md), [USB](../install/usb-install.md), and [PXE boot](../install/pxe-boot-install.md)).

--- a/docs/advanced/storageclass.md
+++ b/docs/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storageclass"/>
 </head>
 
 Harvester uses StorageClasses to describe how Longhorn must provision volumes. Longhorn StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as *profiles* in other storage systems.

--- a/docs/advanced/storagenetwork.md
+++ b/docs/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn to provide block device volumes for virtual machines and pods. If you want to isolate Longhorn replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.

--- a/docs/advanced/vgpusupport.md
+++ b/docs/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/docs/advanced/vm-migration-network.md
+++ b/docs/advanced/vm-migration-network.md
@@ -5,7 +5,7 @@ title: "VM Migration Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vm-migration-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vm-migration-network"/>
 </head>
 
 A VM migration network is useful for isolating migration traffic from cluster traffic on `mgmt` and other cluster-wide workloads. Using a VM migration network results in better network bandwidth and performance.

--- a/docs/advanced/witness.md
+++ b/docs/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/witness"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/docs/developer/addon-development.md
+++ b/docs/developer/addon-development.md
@@ -11,7 +11,7 @@ Description: How to write your own Harvester add-on
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/developer/Add-on-development-guide"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/developer/Add-on-development-guide"/>
 </head>
 
 Harvester add-ons allow you to enable and disable specific Harvester and third-party components based on your requirements. Add-ons function as a wrapper for the [RKE2 HelmChart resource definition (CRD)](https://docs.rke2.io/helm#using-the-helm-crd).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/docs/getting-started/deploy-ha-cluster.md
+++ b/docs/getting-started/deploy-ha-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-ha-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-ha-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/docs/getting-started/deploy-singlenode-cluster.md
+++ b/docs/getting-started/deploy-singlenode-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-singlenode-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-singlenode-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/docs/getting-started/document-conventions.md
+++ b/docs/getting-started/document-conventions.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/document-conventions"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/document-conventions"/>
 </head>
 
 ## Release Types

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/glossary"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/glossary"/>
 </head>
 
 ## **cluster network**

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/docs/image/image-security.md
+++ b/docs/image/image-security.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/image-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/image-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/docs/image/upload-image.md
+++ b/docs/image/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/docs/install/external-disk-support.md
+++ b/docs/install/external-disk-support.md
@@ -12,7 +12,7 @@ description: Install Harvester on diskless systems.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/external-disk-support"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/external-disk-support"/>
 </head>
 
 _Available as of v1.4.0_

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/docs/install/install-binaries-mode.md
+++ b/docs/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/install-binaries-mode"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/install/iso-install.md
+++ b/docs/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/docs/install/management-address.md
+++ b/docs/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/docs/install/net-install.md
+++ b/docs/install/net-install.md
@@ -11,7 +11,7 @@ description: Harvester Net Install ISO is a minimal ISO that contains only the O
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/net-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/net-install"/>
 </head>
 
 The Harvester net install ISO is a minimal installation image that contains only the core OS components, allowing the installer to boot and then install the Harvester OS on a disk. After installation is completed, the Harvester OS pulls all required container images from the internet (mostly from Docker Hub).

--- a/docs/install/post-install.md
+++ b/docs/install/post-install.md
@@ -10,7 +10,7 @@ description: Post-installation steps.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/post-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/post-install"/>
 </head>
 
 You can enhance the security and performance of your Harvester cluster by performing the following procedures after installation is completed.

--- a/docs/install/pxe-boot-install.md
+++ b/docs/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/docs/install/requirements.md
+++ b/docs/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/docs/install/update-harvester-configuration.md
+++ b/docs/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time.

--- a/docs/install/usb-install.md
+++ b/docs/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/docs/logging/harvester-logging.md
+++ b/docs/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/monitoring/calculation-resource-metrics.md
+++ b/docs/monitoring/calculation-resource-metrics.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/calculation-resource-metrics"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/calculation-resource-metrics"/>
 </head>
 
 Harvester calculates resource metrics using data that is dynamically collected from the system. Host-level resource metrics are calculated and then aggregated to obtain the cluster-level metrics.

--- a/docs/monitoring/harvester-monitoring.md
+++ b/docs/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/networking/best-practice.md
+++ b/docs/networking/best-practice.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/best-practice"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/best-practice"/>
 </head>
 
 ## Replace Ethernet NICs

--- a/docs/networking/clusternetwork.md
+++ b/docs/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/index"/>
 </head>
 
 ## Concepts

--- a/docs/networking/deep-dive.md
+++ b/docs/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/deep-dive"/>
 </head>
 
 ## Network Topology

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/docs/networking/hostnetworkconfig.md
+++ b/docs/networking/hostnetworkconfig.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/hostnetworkconfig.md"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/hostnetworkconfig.md"/>
 </head>
 
 ## Host Network Configuration

--- a/docs/networking/ippool.md
+++ b/docs/networking/ippool.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/ippool"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/ippool"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/networking/kubeovn-vm-isolation.md
+++ b/docs/networking/kubeovn-vm-isolation.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vm-isolation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vm-isolation"/>
 </head>
 
 :::note

--- a/docs/networking/kubeovn-vpc.md
+++ b/docs/networking/kubeovn-vpc.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vpc"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vpc"/>
 </head> 
 
 :::note

--- a/docs/networking/kubeovn-vpcnatgateway.md
+++ b/docs/networking/kubeovn-vpcnatgateway.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vpcnatgateway"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vpcnatgateway"/>
 </head>
 
 :::note

--- a/docs/networking/loadbalancer.md
+++ b/docs/networking/loadbalancer.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/loadbalancer"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/loadbalancer"/>
 </head>
 
 _Available as of v1.2.0_

--- a/docs/rancher/cloud-provider.md
+++ b/docs/rancher/cloud-provider.md
@@ -12,7 +12,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/cloud-provider"/>
 </head>
 
 [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/docs/rancher/csi-driver.md
+++ b/docs/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/csi-driver"/>
 </head>
 
 :::caution

--- a/docs/rancher/harvester-ui-extension.md
+++ b/docs/rancher/harvester-ui-extension.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 

--- a/docs/rancher/import-existing-vm.md
+++ b/docs/rancher/import-existing-vm.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/import-existing-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/import-existing-vm"/>
 </head>
 
 Rancher allows you to import existing Harvester VMs in which you installed Kubernetes.

--- a/docs/rancher/node/k3s-cluster.md
+++ b/docs/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/docs/rancher/node/node-driver.md
+++ b/docs/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/docs/rancher/node/rke2-cluster.md
+++ b/docs/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/docs/rancher/rancher-integration.md
+++ b/docs/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/docs/rancher/rancher-terraform.md
+++ b/docs/rancher/rancher-terraform.md
@@ -13,7 +13,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-terraform"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-terraform"/>
 </head>
 
 The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher/rancher2/) allows administrators to create and manage RKE2 guest clusters using Terraform.

--- a/docs/rancher/resource-quota.md
+++ b/docs/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/docs/rancher/virtualization-management.md
+++ b/docs/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/docs/terraform/terraform-provider.md
+++ b/docs/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/docs/troubleshooting/harvester.md
+++ b/docs/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/docs/troubleshooting/installation.md
+++ b/docs/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/docs/troubleshooting/logging.md
+++ b/docs/troubleshooting/logging.md
@@ -5,7 +5,7 @@ title: "Logging"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/logging"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Logging.

--- a/docs/troubleshooting/monitoring.md
+++ b/docs/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/docs/troubleshooting/os.md
+++ b/docs/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/docs/troubleshooting/rancher.md
+++ b/docs/troubleshooting/rancher.md
@@ -5,7 +5,7 @@ title: "Rancher"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/rancher"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/rancher"/>
 </head>
 
 

--- a/docs/troubleshooting/vm.md
+++ b/docs/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/index"/>
 </head>
 
 Harvester is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:

--- a/docs/upgrade/troubleshooting.md
+++ b/docs/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/docs/upgrade/v1-1-2-to-v1-2-0.md
+++ b/docs/upgrade/v1-1-2-to-v1-2-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-1-2-to-v1-2-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
 
 :::caution

--- a/docs/upgrade/v1-2-0-to-v1-2-1.md
+++ b/docs/upgrade/v1-2-0-to-v1-2-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-0-to-v1-2-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-0-to-v1-2-1"/>
 </head>
 
 

--- a/docs/upgrade/v1-2-1-to-v1-2-2.md
+++ b/docs/upgrade/v1-2-1-to-v1-2-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.1 to v1.2.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-1-to-v1-2-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-1-to-v1-2-2"/>
 </head>
 
 ## General information

--- a/docs/upgrade/v1-2-2-to-v1-3-1.md
+++ b/docs/upgrade/v1-2-2-to-v1-3-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-2-to-v1-3-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-2-to-v1-3-1"/>
 </head>
 
 ## General information

--- a/docs/upgrade/v1-3-1-to-v1-3-2.md
+++ b/docs/upgrade/v1-3-1-to-v1-3-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.1 to v1.3.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-1-to-v1-3-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-1-to-v1-3-2"/>
 </head>
 
 ## General information

--- a/docs/upgrade/v1-3-2-to-v1-4-0.md
+++ b/docs/upgrade/v1-3-2-to-v1-4-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.2 to v1.4.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-2-to-v1-4-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-2-to-v1-4-0"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-4-0-to-v1-4-1.md
+++ b/docs/upgrade/v1-4-0-to-v1-4-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.0 to v1.4.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-0-to-v1-4-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-0-to-v1-4-1"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-4-1-to-v1-4-2.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1 to v1.4.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-2"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-4-1-to-v1-4-3.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-4-2-to-v1-5-0.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-0"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-4-2-to-v1-5-1.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-4-2-to-v1-5-2.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-5-0-to-v1-5-1.md
+++ b/docs/upgrade/v1-5-0-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-5-0-to-v1-5-2.md
+++ b/docs/upgrade/v1-5-0-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0/v1.5.1 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-5-x-to-v1-6-x.md
+++ b/docs/upgrade/v1-5-x-to-v1-6-x.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.x to v1.6.x"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-x-to-v1-6-x"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-x-to-v1-6-x"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-6-x-to-v1-6-y.md
+++ b/docs/upgrade/v1-6-x-to-v1-6-y.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.6.x to v1.6.y"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-6-y"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-6-x-to-v1-6-y"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-6-x-to-v1-7-x.md
+++ b/docs/upgrade/v1-6-x-to-v1-7-x.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.6.x to v1.7.x"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-7-x"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-6-x-to-v1-7-x"/>
 </head>
 
 ## General Information

--- a/docs/upgrade/v1-7-x-to-v1-7-y.md
+++ b/docs/upgrade/v1-7-x-to-v1-7-y.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.7.x to v1.7.y"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-7-x-to-v1-7-y"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-7-x-to-v1-7-y"/>
 </head>
 
 ## General Information

--- a/docs/vm/access-to-the-vm.md
+++ b/docs/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/docs/vm/backup-restore.md
+++ b/docs/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/docs/vm/cdrom-hotplug.md
+++ b/docs/vm/cdrom-hotplug.md
@@ -13,7 +13,7 @@ description: Hotplug and hotunplug CD-ROM volumes.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cdrom-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cdrom-hotplug"/>
 </head>
 
 _Available as of v1.8.0_

--- a/docs/vm/clone-vm.md
+++ b/docs/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/docs/vm/cpu-memory-hotplug.md
+++ b/docs/vm/cpu-memory-hotplug.md
@@ -19,7 +19,7 @@ description: Create VM with CPU / Memory Hotplug
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-memory-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-memory-hotplug"/>
 </head>
 
 _Available as of v1.6.0_

--- a/docs/vm/cpu-pinning.md
+++ b/docs/vm/cpu-pinning.md
@@ -19,7 +19,7 @@ description: Create VM with CPU pinning
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-pinning"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-pinning"/>
 </head>
 
 _Available as of v1.4.0_

--- a/docs/vm/create-vm.md
+++ b/docs/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/docs/vm/create-windows-vm.md
+++ b/docs/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/docs/vm/edit-vm.md
+++ b/docs/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/docs/vm/hotplug-volume.md
+++ b/docs/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/docs/vm/live-migration.md
+++ b/docs/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime. A couple of comprehensive processes and tasks are done under the hood to fulfill the live migration.

--- a/docs/vm/nic-hotplug.md
+++ b/docs/vm/nic-hotplug.md
@@ -13,7 +13,7 @@ description: Hotplug and hotunplug network interfaces to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/nic-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/nic-hotplug"/>
 </head>
 
 _Available as of v1.7.0_

--- a/docs/vm/resource-overcommit.md
+++ b/docs/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/docs/vm/virtual-machines.md
+++ b/docs/vm/virtual-machines.md
@@ -11,7 +11,7 @@ description: Information concerning virtual machines that run on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/virtual-machines"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/virtual-machines"/>
 </head>
 
 You can create [Linux VMs](../vm/create-vm.md) using one of the following methods: 

--- a/docs/volume/clone-volume.md
+++ b/docs/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/docs/volume/create-volume.md
+++ b/docs/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/docs/volume/edit-volume.md
+++ b/docs/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/docs/volume/export-volume.md
+++ b/docs/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/docs/volume/storage-migration.md
+++ b/docs/volume/storage-migration.md
@@ -11,7 +11,7 @@ description: Migrate VM volumes between different StorageClasses without data lo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/storage-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/storage-migration"/>
 </head>
 
 Storage migration allows you to move VM volumes data from one StorageClass to another. This is useful when you need to change the storage backend for a VM — for example, migrating from Longhorn replicated storage to LVM local storage for better performance, or from local storage to replicated storage for higher availability.

--- a/docs/volume/volume-security.md
+++ b/docs/volume/volume-security.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/docs/volume/volume-snapshots.md
+++ b/docs/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.4/advanced/addons.md
+++ b/versioned_docs/version-v1.4/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Add-ons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons"/>
 </head>
 
 Harvester provides optional features as add-ons to maintain a minimal installation footprint. This design allows you to easily enable or disable functionality based strictly on your use case and requirements. You can customize the settings of each add-on, though the level of customization depends on the underlying software.

--- a/versioned_docs/version-v1.4/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.4/advanced/addons/lvm-local-storage.md
@@ -5,7 +5,7 @@ title: "Local Storage Support (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/lvm-local-storage"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/lvm-local-storage"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.4/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.4/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/managed-dhcp"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.4/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.4/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "NVIDIA Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.4/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.4/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/pcidevices"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.4/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.4/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/rancher-vcluster"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.4/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.4/advanced/addons/seeder.md
@@ -12,7 +12,7 @@ Description: Perform out-of-band operations on Harvester hosts via IPMI and disc
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/seeder"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.4/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.4/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/vmimport"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.4/advanced/cloudinitcrd.md
+++ b/versioned_docs/version-v1.4/advanced/cloudinitcrd.md
@@ -5,7 +5,7 @@ title: "CloudInit CRD"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/cloudinitcrd"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/cloudinitcrd"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.4/advanced/csidriver.md
+++ b/versioned_docs/version-v1.4/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/csidriver"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.4/advanced/customsuseimages.md
+++ b/versioned_docs/version-v1.4/advanced/customsuseimages.md
@@ -9,7 +9,7 @@ Description: How to create custom SLES and openSUSE guest virtual machine images
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/customsuseimages"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/customsuseimages"/>
 </head>
 
 SUSE provides [SUSE Linux Enterprise (SLE)](https://www.suse.com/download/sles/) and [openSUSE Leap](https://get.opensuse.org/leap/) virtual machine (VM) images suitable for use in Harvester. These images are built on the [openSUSE Build Service](https://build.opensuse.org/) (OBS) using the [Kiwi](https://osinside.github.io/kiwi/) image building tool, and can be used immediately after downloading.

--- a/versioned_docs/version-v1.4/advanced/longhorn-v2.md
+++ b/versioned_docs/version-v1.4/advanced/longhorn-v2.md
@@ -7,7 +7,7 @@ Description: How to enable and use the Longhorn V2 Data Engine
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/longhorn-v2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/longhorn-v2"/>
 </head>
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.

--- a/versioned_docs/version-v1.4/advanced/settings.md
+++ b/versioned_docs/version-v1.4/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/index"/>
 </head>
 
 The following is a list of advanced settings that you can use in Harvester. You can modify the `settings.harvesterhci.io` custom resource using both the Harvester UI and the `kubectl` command.

--- a/versioned_docs/version-v1.4/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.4/advanced/singlenodeclusters.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/singlenodeclusters"/>
 </head>
 
 Harvester supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods ([ISO](../install/iso-install.md), [USB](../install/usb-install.md), and [PXE boot](../install/pxe-boot-install.md)).

--- a/versioned_docs/version-v1.4/advanced/storageclass.md
+++ b/versioned_docs/version-v1.4/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storageclass"/>
 </head>
 
 Harvester uses StorageClasses to describe how Longhorn must provision volumes. Longhorn StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as *profiles* in other storage systems.

--- a/versioned_docs/version-v1.4/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.4/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.

--- a/versioned_docs/version-v1.4/advanced/vgpusupport.md
+++ b/versioned_docs/version-v1.4/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.4/advanced/witness.md
+++ b/versioned_docs/version-v1.4/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/witness"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.4/airgap.md
+++ b/versioned_docs/version-v1.4/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.4/authentication.md
+++ b/versioned_docs/version-v1.4/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.4/developer/addon-development.md
+++ b/versioned_docs/version-v1.4/developer/addon-development.md
@@ -11,7 +11,7 @@ Description: How to write your own Harvester add-on
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/developer/Add-on-development-guide"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/developer/Add-on-development-guide"/>
 </head>
 
 Harvester add-ons allow you to enable and disable specific Harvester and third-party components based on your requirements. Add-ons function as a wrapper for the [RKE2 HelmChart resource definition (CRD)](https://docs.rke2.io/helm#using-the-helm-crd).

--- a/versioned_docs/version-v1.4/faq.md
+++ b/versioned_docs/version-v1.4/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.4/getting-started/deploy-ha-cluster.md
+++ b/versioned_docs/version-v1.4/getting-started/deploy-ha-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-ha-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-ha-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.4/getting-started/deploy-singlenode-cluster.md
+++ b/versioned_docs/version-v1.4/getting-started/deploy-singlenode-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-singlenode-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-singlenode-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.4/getting-started/document-conventions.md
+++ b/versioned_docs/version-v1.4/getting-started/document-conventions.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/document-conventions"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/document-conventions"/>
 </head>
 
 ## Release Labels

--- a/versioned_docs/version-v1.4/getting-started/glossary.md
+++ b/versioned_docs/version-v1.4/getting-started/glossary.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/glossary"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/glossary"/>
 </head>
 
 ## **guest cluster** / **guest Kubernetes cluster**

--- a/versioned_docs/version-v1.4/host/host.md
+++ b/versioned_docs/version-v1.4/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.4/image/image-security.md
+++ b/versioned_docs/version-v1.4/image/image-security.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/image-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/image-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.4/image/upload-image.md
+++ b/versioned_docs/version-v1.4/image/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.4/index.md
+++ b/versioned_docs/version-v1.4/index.md
@@ -13,7 +13,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/versioned_docs/version-v1.4/install/external-disk-support.md
+++ b/versioned_docs/version-v1.4/install/external-disk-support.md
@@ -12,7 +12,7 @@ description: Install Harvester on diskless systems.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/external-disk-support"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/external-disk-support"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.4/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.4/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.4/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.4/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/install-binaries-mode"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.4/install/iso-install.md
+++ b/versioned_docs/version-v1.4/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.4/install/management-address.md
+++ b/versioned_docs/version-v1.4/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.4/install/net-install.md
+++ b/versioned_docs/version-v1.4/install/net-install.md
@@ -11,7 +11,7 @@ description: Harvester Net Install ISO is a minimal ISO that contains only the O
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/net-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/net-install"/>
 </head>
 
 The Harvester net install ISO is a minimal installation image that contains only the core OS components, allowing the installer to boot and then install the Harvester OS on a disk. After installation is completed, the Harvester OS pulls all required container images from the internet (mostly from Docker Hub).

--- a/versioned_docs/version-v1.4/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.4/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.4/install/requirements.md
+++ b/versioned_docs/version-v1.4/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/versioned_docs/version-v1.4/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.4/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/versioned_docs/version-v1.4/install/usb-install.md
+++ b/versioned_docs/version-v1.4/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.4/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.4/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.4/monitoring/calculation-resource-metrics.md
+++ b/versioned_docs/version-v1.4/monitoring/calculation-resource-metrics.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/calculation-resource-metrics"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/calculation-resource-metrics"/>
 </head>
 
 Harvester calculates resource metrics using data that is dynamically collected from the system. Host-level resource metrics are calculated and then aggregated to obtain the cluster-level metrics.

--- a/versioned_docs/version-v1.4/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.4/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.4/networking/best-practice.md
+++ b/versioned_docs/version-v1.4/networking/best-practice.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/best-practice"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/best-practice"/>
 </head>
 
 ## Replace Ethernet NICs

--- a/versioned_docs/version-v1.4/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.4/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.4/networking/deep-dive.md
+++ b/versioned_docs/version-v1.4/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/deep-dive"/>
 </head>
 
 ## Network Topology

--- a/versioned_docs/version-v1.4/networking/harvester-network.md
+++ b/versioned_docs/version-v1.4/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.4/networking/ippool.md
+++ b/versioned_docs/version-v1.4/networking/ippool.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/ippool"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/ippool"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.4/networking/loadbalancer.md
+++ b/versioned_docs/version-v1.4/networking/loadbalancer.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/loadbalancer"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/loadbalancer"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.4/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.4/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.4/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.4/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/csi-driver"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.4/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.4/rancher/harvester-ui-extension.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 

--- a/versioned_docs/version-v1.4/rancher/import-existing-vm.md
+++ b/versioned_docs/version-v1.4/rancher/import-existing-vm.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/import-existing-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/import-existing-vm"/>
 </head>
 
 Rancher allows you to import existing Harvester VMs in which you installed Kubernetes.

--- a/versioned_docs/version-v1.4/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.4/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.4/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.4/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.4/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.4/rancher/node/rke1-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE1 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke1-cluster"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.4/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.4/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.4/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.4/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/versioned_docs/version-v1.4/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.4/rancher/rancher-terraform.md
@@ -13,7 +13,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-terraform"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-terraform"/>
 </head>
 
 The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher/rancher2/) allows administrators to create and manage RKE2 guest clusters using Terraform.

--- a/versioned_docs/version-v1.4/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.4/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/versioned_docs/version-v1.4/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.4/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v1.4/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.4/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.4/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.4/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.4/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.4/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.4/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.4/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.4/troubleshooting/os.md
+++ b/versioned_docs/version-v1.4/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.4/troubleshooting/rancher.md
+++ b/versioned_docs/version-v1.4/troubleshooting/rancher.md
@@ -5,7 +5,7 @@ title: "Rancher"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/rancher"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/rancher"/>
 </head>
 
 

--- a/versioned_docs/version-v1.4/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.4/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.4/upgrade/automatic.md
+++ b/versioned_docs/version-v1.4/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/index"/>
 </head>
 
 ## Upgrade support matrix

--- a/versioned_docs/version-v1.4/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.4/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.4/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-1-2-to-v1-2-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-1-2-to-v1-2-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.4/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-2-0-to-v1-2-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-0-to-v1-2-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-0-to-v1-2-1"/>
 </head>
 
 

--- a/versioned_docs/version-v1.4/upgrade/v1-2-1-to-v1-2-2.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-2-1-to-v1-2-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.1 to v1.2.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-1-to-v1-2-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-1-to-v1-2-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.4/upgrade/v1-2-2-to-v1-3-1.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-2-2-to-v1-3-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-2-to-v1-3-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-2-to-v1-3-1"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.4/upgrade/v1-3-1-to-v1-3-2.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-3-1-to-v1-3-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.1 to v1.3.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-1-to-v1-3-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-1-to-v1-3-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.4/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-3-2-to-v1-4-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.2 to v1.4.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-2-to-v1-4-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-2-to-v1-4-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.4/upgrade/v1-4-0-to-v1-4-1.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-4-0-to-v1-4-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.0 to v1.4.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-0-to-v1-4-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-0-to-v1-4-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-2.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1 to v1.4.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.4/upgrade/v1-4-1-to-v1-4-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.4/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.4/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.4/vm/backup-restore.md
+++ b/versioned_docs/version-v1.4/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.4/vm/clone-vm.md
+++ b/versioned_docs/version-v1.4/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.4/vm/cpu-pinning.md
+++ b/versioned_docs/version-v1.4/vm/cpu-pinning.md
@@ -19,7 +19,7 @@ description: Create VM with CPU pinning
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-pinning"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-pinning"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.4/vm/create-vm.md
+++ b/versioned_docs/version-v1.4/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.4/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.4/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.4/vm/edit-vm.md
+++ b/versioned_docs/version-v1.4/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.4/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.4/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.4/vm/live-migration.md
+++ b/versioned_docs/version-v1.4/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.4/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.4/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.4/vm/virtual-machines.md
+++ b/versioned_docs/version-v1.4/vm/virtual-machines.md
@@ -11,7 +11,7 @@ description: Information concerning virtual machines that run on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/virtual-machines"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/virtual-machines"/>
 </head>
 
 You can create [Linux VMs](../vm/create-vm.md) using one of the following methods: 

--- a/versioned_docs/version-v1.4/volume/clone-volume.md
+++ b/versioned_docs/version-v1.4/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/versioned_docs/version-v1.4/volume/create-volume.md
+++ b/versioned_docs/version-v1.4/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.4/volume/edit-volume.md
+++ b/versioned_docs/version-v1.4/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.4/volume/export-volume.md
+++ b/versioned_docs/version-v1.4/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.4/volume/volume-security.md
+++ b/versioned_docs/version-v1.4/volume/volume-security.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.4/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.4/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.5/advanced/addons.md
+++ b/versioned_docs/version-v1.5/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Add-ons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons"/>
 </head>
 
 Harvester provides optional features as add-ons to maintain a minimal installation footprint. This design allows you to easily enable or disable functionality based strictly on your use case and requirements. You can customize the settings of each add-on, though the level of customization depends on the underlying software.

--- a/versioned_docs/version-v1.5/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.5/advanced/addons/lvm-local-storage.md
@@ -5,7 +5,7 @@ title: "Local Storage Support (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/lvm-local-storage"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/lvm-local-storage"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.5/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/managed-dhcp"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.5/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.5/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "NVIDIA Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.

--- a/versioned_docs/version-v1.5/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.5/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/pcidevices"/>
 </head>
 
 A `PCIDevice` in Harvester represents a host device with a PCI address. 

--- a/versioned_docs/version-v1.5/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.5/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/rancher-vcluster"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.5/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.5/advanced/addons/seeder.md
@@ -12,7 +12,7 @@ Description: Perform out-of-band operations on Harvester hosts via IPMI and disc
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/seeder"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.5/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.5/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/vmimport"/>
 </head>
 
 With the vm-import-controller add-on, you can import virtual machines from VMware and OpenStack.

--- a/versioned_docs/version-v1.5/advanced/cloudinitcrd.md
+++ b/versioned_docs/version-v1.5/advanced/cloudinitcrd.md
@@ -5,7 +5,7 @@ title: "CloudInit CRD"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/cloudinitcrd"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/cloudinitcrd"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.5/advanced/csidriver.md
+++ b/versioned_docs/version-v1.5/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/csidriver"/>
 </head>
 
 _Available as of v1.5.0_

--- a/versioned_docs/version-v1.5/advanced/customsuseimages.md
+++ b/versioned_docs/version-v1.5/advanced/customsuseimages.md
@@ -9,7 +9,7 @@ Description: How to create custom SLES and openSUSE guest virtual machine images
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/customsuseimages"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/customsuseimages"/>
 </head>
 
 SUSE provides [SUSE Linux Enterprise (SLE)](https://www.suse.com/download/sles/) and [openSUSE Leap](https://get.opensuse.org/leap/) virtual machine (VM) images suitable for use in Harvester. These images are built on the [openSUSE Build Service](https://build.opensuse.org/) (OBS) using the [Kiwi](https://osinside.github.io/kiwi/) image building tool, and can be used immediately after downloading.

--- a/versioned_docs/version-v1.5/advanced/longhorn-v2.md
+++ b/versioned_docs/version-v1.5/advanced/longhorn-v2.md
@@ -7,7 +7,7 @@ Description: How to enable and use the Longhorn V2 Data Engine
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/longhorn-v2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/longhorn-v2"/>
 </head>
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.

--- a/versioned_docs/version-v1.5/advanced/settings.md
+++ b/versioned_docs/version-v1.5/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/index"/>
 </head>
 
 The following is a list of advanced settings that you can use in Harvester. You can modify the `settings.harvesterhci.io` custom resource using both the Harvester UI and the `kubectl` command.

--- a/versioned_docs/version-v1.5/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.5/advanced/singlenodeclusters.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/singlenodeclusters"/>
 </head>
 
 Harvester supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods ([ISO](../install/iso-install.md), [USB](../install/usb-install.md), and [PXE boot](../install/pxe-boot-install.md)).

--- a/versioned_docs/version-v1.5/advanced/storageclass.md
+++ b/versioned_docs/version-v1.5/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storageclass"/>
 </head>
 
 Harvester uses StorageClasses to describe how Longhorn must provision volumes. Longhorn StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as *profiles* in other storage systems.

--- a/versioned_docs/version-v1.5/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.5/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn to provide block device volumes for virtual machines and pods. If you want to isolate Longhorn replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.

--- a/versioned_docs/version-v1.5/advanced/vgpusupport.md
+++ b/versioned_docs/version-v1.5/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.5/advanced/witness.md
+++ b/versioned_docs/version-v1.5/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/witness"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.5/airgap.md
+++ b/versioned_docs/version-v1.5/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.5/authentication.md
+++ b/versioned_docs/version-v1.5/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.5/developer/addon-development.md
+++ b/versioned_docs/version-v1.5/developer/addon-development.md
@@ -11,7 +11,7 @@ Description: How to write your own Harvester add-on
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/developer/Add-on-development-guide"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/developer/Add-on-development-guide"/>
 </head>
 
 Harvester add-ons allow you to enable and disable specific Harvester and third-party components based on your requirements. Add-ons function as a wrapper for the [RKE2 HelmChart resource definition (CRD)](https://docs.rke2.io/helm#using-the-helm-crd).

--- a/versioned_docs/version-v1.5/faq.md
+++ b/versioned_docs/version-v1.5/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.5/getting-started/deploy-ha-cluster.md
+++ b/versioned_docs/version-v1.5/getting-started/deploy-ha-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-ha-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-ha-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.5/getting-started/deploy-singlenode-cluster.md
+++ b/versioned_docs/version-v1.5/getting-started/deploy-singlenode-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-singlenode-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-singlenode-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.5/getting-started/document-conventions.md
+++ b/versioned_docs/version-v1.5/getting-started/document-conventions.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/document-conventions"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/document-conventions"/>
 </head>
 
 ## Release Types

--- a/versioned_docs/version-v1.5/getting-started/glossary.md
+++ b/versioned_docs/version-v1.5/getting-started/glossary.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/glossary"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/glossary"/>
 </head>
 
 ## **cluster network**

--- a/versioned_docs/version-v1.5/host/host.md
+++ b/versioned_docs/version-v1.5/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.5/image/image-security.md
+++ b/versioned_docs/version-v1.5/image/image-security.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/image-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/image-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.5/image/upload-image.md
+++ b/versioned_docs/version-v1.5/image/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.5/index.md
+++ b/versioned_docs/version-v1.5/index.md
@@ -13,7 +13,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/versioned_docs/version-v1.5/install/external-disk-support.md
+++ b/versioned_docs/version-v1.5/install/external-disk-support.md
@@ -12,7 +12,7 @@ description: Install Harvester on diskless systems.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/external-disk-support"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/external-disk-support"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.5/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.5/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.5/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.5/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/install-binaries-mode"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.5/install/iso-install.md
+++ b/versioned_docs/version-v1.5/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/index"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.5/install/management-address.md
+++ b/versioned_docs/version-v1.5/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.5/install/net-install.md
+++ b/versioned_docs/version-v1.5/install/net-install.md
@@ -11,7 +11,7 @@ description: Harvester Net Install ISO is a minimal ISO that contains only the O
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/net-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/net-install"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.5/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.5/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.5/install/requirements.md
+++ b/versioned_docs/version-v1.5/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/versioned_docs/version-v1.5/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.5/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/versioned_docs/version-v1.5/install/usb-install.md
+++ b/versioned_docs/version-v1.5/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/usb-install"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.5/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.5/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.5/monitoring/calculation-resource-metrics.md
+++ b/versioned_docs/version-v1.5/monitoring/calculation-resource-metrics.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/calculation-resource-metrics"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/calculation-resource-metrics"/>
 </head>
 
 Harvester calculates resource metrics using data that is dynamically collected from the system. Host-level resource metrics are calculated and then aggregated to obtain the cluster-level metrics.

--- a/versioned_docs/version-v1.5/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.5/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.5/networking/best-practice.md
+++ b/versioned_docs/version-v1.5/networking/best-practice.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/best-practice"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/best-practice"/>
 </head>
 
 ## Replace Ethernet NICs

--- a/versioned_docs/version-v1.5/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.5/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.5/networking/deep-dive.md
+++ b/versioned_docs/version-v1.5/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/deep-dive"/>
 </head>
 
 ## Network Topology

--- a/versioned_docs/version-v1.5/networking/harvester-network.md
+++ b/versioned_docs/version-v1.5/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.5/networking/ippool.md
+++ b/versioned_docs/version-v1.5/networking/ippool.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/ippool"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/ippool"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.5/networking/loadbalancer.md
+++ b/versioned_docs/version-v1.5/networking/loadbalancer.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/loadbalancer"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/loadbalancer"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.5/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.5/rancher/cloud-provider.md
@@ -14,7 +14,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/cloud-provider"/>
 </head>
 
 [RKE1](./node/rke1-cluster.md) and [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.5/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.5/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/csi-driver"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.5/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.5/rancher/harvester-ui-extension.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 

--- a/versioned_docs/version-v1.5/rancher/import-existing-vm.md
+++ b/versioned_docs/version-v1.5/rancher/import-existing-vm.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/import-existing-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/import-existing-vm"/>
 </head>
 
 Rancher allows you to import existing Harvester VMs in which you installed Kubernetes.

--- a/versioned_docs/version-v1.5/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.5/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.5/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.5/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.5/rancher/node/rke1-cluster.md
+++ b/versioned_docs/version-v1.5/rancher/node/rke1-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE1 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke1-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke1-cluster"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.5/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.5/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.5/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.5/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.5/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.5/rancher/rancher-terraform.md
@@ -13,7 +13,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-terraform"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-terraform"/>
 </head>
 
 The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher/rancher2/) allows administrators to create and manage RKE2 guest clusters using Terraform.

--- a/versioned_docs/version-v1.5/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.5/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/versioned_docs/version-v1.5/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.5/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v1.5/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.5/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.5/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.5/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.5/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.5/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.5/troubleshooting/logging.md
+++ b/versioned_docs/version-v1.5/troubleshooting/logging.md
@@ -5,7 +5,7 @@ title: "Logging"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/logging"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Logging.

--- a/versioned_docs/version-v1.5/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.5/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.5/troubleshooting/os.md
+++ b/versioned_docs/version-v1.5/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.5/troubleshooting/rancher.md
+++ b/versioned_docs/version-v1.5/troubleshooting/rancher.md
@@ -5,7 +5,7 @@ title: "Rancher"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/rancher"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/rancher"/>
 </head>
 
 

--- a/versioned_docs/version-v1.5/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.5/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.5/upgrade/automatic.md
+++ b/versioned_docs/version-v1.5/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/index"/>
 </head>
 
 Harvester is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:

--- a/versioned_docs/version-v1.5/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.5/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.5/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-1-2-to-v1-2-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-1-2-to-v1-2-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.5/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-2-0-to-v1-2-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-0-to-v1-2-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-0-to-v1-2-1"/>
 </head>
 
 

--- a/versioned_docs/version-v1.5/upgrade/v1-2-1-to-v1-2-2.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-2-1-to-v1-2-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.1 to v1.2.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-1-to-v1-2-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-1-to-v1-2-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.5/upgrade/v1-2-2-to-v1-3-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-2-2-to-v1-3-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-2-to-v1-3-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-2-to-v1-3-1"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.5/upgrade/v1-3-1-to-v1-3-2.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-3-1-to-v1-3-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.1 to v1.3.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-1-to-v1-3-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-1-to-v1-3-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.5/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-3-2-to-v1-4-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.2 to v1.4.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-2-to-v1-4-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-2-to-v1-4-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.5/upgrade/v1-4-0-to-v1-4-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-0-to-v1-4-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.0 to v1.4.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-0-to-v1-4-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-0-to-v1-4-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-2.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1 to v1.4.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-1-to-v1-4-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.5/upgrade/v1-4-2-to-v1-5-0.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-2-to-v1-5-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.5/upgrade/v1-4-2-to-v1-5-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-4-2-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.5/upgrade/v1-5-0-to-v1-5-1.md
+++ b/versioned_docs/version-v1.5/upgrade/v1-5-0-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.5/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.5/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.5/vm/backup-restore.md
+++ b/versioned_docs/version-v1.5/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.5/vm/clone-vm.md
+++ b/versioned_docs/version-v1.5/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.5/vm/cpu-pinning.md
+++ b/versioned_docs/version-v1.5/vm/cpu-pinning.md
@@ -19,7 +19,7 @@ description: Create VM with CPU pinning
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-pinning"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-pinning"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.5/vm/create-vm.md
+++ b/versioned_docs/version-v1.5/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.5/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.5/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.5/vm/edit-vm.md
+++ b/versioned_docs/version-v1.5/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.5/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.5/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.5/vm/live-migration.md
+++ b/versioned_docs/version-v1.5/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime.

--- a/versioned_docs/version-v1.5/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.5/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.5/vm/virtual-machines.md
+++ b/versioned_docs/version-v1.5/vm/virtual-machines.md
@@ -11,7 +11,7 @@ description: Information concerning virtual machines that run on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/virtual-machines"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/virtual-machines"/>
 </head>
 
 You can create [Linux VMs](../vm/create-vm.md) using one of the following methods: 

--- a/versioned_docs/version-v1.5/volume/clone-volume.md
+++ b/versioned_docs/version-v1.5/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/versioned_docs/version-v1.5/volume/create-volume.md
+++ b/versioned_docs/version-v1.5/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.5/volume/edit-volume.md
+++ b/versioned_docs/version-v1.5/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.5/volume/export-volume.md
+++ b/versioned_docs/version-v1.5/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.5/volume/volume-security.md
+++ b/versioned_docs/version-v1.5/volume/volume-security.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.5/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.5/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.6/advanced/addons.md
+++ b/versioned_docs/version-v1.6/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Add-ons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons"/>
 </head>
 
 Harvester provides optional features as add-ons to maintain a minimal installation footprint. This design allows you to easily enable or disable functionality based strictly on your use case and requirements. You can customize the settings of each add-on, though the level of customization depends on the underlying software.

--- a/versioned_docs/version-v1.6/advanced/addons/kubeovn-operator.md
+++ b/versioned_docs/version-v1.6/advanced/addons/kubeovn-operator.md
@@ -5,7 +5,7 @@ title: "Kube-OVN Operator (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/kubeovn-operator"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/kubeovn-operator"/>
 </head>
 
 _Available as of v1.6.0_

--- a/versioned_docs/version-v1.6/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.6/advanced/addons/lvm-local-storage.md
@@ -5,7 +5,7 @@ title: "Local Storage Support (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/lvm-local-storage"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/lvm-local-storage"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.6/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.6/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/managed-dhcp"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.6/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.6/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "NVIDIA Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.

--- a/versioned_docs/version-v1.6/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.6/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/pcidevices"/>
 </head>
 
 A `PCIDevice` in Harvester represents a host device with a PCI address. 

--- a/versioned_docs/version-v1.6/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.6/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/rancher-vcluster"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.6/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.6/advanced/addons/seeder.md
@@ -12,7 +12,7 @@ Description: Perform out-of-band operations on Harvester hosts via IPMI and disc
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/seeder"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.6/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.6/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/vmimport"/>
 </head>
 
 With the vm-import-controller add-on, you can import virtual machines from VMware and OpenStack.

--- a/versioned_docs/version-v1.6/advanced/cloudinitcrd.md
+++ b/versioned_docs/version-v1.6/advanced/cloudinitcrd.md
@@ -5,7 +5,7 @@ title: "CloudInit CRD"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/cloudinitcrd"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/cloudinitcrd"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.6/advanced/csidriver.md
+++ b/versioned_docs/version-v1.6/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/csidriver"/>
 </head>
 
 _Available as of v1.5.0_

--- a/versioned_docs/version-v1.6/advanced/customsuseimages.md
+++ b/versioned_docs/version-v1.6/advanced/customsuseimages.md
@@ -9,7 +9,7 @@ Description: How to create custom SLES and openSUSE guest virtual machine images
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/customsuseimages"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/customsuseimages"/>
 </head>
 
 SUSE provides [SUSE Linux Enterprise (SLE)](https://www.suse.com/download/sles/) and [openSUSE Leap](https://get.opensuse.org/leap/) virtual machine (VM) images suitable for use in Harvester. These images are built on the [openSUSE Build Service](https://build.opensuse.org/) (OBS) using the [Kiwi](https://osinside.github.io/kiwi/) image building tool, and can be used immediately after downloading.

--- a/versioned_docs/version-v1.6/advanced/longhorn-v2.md
+++ b/versioned_docs/version-v1.6/advanced/longhorn-v2.md
@@ -7,7 +7,7 @@ Description: How to enable and use the Longhorn V2 Data Engine
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/longhorn-v2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/longhorn-v2"/>
 </head>
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.

--- a/versioned_docs/version-v1.6/advanced/settings.md
+++ b/versioned_docs/version-v1.6/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/index"/>
 </head>
 
 The following is a list of advanced settings that you can use in Harvester. You can modify the `settings.harvesterhci.io` custom resource using both the Harvester UI and the `kubectl` command.

--- a/versioned_docs/version-v1.6/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.6/advanced/singlenodeclusters.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/singlenodeclusters"/>
 </head>
 
 Harvester supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods ([ISO](../install/iso-install.md), [USB](../install/usb-install.md), and [PXE boot](../install/pxe-boot-install.md)).

--- a/versioned_docs/version-v1.6/advanced/storageclass.md
+++ b/versioned_docs/version-v1.6/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storageclass"/>
 </head>
 
 Harvester uses StorageClasses to describe how Longhorn must provision volumes. Longhorn StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as *profiles* in other storage systems.

--- a/versioned_docs/version-v1.6/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.6/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn to provide block device volumes for virtual machines and pods. If you want to isolate Longhorn replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.

--- a/versioned_docs/version-v1.6/advanced/vgpusupport.md
+++ b/versioned_docs/version-v1.6/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.6/advanced/vm-migration-network.md
+++ b/versioned_docs/version-v1.6/advanced/vm-migration-network.md
@@ -5,7 +5,7 @@ title: "VM Migration Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vm-migration-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vm-migration-network"/>
 </head>
 
 A VM migration network is useful for isolating migration traffic from cluster traffic on `mgmt` and other cluster-wide workloads. Using a VM migration network results in better network bandwidth and performance.

--- a/versioned_docs/version-v1.6/advanced/witness.md
+++ b/versioned_docs/version-v1.6/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/witness"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.6/airgap.md
+++ b/versioned_docs/version-v1.6/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.6/authentication.md
+++ b/versioned_docs/version-v1.6/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.6/developer/addon-development.md
+++ b/versioned_docs/version-v1.6/developer/addon-development.md
@@ -11,7 +11,7 @@ Description: How to write your own Harvester add-on
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/developer/Add-on-development-guide"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/developer/Add-on-development-guide"/>
 </head>
 
 Harvester add-ons allow you to enable and disable specific Harvester and third-party components based on your requirements. Add-ons function as a wrapper for the [RKE2 HelmChart resource definition (CRD)](https://docs.rke2.io/helm#using-the-helm-crd).

--- a/versioned_docs/version-v1.6/faq.md
+++ b/versioned_docs/version-v1.6/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.6/getting-started/deploy-ha-cluster.md
+++ b/versioned_docs/version-v1.6/getting-started/deploy-ha-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-ha-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-ha-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.6/getting-started/deploy-singlenode-cluster.md
+++ b/versioned_docs/version-v1.6/getting-started/deploy-singlenode-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-singlenode-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-singlenode-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.6/getting-started/document-conventions.md
+++ b/versioned_docs/version-v1.6/getting-started/document-conventions.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/document-conventions"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/document-conventions"/>
 </head>
 
 ## Release Types

--- a/versioned_docs/version-v1.6/getting-started/glossary.md
+++ b/versioned_docs/version-v1.6/getting-started/glossary.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/glossary"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/glossary"/>
 </head>
 
 ## **cluster network**

--- a/versioned_docs/version-v1.6/host/host.md
+++ b/versioned_docs/version-v1.6/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.6/image/image-security.md
+++ b/versioned_docs/version-v1.6/image/image-security.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/image-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/image-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.6/image/upload-image.md
+++ b/versioned_docs/version-v1.6/image/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.6/index.md
+++ b/versioned_docs/version-v1.6/index.md
@@ -13,7 +13,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/versioned_docs/version-v1.6/install/external-disk-support.md
+++ b/versioned_docs/version-v1.6/install/external-disk-support.md
@@ -12,7 +12,7 @@ description: Install Harvester on diskless systems.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/external-disk-support"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/external-disk-support"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.6/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.6/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.6/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.6/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/install-binaries-mode"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.6/install/iso-install.md
+++ b/versioned_docs/version-v1.6/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/index"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.6/install/management-address.md
+++ b/versioned_docs/version-v1.6/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.6/install/net-install.md
+++ b/versioned_docs/version-v1.6/install/net-install.md
@@ -11,7 +11,7 @@ description: Harvester Net Install ISO is a minimal ISO that contains only the O
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/net-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/net-install"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.6/install/post-install.md
+++ b/versioned_docs/version-v1.6/install/post-install.md
@@ -10,7 +10,7 @@ description: Post-installation steps.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/post-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/post-install"/>
 </head>
 
 You can enhance the security and performance of your Harvester cluster by performing the following procedures after installation is completed.

--- a/versioned_docs/version-v1.6/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.6/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.6/install/requirements.md
+++ b/versioned_docs/version-v1.6/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/versioned_docs/version-v1.6/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.6/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time. 

--- a/versioned_docs/version-v1.6/install/usb-install.md
+++ b/versioned_docs/version-v1.6/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/usb-install"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.6/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.6/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.6/monitoring/calculation-resource-metrics.md
+++ b/versioned_docs/version-v1.6/monitoring/calculation-resource-metrics.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/calculation-resource-metrics"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/calculation-resource-metrics"/>
 </head>
 
 Harvester calculates resource metrics using data that is dynamically collected from the system. Host-level resource metrics are calculated and then aggregated to obtain the cluster-level metrics.

--- a/versioned_docs/version-v1.6/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.6/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.6/networking/best-practice.md
+++ b/versioned_docs/version-v1.6/networking/best-practice.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/best-practice"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/best-practice"/>
 </head>
 
 ## Replace Ethernet NICs

--- a/versioned_docs/version-v1.6/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.6/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.6/networking/deep-dive.md
+++ b/versioned_docs/version-v1.6/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/deep-dive"/>
 </head>
 
 ## Network Topology

--- a/versioned_docs/version-v1.6/networking/harvester-network.md
+++ b/versioned_docs/version-v1.6/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.6/networking/ippool.md
+++ b/versioned_docs/version-v1.6/networking/ippool.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/ippool"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/ippool"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.6/networking/kubeovn-vm-isolation.md
+++ b/versioned_docs/version-v1.6/networking/kubeovn-vm-isolation.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vm-isolation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vm-isolation"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.6/networking/kubeovn-vpc.md
+++ b/versioned_docs/version-v1.6/networking/kubeovn-vpc.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vpc"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vpc"/>
 </head> 
 
 :::note

--- a/versioned_docs/version-v1.6/networking/loadbalancer.md
+++ b/versioned_docs/version-v1.6/networking/loadbalancer.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/loadbalancer"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/loadbalancer"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.6/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.6/rancher/cloud-provider.md
@@ -12,7 +12,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/cloud-provider"/>
 </head>
 
 [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.6/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.6/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/csi-driver"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.6/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.6/rancher/harvester-ui-extension.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 

--- a/versioned_docs/version-v1.6/rancher/import-existing-vm.md
+++ b/versioned_docs/version-v1.6/rancher/import-existing-vm.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/import-existing-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/import-existing-vm"/>
 </head>
 
 Rancher allows you to import existing Harvester VMs in which you installed Kubernetes.

--- a/versioned_docs/version-v1.6/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.6/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.6/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.6/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.6/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.6/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.6/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.6/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.6/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.6/rancher/rancher-terraform.md
@@ -13,7 +13,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-terraform"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-terraform"/>
 </head>
 
 The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher/rancher2/) allows administrators to create and manage RKE2 guest clusters using Terraform.

--- a/versioned_docs/version-v1.6/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.6/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/versioned_docs/version-v1.6/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.6/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v1.6/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.6/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.6/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.6/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.6/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.6/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.6/troubleshooting/logging.md
+++ b/versioned_docs/version-v1.6/troubleshooting/logging.md
@@ -5,7 +5,7 @@ title: "Logging"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/logging"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Logging.

--- a/versioned_docs/version-v1.6/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.6/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.6/troubleshooting/os.md
+++ b/versioned_docs/version-v1.6/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.6/troubleshooting/rancher.md
+++ b/versioned_docs/version-v1.6/troubleshooting/rancher.md
@@ -5,7 +5,7 @@ title: "Rancher"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/rancher"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/rancher"/>
 </head>
 
 

--- a/versioned_docs/version-v1.6/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.6/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.6/upgrade/automatic.md
+++ b/versioned_docs/version-v1.6/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/index"/>
 </head>
 
 Harvester is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:

--- a/versioned_docs/version-v1.6/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.6/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.6/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-1-2-to-v1-2-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-1-2-to-v1-2-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.6/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-2-0-to-v1-2-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-0-to-v1-2-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-0-to-v1-2-1"/>
 </head>
 
 

--- a/versioned_docs/version-v1.6/upgrade/v1-2-1-to-v1-2-2.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-2-1-to-v1-2-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.1 to v1.2.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-1-to-v1-2-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-1-to-v1-2-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.6/upgrade/v1-2-2-to-v1-3-1.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-2-2-to-v1-3-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-2-to-v1-3-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-2-to-v1-3-1"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.6/upgrade/v1-3-1-to-v1-3-2.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-3-1-to-v1-3-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.1 to v1.3.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-1-to-v1-3-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-1-to-v1-3-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.6/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-3-2-to-v1-4-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.2 to v1.4.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-2-to-v1-4-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-2-to-v1-4-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-4-0-to-v1-4-1.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-4-0-to-v1-4-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.0 to v1.4.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-0-to-v1-4-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-0-to-v1-4-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-4-1-to-v1-4-2.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-4-1-to-v1-4-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1 to v1.4.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-4-1-to-v1-4-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-4-2-to-v1-5-0.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-4-2-to-v1-5-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-4-2-to-v1-5-1.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-4-2-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-4-2-to-v1-5-2.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-4-2-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-5-0-to-v1-5-1.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-5-0-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-5-0-to-v1-5-2.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-5-0-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0/v1.5.1 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-5-x-to-v1-6-x.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-5-x-to-v1-6-x.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.x to v1.6.x"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-x-to-v1-6-x"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-x-to-v1-6-x"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/upgrade/v1-6-x-to-v1-6-y.md
+++ b/versioned_docs/version-v1.6/upgrade/v1-6-x-to-v1-6-y.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.6.x to v1.6.y"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-6-y"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-6-x-to-v1-6-y"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.6/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.6/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.6/vm/backup-restore.md
+++ b/versioned_docs/version-v1.6/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.6/vm/clone-vm.md
+++ b/versioned_docs/version-v1.6/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.6/vm/cpu-memory-hotplug.md
+++ b/versioned_docs/version-v1.6/vm/cpu-memory-hotplug.md
@@ -19,7 +19,7 @@ description: Create VM with CPU / Memory Hotplug
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-memory-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-memory-hotplug"/>
 </head>
 
 _Available as of v1.6.0_

--- a/versioned_docs/version-v1.6/vm/cpu-pinning.md
+++ b/versioned_docs/version-v1.6/vm/cpu-pinning.md
@@ -19,7 +19,7 @@ description: Create VM with CPU pinning
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-pinning"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-pinning"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.6/vm/create-vm.md
+++ b/versioned_docs/version-v1.6/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.6/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.6/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.6/vm/edit-vm.md
+++ b/versioned_docs/version-v1.6/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.6/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.6/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.6/vm/live-migration.md
+++ b/versioned_docs/version-v1.6/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime. A couple of comprehensive processes and tasks are done under the hood to fulfill the live migration.

--- a/versioned_docs/version-v1.6/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.6/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.6/vm/virtual-machines.md
+++ b/versioned_docs/version-v1.6/vm/virtual-machines.md
@@ -11,7 +11,7 @@ description: Information concerning virtual machines that run on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/virtual-machines"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/virtual-machines"/>
 </head>
 
 You can create [Linux VMs](../vm/create-vm.md) using one of the following methods: 

--- a/versioned_docs/version-v1.6/volume/clone-volume.md
+++ b/versioned_docs/version-v1.6/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/versioned_docs/version-v1.6/volume/create-volume.md
+++ b/versioned_docs/version-v1.6/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.6/volume/edit-volume.md
+++ b/versioned_docs/version-v1.6/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.6/volume/export-volume.md
+++ b/versioned_docs/version-v1.6/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.6/volume/volume-security.md
+++ b/versioned_docs/version-v1.6/volume/volume-security.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.6/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.6/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.7/advanced/addons.md
+++ b/versioned_docs/version-v1.7/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Add-ons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons"/>
 </head>
 
 Harvester provides optional features as add-ons to maintain a minimal installation footprint. This design allows you to easily enable or disable functionality based strictly on your use case and requirements. You can customize the settings of each add-on, though the level of customization depends on the underlying software.

--- a/versioned_docs/version-v1.7/advanced/addons/kubeovn-operator.md
+++ b/versioned_docs/version-v1.7/advanced/addons/kubeovn-operator.md
@@ -5,7 +5,7 @@ title: "Kube-OVN Operator (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/kubeovn-operator"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/kubeovn-operator"/>
 </head>
 
 _Available as of v1.6.0_

--- a/versioned_docs/version-v1.7/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.7/advanced/addons/lvm-local-storage.md
@@ -5,7 +5,7 @@ title: "Local Storage Support (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/lvm-local-storage"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/lvm-local-storage"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.7/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.7/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/managed-dhcp"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.7/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.7/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "NVIDIA Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.

--- a/versioned_docs/version-v1.7/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.7/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/pcidevices"/>
 </head>
 
 A `PCIDevice` in Harvester represents a host device with a PCI address. 

--- a/versioned_docs/version-v1.7/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.7/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/rancher-vcluster"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.7/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.7/advanced/addons/seeder.md
@@ -12,7 +12,7 @@ Description: Perform out-of-band operations on Harvester hosts via IPMI and disc
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/seeder"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.7/advanced/addons/virtual-machine-auto-balance.md
+++ b/versioned_docs/version-v1.7/advanced/addons/virtual-machine-auto-balance.md
@@ -5,7 +5,7 @@ title: "Virtual Machine Auto Balance (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/virtual-machine-auto-balance"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/virtual-machine-auto-balance"/>
 </head>
 
 _Available as of v1.7.0_

--- a/versioned_docs/version-v1.7/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.7/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/vmimport"/>
 </head>
 
 With the vm-import-controller add-on, you can import virtual machines from VMware, OpenStack, and Open Virtual Appliance (OVA) packages.

--- a/versioned_docs/version-v1.7/advanced/cloudinitcrd.md
+++ b/versioned_docs/version-v1.7/advanced/cloudinitcrd.md
@@ -5,7 +5,7 @@ title: "CloudInit CRD"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/cloudinitcrd"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/cloudinitcrd"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.7/advanced/csidriver.md
+++ b/versioned_docs/version-v1.7/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/csidriver"/>
 </head>
 
 _Available as of v1.5.0_

--- a/versioned_docs/version-v1.7/advanced/customsuseimages.md
+++ b/versioned_docs/version-v1.7/advanced/customsuseimages.md
@@ -9,7 +9,7 @@ Description: How to create custom SLES and openSUSE guest virtual machine images
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/customsuseimages"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/customsuseimages"/>
 </head>
 
 SUSE provides [SUSE Linux Enterprise (SLE)](https://www.suse.com/download/sles/) and [openSUSE Leap](https://get.opensuse.org/leap/) virtual machine (VM) images suitable for use in Harvester. These images are built on the [openSUSE Build Service](https://build.opensuse.org/) (OBS) using the [Kiwi](https://osinside.github.io/kiwi/) image building tool, and can be used immediately after downloading.

--- a/versioned_docs/version-v1.7/advanced/longhorn-v2.md
+++ b/versioned_docs/version-v1.7/advanced/longhorn-v2.md
@@ -7,7 +7,7 @@ Description: How to enable and use the Longhorn V2 Data Engine
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/longhorn-v2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/longhorn-v2"/>
 </head>
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.

--- a/versioned_docs/version-v1.7/advanced/settings.md
+++ b/versioned_docs/version-v1.7/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/index"/>
 </head>
 
 The following is a list of advanced settings that you can use in Harvester. You can modify the `settings.harvesterhci.io` custom resource using both the Harvester UI and the `kubectl` command.

--- a/versioned_docs/version-v1.7/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.7/advanced/singlenodeclusters.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/singlenodeclusters"/>
 </head>
 
 Harvester supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods ([ISO](../install/iso-install.md), [USB](../install/usb-install.md), and [PXE boot](../install/pxe-boot-install.md)).

--- a/versioned_docs/version-v1.7/advanced/storageclass.md
+++ b/versioned_docs/version-v1.7/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storageclass"/>
 </head>
 
 Harvester uses StorageClasses to describe how Longhorn must provision volumes. Longhorn StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as *profiles* in other storage systems.

--- a/versioned_docs/version-v1.7/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.7/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn to provide block device volumes for virtual machines and pods. If you want to isolate Longhorn replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.

--- a/versioned_docs/version-v1.7/advanced/vgpusupport.md
+++ b/versioned_docs/version-v1.7/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.7/advanced/vm-migration-network.md
+++ b/versioned_docs/version-v1.7/advanced/vm-migration-network.md
@@ -5,7 +5,7 @@ title: "VM Migration Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vm-migration-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vm-migration-network"/>
 </head>
 
 A VM migration network is useful for isolating migration traffic from cluster traffic on `mgmt` and other cluster-wide workloads. Using a VM migration network results in better network bandwidth and performance.

--- a/versioned_docs/version-v1.7/advanced/witness.md
+++ b/versioned_docs/version-v1.7/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/witness"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.7/airgap.md
+++ b/versioned_docs/version-v1.7/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.7/authentication.md
+++ b/versioned_docs/version-v1.7/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.7/developer/addon-development.md
+++ b/versioned_docs/version-v1.7/developer/addon-development.md
@@ -11,7 +11,7 @@ Description: How to write your own Harvester add-on
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/developer/Add-on-development-guide"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/developer/Add-on-development-guide"/>
 </head>
 
 Harvester add-ons allow you to enable and disable specific Harvester and third-party components based on your requirements. Add-ons function as a wrapper for the [RKE2 HelmChart resource definition (CRD)](https://docs.rke2.io/helm#using-the-helm-crd).

--- a/versioned_docs/version-v1.7/faq.md
+++ b/versioned_docs/version-v1.7/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.7/getting-started/deploy-ha-cluster.md
+++ b/versioned_docs/version-v1.7/getting-started/deploy-ha-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-ha-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-ha-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.7/getting-started/deploy-singlenode-cluster.md
+++ b/versioned_docs/version-v1.7/getting-started/deploy-singlenode-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-singlenode-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-singlenode-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.7/getting-started/document-conventions.md
+++ b/versioned_docs/version-v1.7/getting-started/document-conventions.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/document-conventions"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/document-conventions"/>
 </head>
 
 ## Release Types

--- a/versioned_docs/version-v1.7/getting-started/glossary.md
+++ b/versioned_docs/version-v1.7/getting-started/glossary.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/glossary"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/glossary"/>
 </head>
 
 ## **cluster network**

--- a/versioned_docs/version-v1.7/host/host.md
+++ b/versioned_docs/version-v1.7/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.7/image/image-security.md
+++ b/versioned_docs/version-v1.7/image/image-security.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/image-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/image-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.7/image/upload-image.md
+++ b/versioned_docs/version-v1.7/image/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.7/index.md
+++ b/versioned_docs/version-v1.7/index.md
@@ -13,7 +13,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/versioned_docs/version-v1.7/install/external-disk-support.md
+++ b/versioned_docs/version-v1.7/install/external-disk-support.md
@@ -12,7 +12,7 @@ description: Install Harvester on diskless systems.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/external-disk-support"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/external-disk-support"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.7/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.7/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.7/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.7/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/install-binaries-mode"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.7/install/iso-install.md
+++ b/versioned_docs/version-v1.7/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.7/install/management-address.md
+++ b/versioned_docs/version-v1.7/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.7/install/net-install.md
+++ b/versioned_docs/version-v1.7/install/net-install.md
@@ -11,7 +11,7 @@ description: Harvester Net Install ISO is a minimal ISO that contains only the O
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/net-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/net-install"/>
 </head>
 
 The Harvester net install ISO is a minimal installation image that contains only the core OS components, allowing the installer to boot and then install the Harvester OS on a disk. After installation is completed, the Harvester OS pulls all required container images from the internet (mostly from Docker Hub).

--- a/versioned_docs/version-v1.7/install/post-install.md
+++ b/versioned_docs/version-v1.7/install/post-install.md
@@ -10,7 +10,7 @@ description: Post-installation steps.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/post-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/post-install"/>
 </head>
 
 You can enhance the security and performance of your Harvester cluster by performing the following procedures after installation is completed.

--- a/versioned_docs/version-v1.7/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.7/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.7/install/requirements.md
+++ b/versioned_docs/version-v1.7/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/versioned_docs/version-v1.7/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.7/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time.

--- a/versioned_docs/version-v1.7/install/usb-install.md
+++ b/versioned_docs/version-v1.7/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.7/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.7/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.7/monitoring/calculation-resource-metrics.md
+++ b/versioned_docs/version-v1.7/monitoring/calculation-resource-metrics.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/calculation-resource-metrics"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/calculation-resource-metrics"/>
 </head>
 
 Harvester calculates resource metrics using data that is dynamically collected from the system. Host-level resource metrics are calculated and then aggregated to obtain the cluster-level metrics.

--- a/versioned_docs/version-v1.7/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.7/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.7/networking/best-practice.md
+++ b/versioned_docs/version-v1.7/networking/best-practice.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/best-practice"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/best-practice"/>
 </head>
 
 ## Replace Ethernet NICs

--- a/versioned_docs/version-v1.7/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.7/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.7/networking/deep-dive.md
+++ b/versioned_docs/version-v1.7/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/deep-dive"/>
 </head>
 
 ## Network Topology

--- a/versioned_docs/version-v1.7/networking/harvester-network.md
+++ b/versioned_docs/version-v1.7/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.7/networking/ippool.md
+++ b/versioned_docs/version-v1.7/networking/ippool.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/ippool"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/ippool"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.7/networking/kubeovn-vm-isolation.md
+++ b/versioned_docs/version-v1.7/networking/kubeovn-vm-isolation.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vm-isolation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vm-isolation"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.7/networking/kubeovn-vpc.md
+++ b/versioned_docs/version-v1.7/networking/kubeovn-vpc.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vpc"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vpc"/>
 </head> 
 
 :::note

--- a/versioned_docs/version-v1.7/networking/loadbalancer.md
+++ b/versioned_docs/version-v1.7/networking/loadbalancer.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/loadbalancer"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/loadbalancer"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.7/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.7/rancher/cloud-provider.md
@@ -12,7 +12,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/cloud-provider"/>
 </head>
 
 [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.7/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.7/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/csi-driver"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.7/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.7/rancher/harvester-ui-extension.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 

--- a/versioned_docs/version-v1.7/rancher/import-existing-vm.md
+++ b/versioned_docs/version-v1.7/rancher/import-existing-vm.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/import-existing-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/import-existing-vm"/>
 </head>
 
 Rancher allows you to import existing Harvester VMs in which you installed Kubernetes.

--- a/versioned_docs/version-v1.7/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.7/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.7/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.7/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.7/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.7/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.7/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.7/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 :::warning

--- a/versioned_docs/version-v1.7/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.7/rancher/rancher-terraform.md
@@ -13,7 +13,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-terraform"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-terraform"/>
 </head>
 
 The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher/rancher2/) allows administrators to create and manage RKE2 guest clusters using Terraform.

--- a/versioned_docs/version-v1.7/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.7/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/versioned_docs/version-v1.7/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.7/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v1.7/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.7/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.7/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.7/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.7/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.7/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.7/troubleshooting/logging.md
+++ b/versioned_docs/version-v1.7/troubleshooting/logging.md
@@ -5,7 +5,7 @@ title: "Logging"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/logging"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Logging.

--- a/versioned_docs/version-v1.7/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.7/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.7/troubleshooting/os.md
+++ b/versioned_docs/version-v1.7/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.7/troubleshooting/rancher.md
+++ b/versioned_docs/version-v1.7/troubleshooting/rancher.md
@@ -5,7 +5,7 @@ title: "Rancher"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/rancher"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/rancher"/>
 </head>
 
 

--- a/versioned_docs/version-v1.7/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.7/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.7/upgrade/automatic.md
+++ b/versioned_docs/version-v1.7/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/index"/>
 </head>
 
 Harvester is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:

--- a/versioned_docs/version-v1.7/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.7/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.7/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-1-2-to-v1-2-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-1-2-to-v1-2-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.7/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-2-0-to-v1-2-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-0-to-v1-2-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-0-to-v1-2-1"/>
 </head>
 
 

--- a/versioned_docs/version-v1.7/upgrade/v1-2-1-to-v1-2-2.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-2-1-to-v1-2-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.1 to v1.2.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-1-to-v1-2-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-1-to-v1-2-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.7/upgrade/v1-2-2-to-v1-3-1.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-2-2-to-v1-3-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-2-to-v1-3-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-2-to-v1-3-1"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.7/upgrade/v1-3-1-to-v1-3-2.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-3-1-to-v1-3-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.1 to v1.3.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-1-to-v1-3-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-1-to-v1-3-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.7/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-3-2-to-v1-4-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.2 to v1.4.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-2-to-v1-4-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-2-to-v1-4-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-4-0-to-v1-4-1.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-4-0-to-v1-4-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.0 to v1.4.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-0-to-v1-4-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-0-to-v1-4-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-4-1-to-v1-4-2.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-4-1-to-v1-4-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1 to v1.4.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-4-1-to-v1-4-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-4-2-to-v1-5-0.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-4-2-to-v1-5-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-4-2-to-v1-5-1.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-4-2-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-4-2-to-v1-5-2.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-4-2-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-5-0-to-v1-5-1.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-5-0-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-5-0-to-v1-5-2.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-5-0-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0/v1.5.1 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-5-x-to-v1-6-x.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-5-x-to-v1-6-x.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.x to v1.6.x"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-x-to-v1-6-x"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-x-to-v1-6-x"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-6-y.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-6-y.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.6.x to v1.6.y"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-6-y"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-6-x-to-v1-6-y"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-7-x.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-7-x.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.6.x to v1.7.x"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-7-x"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-6-x-to-v1-7-x"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.7.x to v1.7.y"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-7-x-to-v1-7-y"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-7-x-to-v1-7-y"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.7/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.7/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.7/vm/backup-restore.md
+++ b/versioned_docs/version-v1.7/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.7/vm/clone-vm.md
+++ b/versioned_docs/version-v1.7/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.7/vm/cpu-memory-hotplug.md
+++ b/versioned_docs/version-v1.7/vm/cpu-memory-hotplug.md
@@ -19,7 +19,7 @@ description: Create VM with CPU / Memory Hotplug
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-memory-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-memory-hotplug"/>
 </head>
 
 _Available as of v1.6.0_

--- a/versioned_docs/version-v1.7/vm/cpu-pinning.md
+++ b/versioned_docs/version-v1.7/vm/cpu-pinning.md
@@ -19,7 +19,7 @@ description: Create VM with CPU pinning
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-pinning"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-pinning"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.7/vm/create-vm.md
+++ b/versioned_docs/version-v1.7/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.7/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.7/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.7/vm/edit-vm.md
+++ b/versioned_docs/version-v1.7/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.7/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.7/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.7/vm/live-migration.md
+++ b/versioned_docs/version-v1.7/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime. A couple of comprehensive processes and tasks are done under the hood to fulfill the live migration.

--- a/versioned_docs/version-v1.7/vm/nic-hotplug.md
+++ b/versioned_docs/version-v1.7/vm/nic-hotplug.md
@@ -13,7 +13,7 @@ description: Hotplug and hotunplug network interfaces to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/nic-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/nic-hotplug"/>
 </head>
 
 _Available as of v1.7.0_

--- a/versioned_docs/version-v1.7/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.7/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.7/vm/virtual-machines.md
+++ b/versioned_docs/version-v1.7/vm/virtual-machines.md
@@ -11,7 +11,7 @@ description: Information concerning virtual machines that run on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/virtual-machines"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/virtual-machines"/>
 </head>
 
 You can create [Linux VMs](../vm/create-vm.md) using one of the following methods: 

--- a/versioned_docs/version-v1.7/volume/clone-volume.md
+++ b/versioned_docs/version-v1.7/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/versioned_docs/version-v1.7/volume/create-volume.md
+++ b/versioned_docs/version-v1.7/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.7/volume/edit-volume.md
+++ b/versioned_docs/version-v1.7/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.7/volume/export-volume.md
+++ b/versioned_docs/version-v1.7/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.7/volume/volume-security.md
+++ b/versioned_docs/version-v1.7/volume/volume-security.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.7/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.7/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.

--- a/versioned_docs/version-v1.8/advanced/addons.md
+++ b/versioned_docs/version-v1.8/advanced/addons.md
@@ -5,7 +5,7 @@ title: "Add-ons"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons"/>
 </head>
 
 Harvester provides optional features as add-ons to maintain a minimal installation footprint. This design allows you to easily enable or disable functionality based strictly on your use case and requirements. You can customize the settings of each add-on, though the level of customization depends on the underlying software.

--- a/versioned_docs/version-v1.8/advanced/addons/kubeovn-operator.md
+++ b/versioned_docs/version-v1.8/advanced/addons/kubeovn-operator.md
@@ -5,7 +5,7 @@ title: "Kube-OVN Operator (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/kubeovn-operator"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/kubeovn-operator"/>
 </head>
 
 _Available as of v1.6.0_

--- a/versioned_docs/version-v1.8/advanced/addons/lvm-local-storage.md
+++ b/versioned_docs/version-v1.8/advanced/addons/lvm-local-storage.md
@@ -5,7 +5,7 @@ title: "Local Storage Support (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/lvm-local-storage"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/lvm-local-storage"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.8/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.8/advanced/addons/managed-dhcp.md
@@ -5,7 +5,7 @@ title: "Managed DHCP (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/managed-dhcp"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/managed-dhcp"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.8/advanced/addons/nvidiadrivertoolkit.md
+++ b/versioned_docs/version-v1.8/advanced/addons/nvidiadrivertoolkit.md
@@ -5,7 +5,7 @@ title: "NVIDIA Driver Toolkit"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/nvidiadrivertoolkit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/nvidiadrivertoolkit"/>
 </head>
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.

--- a/versioned_docs/version-v1.8/advanced/addons/pcidevices.md
+++ b/versioned_docs/version-v1.8/advanced/addons/pcidevices.md
@@ -5,7 +5,7 @@ title: "PCI Devices"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/pcidevices"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/pcidevices"/>
 </head>
 
 A `PCIDevice` in Harvester represents a host device with a PCI address. 

--- a/versioned_docs/version-v1.8/advanced/addons/rancher-vcluster.md
+++ b/versioned_docs/version-v1.8/advanced/addons/rancher-vcluster.md
@@ -5,7 +5,7 @@ title: "Rancher Manager (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/rancher-vcluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/rancher-vcluster"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.8/advanced/addons/seeder.md
+++ b/versioned_docs/version-v1.8/advanced/addons/seeder.md
@@ -12,7 +12,7 @@ Description: Perform out-of-band operations on Harvester hosts via IPMI and disc
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/seeder"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/seeder"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.8/advanced/addons/virtual-machine-auto-balance.md
+++ b/versioned_docs/version-v1.8/advanced/addons/virtual-machine-auto-balance.md
@@ -5,7 +5,7 @@ title: "Virtual Machine Auto Balance (Experimental)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/virtual-machine-auto-balance"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/virtual-machine-auto-balance"/>
 </head>
 
 _Available as of v1.7.0_

--- a/versioned_docs/version-v1.8/advanced/addons/vmimport.md
+++ b/versioned_docs/version-v1.8/advanced/addons/vmimport.md
@@ -5,7 +5,7 @@ title: "VM Import"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/addons/vmimport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/addons/vmimport"/>
 </head>
 
 With the vm-import-controller add-on, you can import virtual machines from VMware, OpenStack, and Open Virtual Appliance (OVA) packages.

--- a/versioned_docs/version-v1.8/advanced/cloudinitcrd.md
+++ b/versioned_docs/version-v1.8/advanced/cloudinitcrd.md
@@ -5,7 +5,7 @@ title: "CloudInit CRD"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/cloudinitcrd"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/cloudinitcrd"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.8/advanced/csidriver.md
+++ b/versioned_docs/version-v1.8/advanced/csidriver.md
@@ -5,7 +5,7 @@ title: "Third-Party Storage Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/csidriver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/csidriver"/>
 </head>
 
 _Available as of v1.5.0_

--- a/versioned_docs/version-v1.8/advanced/customsuseimages.md
+++ b/versioned_docs/version-v1.8/advanced/customsuseimages.md
@@ -9,7 +9,7 @@ Description: How to create custom SLES and openSUSE guest virtual machine images
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/customsuseimages"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/customsuseimages"/>
 </head>
 
 SUSE provides [SUSE Linux Enterprise (SLE)](https://www.suse.com/download/sles/) and [openSUSE Leap](https://get.opensuse.org/leap/) virtual machine (VM) images suitable for use in Harvester. These images are built on the [openSUSE Build Service](https://build.opensuse.org/) (OBS) using the [Kiwi](https://osinside.github.io/kiwi/) image building tool, and can be used immediately after downloading.

--- a/versioned_docs/version-v1.8/advanced/longhorn-v2.md
+++ b/versioned_docs/version-v1.8/advanced/longhorn-v2.md
@@ -7,7 +7,7 @@ Description: How to enable and use the Longhorn V2 Data Engine
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/longhorn-v2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/longhorn-v2"/>
 </head>
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.

--- a/versioned_docs/version-v1.8/advanced/settings.md
+++ b/versioned_docs/version-v1.8/advanced/settings.md
@@ -6,7 +6,7 @@ title: "Settings"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/index"/>
 </head>
 
 The following is a list of advanced settings that you can use in Harvester. You can modify the `settings.harvesterhci.io` custom resource using both the Harvester UI and the `kubectl` command.

--- a/versioned_docs/version-v1.8/advanced/singlenodeclusters.md
+++ b/versioned_docs/version-v1.8/advanced/singlenodeclusters.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/singlenodeclusters"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/singlenodeclusters"/>
 </head>
 
 Harvester supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods ([ISO](../install/iso-install.md), [USB](../install/usb-install.md), and [PXE boot](../install/pxe-boot-install.md)).

--- a/versioned_docs/version-v1.8/advanced/storageclass.md
+++ b/versioned_docs/version-v1.8/advanced/storageclass.md
@@ -5,7 +5,7 @@ title: "StorageClass"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storageclass"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storageclass"/>
 </head>
 
 Harvester uses StorageClasses to describe how Longhorn must provision volumes. Longhorn StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as *profiles* in other storage systems.

--- a/versioned_docs/version-v1.8/advanced/storagenetwork.md
+++ b/versioned_docs/version-v1.8/advanced/storagenetwork.md
@@ -5,7 +5,7 @@ title: "Storage Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/storagenetwork"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/storagenetwork"/>
 </head>
 
 Harvester uses Longhorn to provide block device volumes for virtual machines and pods. If you want to isolate Longhorn replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.

--- a/versioned_docs/version-v1.8/advanced/vgpusupport.md
+++ b/versioned_docs/version-v1.8/advanced/vgpusupport.md
@@ -5,7 +5,7 @@ title: "vGPU Support"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vgpusupport"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vgpusupport"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.8/advanced/vm-migration-network.md
+++ b/versioned_docs/version-v1.8/advanced/vm-migration-network.md
@@ -5,7 +5,7 @@ title: "VM Migration Network"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/vm-migration-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/vm-migration-network"/>
 </head>
 
 A VM migration network is useful for isolating migration traffic from cluster traffic on `mgmt` and other cluster-wide workloads. Using a VM migration network results in better network bandwidth and performance.

--- a/versioned_docs/version-v1.8/advanced/witness.md
+++ b/versioned_docs/version-v1.8/advanced/witness.md
@@ -5,7 +5,7 @@ title: "Witness Node"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/advanced/witness"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/advanced/witness"/>
 </head>
 
 _Available as of v1.3.0_

--- a/versioned_docs/version-v1.8/airgap.md
+++ b/versioned_docs/version-v1.8/airgap.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/airgap"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/airgap"/>
 </head>
 
 This section describes how to use Harvester in an air gapped environment. Some use cases could be where Harvester will be installed offline, behind a firewall, or behind a proxy.

--- a/versioned_docs/version-v1.8/authentication.md
+++ b/versioned_docs/version-v1.8/authentication.md
@@ -13,7 +13,7 @@ description: With ISO installation mode, user will be prompted to set the passwo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/authentication"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/authentication"/>
 </head>
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.

--- a/versioned_docs/version-v1.8/developer/addon-development.md
+++ b/versioned_docs/version-v1.8/developer/addon-development.md
@@ -11,7 +11,7 @@ Description: How to write your own Harvester add-on
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/developer/Add-on-development-guide"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/developer/Add-on-development-guide"/>
 </head>
 
 Harvester add-ons allow you to enable and disable specific Harvester and third-party components based on your requirements. Add-ons function as a wrapper for the [RKE2 HelmChart resource definition (CRD)](https://docs.rke2.io/helm#using-the-helm-crd).

--- a/versioned_docs/version-v1.8/faq.md
+++ b/versioned_docs/version-v1.8/faq.md
@@ -6,7 +6,7 @@ title: "FAQ"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/faq"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/faq"/>
 </head>
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.

--- a/versioned_docs/version-v1.8/getting-started/deploy-ha-cluster.md
+++ b/versioned_docs/version-v1.8/getting-started/deploy-ha-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-ha-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-ha-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.8/getting-started/deploy-singlenode-cluster.md
+++ b/versioned_docs/version-v1.8/getting-started/deploy-singlenode-cluster.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/deploy-singlenode-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/deploy-singlenode-cluster"/>
 </head>
 
 A [Harvester cluster](../getting-started/glossary.md#harvester-cluster) with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one [witness node](../advanced/witness.md) (and optionally, one or more worker nodes). You can also create [single-node clusters](../advanced/singlenodeclusters.md) that support most Harvester features (excluding high availability, multi-replica support, and live migration). 

--- a/versioned_docs/version-v1.8/getting-started/document-conventions.md
+++ b/versioned_docs/version-v1.8/getting-started/document-conventions.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/document-conventions"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/document-conventions"/>
 </head>
 
 ## Release Types

--- a/versioned_docs/version-v1.8/getting-started/glossary.md
+++ b/versioned_docs/version-v1.8/getting-started/glossary.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/getting-started/glossary"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/getting-started/glossary"/>
 </head>
 
 ## **cluster network**

--- a/versioned_docs/version-v1.8/host/host.md
+++ b/versioned_docs/version-v1.8/host/host.md
@@ -6,7 +6,7 @@ title: "Host Management"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/host"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/host"/>
 </head>
 
 Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.

--- a/versioned_docs/version-v1.8/image/image-security.md
+++ b/versioned_docs/version-v1.8/image/image-security.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/image-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/image-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.8/image/upload-image.md
+++ b/versioned_docs/version-v1.8/image/upload-image.md
@@ -13,7 +13,7 @@ description: To import virtual machine images in the **Images** page, enter a UR
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/image/upload-image"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/image/upload-image"/>
 </head>
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.

--- a/versioned_docs/version-v1.8/index.md
+++ b/versioned_docs/version-v1.8/index.md
@@ -13,7 +13,7 @@ description: Harvester is an open source hyper-converged infrastructure (HCI) so
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8"/>
 </head>
 
 [Harvester](https://harvesterhci.io/) is a modern, open, interoperable, [hyperconverged infrastructure (HCI)](https://en.wikipedia.org/wiki/Hyper-converged_infrastructure) solution built on Kubernetes. It is an open-source alternative designed for operators seeking a [cloud-native](https://about.gitlab.com/topics/cloud-native/) HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with [Rancher](https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester). It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.

--- a/versioned_docs/version-v1.8/install/external-disk-support.md
+++ b/versioned_docs/version-v1.8/install/external-disk-support.md
@@ -12,7 +12,7 @@ description: Install Harvester on diskless systems.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/external-disk-support"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/external-disk-support"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.8/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.8/install/harvester-configuration.md
@@ -12,7 +12,7 @@ description: Harvester configuration file can be provided during manual or autom
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/harvester-configuration"/>
 </head>
 
 ## Configuration Example

--- a/versioned_docs/version-v1.8/install/install-binaries-mode.md
+++ b/versioned_docs/version-v1.8/install/install-binaries-mode.md
@@ -12,7 +12,7 @@ description: To get the Harvester ISO, download it from the GitHub releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/install-binaries-mode"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/install-binaries-mode"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.8/install/iso-install.md
+++ b/versioned_docs/version-v1.8/install/iso-install.md
@@ -13,7 +13,7 @@ description: To get the Harvester ISO, download it from the Github releases. Dur
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/index"/>
 </head>
 
 Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download **💿 harvester-v1.x.x-amd64.iso** from the [Harvester releases](https://github.com/harvester/harvester/releases) page.

--- a/versioned_docs/version-v1.8/install/management-address.md
+++ b/versioned_docs/version-v1.8/install/management-address.md
@@ -8,7 +8,7 @@ description: The Harvester provides a virtual IP as the management address.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/management-address"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/management-address"/>
 </head>
 
 Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP.  You can find the management address on the console dashboard after the installation.

--- a/versioned_docs/version-v1.8/install/net-install.md
+++ b/versioned_docs/version-v1.8/install/net-install.md
@@ -11,7 +11,7 @@ description: Harvester Net Install ISO is a minimal ISO that contains only the O
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/net-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/net-install"/>
 </head>
 
 The Harvester net install ISO is a minimal installation image that contains only the core OS components, allowing the installer to boot and then install the Harvester OS on a disk. After installation is completed, the Harvester OS pulls all required container images from the internet (mostly from Docker Hub).

--- a/versioned_docs/version-v1.8/install/post-install.md
+++ b/versioned_docs/version-v1.8/install/post-install.md
@@ -10,7 +10,7 @@ description: Post-installation steps.
 
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/post-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/post-install"/>
 </head>
 
 You can enhance the security and performance of your Harvester cluster by performing the following procedures after installation is completed.

--- a/versioned_docs/version-v1.8/install/pxe-boot-install.md
+++ b/versioned_docs/version-v1.8/install/pxe-boot-install.md
@@ -15,7 +15,7 @@ description: Starting from version `0.2.0`, Harvester can be installed automatic
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/pxe-boot-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/pxe-boot-install"/>
 </head>
 
 Starting from version `0.2.0`, Harvester can be installed automatically. This document provides an example to do an automatic installation with PXE boot.

--- a/versioned_docs/version-v1.8/install/requirements.md
+++ b/versioned_docs/version-v1.8/install/requirements.md
@@ -9,7 +9,7 @@ description: Outline the Harvester installation requirements
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/requirements"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/requirements"/>
 </head>
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.

--- a/versioned_docs/version-v1.8/install/update-harvester-configuration.md
+++ b/versioned_docs/version-v1.8/install/update-harvester-configuration.md
@@ -9,7 +9,7 @@ description: How to update Harvester configuration after installation
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/update-harvester-configuration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/update-harvester-configuration"/>
 </head>
 
 Harvester's OS has an immutable design, which means most files in the OS revert to their pre-configured state after a reboot. The Harvester OS loads the pre-configured values of system components from configuration files during the boot time.

--- a/versioned_docs/version-v1.8/install/usb-install.md
+++ b/versioned_docs/version-v1.8/install/usb-install.md
@@ -5,7 +5,7 @@ title: "USB Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/install/usb-install"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/install/usb-install"/>
 </head>
 
 ## Create a bootable USB flash drive

--- a/versioned_docs/version-v1.8/logging/harvester-logging.md
+++ b/versioned_docs/version-v1.8/logging/harvester-logging.md
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/logging/harvester-logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/logging/harvester-logging"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.8/monitoring/calculation-resource-metrics.md
+++ b/versioned_docs/version-v1.8/monitoring/calculation-resource-metrics.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/calculation-resource-metrics"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/calculation-resource-metrics"/>
 </head>
 
 Harvester calculates resource metrics using data that is dynamically collected from the system. Host-level resource metrics are calculated and then aggregated to obtain the cluster-level metrics.

--- a/versioned_docs/version-v1.8/monitoring/harvester-monitoring.md
+++ b/versioned_docs/version-v1.8/monitoring/harvester-monitoring.md
@@ -6,7 +6,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/monitoring/harvester-monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/monitoring/harvester-monitoring"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.8/networking/best-practice.md
+++ b/versioned_docs/version-v1.8/networking/best-practice.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/best-practice"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/best-practice"/>
 </head>
 
 ## Replace Ethernet NICs

--- a/versioned_docs/version-v1.8/networking/clusternetwork.md
+++ b/versioned_docs/version-v1.8/networking/clusternetwork.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/index"/>
 </head>
 
 ## Concepts

--- a/versioned_docs/version-v1.8/networking/deep-dive.md
+++ b/versioned_docs/version-v1.8/networking/deep-dive.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/deep-dive"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/deep-dive"/>
 </head>
 
 ## Network Topology

--- a/versioned_docs/version-v1.8/networking/harvester-network.md
+++ b/versioned_docs/version-v1.8/networking/harvester-network.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/harvester-network"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/harvester-network"/>
 </head>
 
 Harvester provides three types of networks for virtual machines (VMs), including:

--- a/versioned_docs/version-v1.8/networking/hostnetworkconfig.md
+++ b/versioned_docs/version-v1.8/networking/hostnetworkconfig.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/hostnetworkconfig.md"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/hostnetworkconfig.md"/>
 </head>
 
 ## Host Network Configuration

--- a/versioned_docs/version-v1.8/networking/ippool.md
+++ b/versioned_docs/version-v1.8/networking/ippool.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/ippool"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/ippool"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.8/networking/kubeovn-vm-isolation.md
+++ b/versioned_docs/version-v1.8/networking/kubeovn-vm-isolation.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vm-isolation"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vm-isolation"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.8/networking/kubeovn-vpc.md
+++ b/versioned_docs/version-v1.8/networking/kubeovn-vpc.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vpc"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vpc"/>
 </head> 
 
 :::note

--- a/versioned_docs/version-v1.8/networking/kubeovn-vpcnatgateway.md
+++ b/versioned_docs/version-v1.8/networking/kubeovn-vpcnatgateway.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/kubeovn-vpcnatgateway"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/kubeovn-vpcnatgateway"/>
 </head>
 
 :::note

--- a/versioned_docs/version-v1.8/networking/loadbalancer.md
+++ b/versioned_docs/version-v1.8/networking/loadbalancer.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/networking/loadbalancer"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/networking/loadbalancer"/>
 </head>
 
 _Available as of v1.2.0_

--- a/versioned_docs/version-v1.8/rancher/cloud-provider.md
+++ b/versioned_docs/version-v1.8/rancher/cloud-provider.md
@@ -12,7 +12,7 @@ description: The Harvester cloud provider used by the guest cluster in Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/cloud-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/cloud-provider"/>
 </head>
 
 [RKE2](./node/rke2-cluster.md) clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides [load balancer](#load-balancer-support) and Harvester cluster [storage passthrough](./csi-driver.md) support to the guest Kubernetes cluster.

--- a/versioned_docs/version-v1.8/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.8/rancher/csi-driver.md
@@ -9,7 +9,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/csi-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/csi-driver"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.8/rancher/harvester-ui-extension.md
+++ b/versioned_docs/version-v1.8/rancher/harvester-ui-extension.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 

--- a/versioned_docs/version-v1.8/rancher/import-existing-vm.md
+++ b/versioned_docs/version-v1.8/rancher/import-existing-vm.md
@@ -10,7 +10,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/import-existing-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/import-existing-vm"/>
 </head>
 
 Rancher allows you to import existing Harvester VMs in which you installed Kubernetes.

--- a/versioned_docs/version-v1.8/rancher/node/k3s-cluster.md
+++ b/versioned_docs/version-v1.8/rancher/node/k3s-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an K3s Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/k3s-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/k3s-cluster"/>
 </head>
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.8/rancher/node/node-driver.md
+++ b/versioned_docs/version-v1.8/rancher/node/node-driver.md
@@ -12,7 +12,7 @@ description: The Harvester node driver is used to provision VMs in the Harvester
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/node-driver"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/node-driver"/>
 </head>
 
 The [Harvester node driver](https://github.com/harvester/docker-machine-driver-harvester), similar to the Docker Machine driver, is used to provision VMs in the Harvester cluster, and Rancher uses it to launch and manage Kubernetes clusters.

--- a/versioned_docs/version-v1.8/rancher/node/rke2-cluster.md
+++ b/versioned_docs/version-v1.8/rancher/node/rke2-cluster.md
@@ -5,7 +5,7 @@ title: "Creating an RKE2 Kubernetes Cluster"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/node/rke2-cluster"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/node/rke2-cluster"/>
 </head>
 
 You can now provision RKE2 Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.

--- a/versioned_docs/version-v1.8/rancher/rancher-integration.md
+++ b/versioned_docs/version-v1.8/rancher/rancher-integration.md
@@ -12,7 +12,7 @@ description: Rancher is an open source multi-cluster management platform. Harves
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-integration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-integration"/>
 </head>
 
 [Rancher](https://github.com/rancher/rancher) is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.

--- a/versioned_docs/version-v1.8/rancher/rancher-terraform.md
+++ b/versioned_docs/version-v1.8/rancher/rancher-terraform.md
@@ -13,7 +13,7 @@ description: Rancher Terraform allows administrators to create and manage RKE2 g
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/rancher-terraform"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/rancher-terraform"/>
 </head>
 
 The [Rancher Terraform Provider](https://registry.terraform.io/providers/rancher/rancher2/) allows administrators to create and manage RKE2 guest clusters using Terraform.

--- a/versioned_docs/version-v1.8/rancher/resource-quota.md
+++ b/versioned_docs/version-v1.8/rancher/resource-quota.md
@@ -12,7 +12,7 @@ description: ResourceQuota allows administrators to set resource limits per name
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/resource-quota"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/resource-quota"/>
 </head>
 
 [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.

--- a/versioned_docs/version-v1.8/rancher/virtualization-management.md
+++ b/versioned_docs/version-v1.8/rancher/virtualization-management.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/rancher/virtualization-management"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/rancher/virtualization-management"/>
 </head>
 
 With Rancher's virtualization management capabilities, you can import and manage multiple Harvester clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.

--- a/versioned_docs/version-v1.8/terraform/terraform-provider.md
+++ b/versioned_docs/version-v1.8/terraform/terraform-provider.md
@@ -6,7 +6,7 @@ title: "Harvester Terraform Provider"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/terraform/terraform-provider"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/terraform/terraform-provider"/>
 </head>
 
 ## Support Matrix

--- a/versioned_docs/version-v1.8/troubleshooting/harvester.md
+++ b/versioned_docs/version-v1.8/troubleshooting/harvester.md
@@ -5,7 +5,7 @@ title: "Harvester"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/harvester"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/harvester"/>
 </head>
 
 ## Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting

--- a/versioned_docs/version-v1.8/troubleshooting/installation.md
+++ b/versioned_docs/version-v1.8/troubleshooting/installation.md
@@ -6,7 +6,7 @@ title: "Installation"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/index"/>
 </head>
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.

--- a/versioned_docs/version-v1.8/troubleshooting/logging.md
+++ b/versioned_docs/version-v1.8/troubleshooting/logging.md
@@ -5,7 +5,7 @@ title: "Logging"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/logging"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/logging"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Logging.

--- a/versioned_docs/version-v1.8/troubleshooting/monitoring.md
+++ b/versioned_docs/version-v1.8/troubleshooting/monitoring.md
@@ -5,7 +5,7 @@ title: "Monitoring"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/monitoring"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/monitoring"/>
 </head>
 
 The following sections contain tips to troubleshoot Harvester Monitoring.

--- a/versioned_docs/version-v1.8/troubleshooting/os.md
+++ b/versioned_docs/version-v1.8/troubleshooting/os.md
@@ -5,7 +5,7 @@ title: "Operating System"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/os"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/os"/>
 </head>
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the [elemental-toolkit](https://github.com/rancher/elemental-toolkit). The following sections contain information and tips to help users troubleshoot OS-related issues.

--- a/versioned_docs/version-v1.8/troubleshooting/rancher.md
+++ b/versioned_docs/version-v1.8/troubleshooting/rancher.md
@@ -5,7 +5,7 @@ title: "Rancher"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/rancher"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/rancher"/>
 </head>
 
 

--- a/versioned_docs/version-v1.8/troubleshooting/vm.md
+++ b/versioned_docs/version-v1.8/troubleshooting/vm.md
@@ -5,7 +5,7 @@ title: "VM"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/troubleshooting/vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/troubleshooting/vm"/>
 </head>
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.

--- a/versioned_docs/version-v1.8/upgrade/automatic.md
+++ b/versioned_docs/version-v1.8/upgrade/automatic.md
@@ -13,7 +13,7 @@ description: Harvester provides two ways to upgrade. Users can either upgrade us
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/index"/>
 </head>
 
 Harvester is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:

--- a/versioned_docs/version-v1.8/upgrade/troubleshooting.md
+++ b/versioned_docs/version-v1.8/upgrade/troubleshooting.md
@@ -5,7 +5,7 @@ title: "Troubleshooting"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/troubleshooting"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/troubleshooting"/>
 </head>
 
 ## Overview

--- a/versioned_docs/version-v1.8/upgrade/v1-1-2-to-v1-2-0.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-1-2-to-v1-2-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-1-2-to-v1-2-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-1-2-to-v1-2-0"/>
 </head>
 
 :::caution

--- a/versioned_docs/version-v1.8/upgrade/v1-2-0-to-v1-2-1.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-2-0-to-v1-2-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-0-to-v1-2-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-0-to-v1-2-1"/>
 </head>
 
 

--- a/versioned_docs/version-v1.8/upgrade/v1-2-1-to-v1-2-2.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-2-1-to-v1-2-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.1 to v1.2.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-1-to-v1-2-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-1-to-v1-2-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.8/upgrade/v1-2-2-to-v1-3-1.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-2-2-to-v1-3-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-2-2-to-v1-3-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-2-2-to-v1-3-1"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.8/upgrade/v1-3-1-to-v1-3-2.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-3-1-to-v1-3-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.1 to v1.3.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-1-to-v1-3-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-1-to-v1-3-2"/>
 </head>
 
 ## General information

--- a/versioned_docs/version-v1.8/upgrade/v1-3-2-to-v1-4-0.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-3-2-to-v1-4-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.3.2 to v1.4.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-3-2-to-v1-4-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-3-2-to-v1-4-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-4-0-to-v1-4-1.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-4-0-to-v1-4-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.0 to v1.4.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-0-to-v1-4-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-0-to-v1-4-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-4-1-to-v1-4-2.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-4-1-to-v1-4-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1 to v1.4.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-4-1-to-v1-4-3.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-4-1-to-v1-4-3.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-1-to-v1-4-3"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-1-to-v1-4-3"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-4-2-to-v1-5-0.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-4-2-to-v1-5-0.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-0"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-0"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-4-2-to-v1-5-1.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-4-2-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-4-2-to-v1-5-2.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-4-2-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.4.2/v1.4.3 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-4-2-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-4-2-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-5-0-to-v1-5-1.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-5-0-to-v1-5-1.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0 to v1.5.1"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-1"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-1"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-5-0-to-v1-5-2.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-5-0-to-v1-5-2.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.0/v1.5.1 to v1.5.2"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-0-to-v1-5-2"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-0-to-v1-5-2"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-5-x-to-v1-6-x.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-5-x-to-v1-6-x.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.5.x to v1.6.x"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-5-x-to-v1-6-x"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-5-x-to-v1-6-x"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-6-y.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-6-y.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.6.x to v1.6.y"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-6-y"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-6-x-to-v1-6-y"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-7-x.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-7-x.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.6.x to v1.7.x"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-6-x-to-v1-7-x"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-6-x-to-v1-7-x"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
@@ -5,7 +5,7 @@ title: "Upgrade from v1.7.x to v1.7.y"
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/upgrade/v1-7-x-to-v1-7-y"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-7-x-to-v1-7-y"/>
 </head>
 
 ## General Information

--- a/versioned_docs/version-v1.8/vm/access-to-the-vm.md
+++ b/versioned_docs/version-v1.8/vm/access-to-the-vm.md
@@ -12,7 +12,7 @@ description: Once the VM is up and running, it can be accessed using either VNC 
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/access-to-the-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/access-to-the-vm"/>
 </head>
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.

--- a/versioned_docs/version-v1.8/vm/backup-restore.md
+++ b/versioned_docs/version-v1.8/vm/backup-restore.md
@@ -12,7 +12,7 @@ description: VM backups are created from the Virtual Machines page. The VM backu
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/backup-restore"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/backup-restore"/>
 </head>
 
 ## VM Backup & Restore

--- a/versioned_docs/version-v1.8/vm/cdrom-hotplug.md
+++ b/versioned_docs/version-v1.8/vm/cdrom-hotplug.md
@@ -13,7 +13,7 @@ description: Hotplug and hotunplug CD-ROM volumes.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cdrom-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cdrom-hotplug"/>
 </head>
 
 _Available as of v1.8.0_

--- a/versioned_docs/version-v1.8/vm/clone-vm.md
+++ b/versioned_docs/version-v1.8/vm/clone-vm.md
@@ -12,7 +12,7 @@ description: VM can be cloned with/without data. This function doesn't need to t
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/clone-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/clone-vm"/>
 </head>
 
 _Available as of v1.1.0_

--- a/versioned_docs/version-v1.8/vm/cpu-memory-hotplug.md
+++ b/versioned_docs/version-v1.8/vm/cpu-memory-hotplug.md
@@ -19,7 +19,7 @@ description: Create VM with CPU / Memory Hotplug
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-memory-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-memory-hotplug"/>
 </head>
 
 _Available as of v1.6.0_

--- a/versioned_docs/version-v1.8/vm/cpu-pinning.md
+++ b/versioned_docs/version-v1.8/vm/cpu-pinning.md
@@ -19,7 +19,7 @@ description: Create VM with CPU pinning
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/cpu-pinning"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/cpu-pinning"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.8/vm/create-vm.md
+++ b/versioned_docs/version-v1.8/vm/create-vm.md
@@ -15,7 +15,7 @@ description: Create one or more virtual machines from the Virtual Machines page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/index"/>
 </head>
 
 ## How to Create a VM

--- a/versioned_docs/version-v1.8/vm/create-windows-vm.md
+++ b/versioned_docs/version-v1.8/vm/create-windows-vm.md
@@ -16,7 +16,7 @@ description: Create one or more Windows virtual machines from the Virtual Machin
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/create-windows-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/create-windows-vm"/>
 </head>
 
 Create one or more virtual machines from the **Virtual Machines** page.

--- a/versioned_docs/version-v1.8/vm/edit-vm.md
+++ b/versioned_docs/version-v1.8/vm/edit-vm.md
@@ -14,7 +14,7 @@ description: Edit Virtual Machines from the Harvester VM page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/edit-vm"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/edit-vm"/>
 </head>
 
 ## How to Edit a VM

--- a/versioned_docs/version-v1.8/vm/hotplug-volume.md
+++ b/versioned_docs/version-v1.8/vm/hotplug-volume.md
@@ -10,7 +10,7 @@ description: Adding hot-plug volumes to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/hotplug-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/hotplug-volume"/>
 </head>
 
 Harvester supports adding hot-plug volumes to a running VM.

--- a/versioned_docs/version-v1.8/vm/live-migration.md
+++ b/versioned_docs/version-v1.8/vm/live-migration.md
@@ -12,7 +12,7 @@ description: Live migration means moving a virtual machine to a different host w
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/live-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/live-migration"/>
 </head>
 
 Live migration means moving a virtual machine to a different host without downtime. A couple of comprehensive processes and tasks are done under the hood to fulfill the live migration.

--- a/versioned_docs/version-v1.8/vm/nic-hotplug.md
+++ b/versioned_docs/version-v1.8/vm/nic-hotplug.md
@@ -13,7 +13,7 @@ description: Hotplug and hotunplug network interfaces to a running VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/nic-hotplug"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/nic-hotplug"/>
 </head>
 
 _Available as of v1.7.0_

--- a/versioned_docs/version-v1.8/vm/resource-overcommit.md
+++ b/versioned_docs/version-v1.8/vm/resource-overcommit.md
@@ -11,7 +11,7 @@ description: Overcommit resources to a VM.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/resource-overcommit"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/resource-overcommit"/>
 </head>
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting [`overcommit-config`](../advanced/settings.md#overcommit-config), this will allow scheduling of additional virtual machines even when physical resources are fully utilized.

--- a/versioned_docs/version-v1.8/vm/virtual-machines.md
+++ b/versioned_docs/version-v1.8/vm/virtual-machines.md
@@ -11,7 +11,7 @@ description: Information concerning virtual machines that run on top of the Harv
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/vm/virtual-machines"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/vm/virtual-machines"/>
 </head>
 
 You can create [Linux VMs](../vm/create-vm.md) using one of the following methods: 

--- a/versioned_docs/version-v1.8/volume/clone-volume.md
+++ b/versioned_docs/version-v1.8/volume/clone-volume.md
@@ -8,7 +8,7 @@ description: Clone volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/clone-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/clone-volume"/>
 </head>
 
 ## How to Clone a Volume

--- a/versioned_docs/version-v1.8/volume/create-volume.md
+++ b/versioned_docs/version-v1.8/volume/create-volume.md
@@ -9,7 +9,7 @@ description: Create a volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/index"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/index"/>
 </head>
 
 ## Create an Empty Volume

--- a/versioned_docs/version-v1.8/volume/edit-volume.md
+++ b/versioned_docs/version-v1.8/volume/edit-volume.md
@@ -8,7 +8,7 @@ description: Edit volume from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/edit-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/edit-volume"/>
 </head>
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.

--- a/versioned_docs/version-v1.8/volume/export-volume.md
+++ b/versioned_docs/version-v1.8/volume/export-volume.md
@@ -8,7 +8,7 @@ description: Export volume to image from the Volume page.
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/export-volume"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/export-volume"/>
 </head>
 
 You can select and export an existing volume to an image by following the steps below:

--- a/versioned_docs/version-v1.8/volume/storage-migration.md
+++ b/versioned_docs/version-v1.8/volume/storage-migration.md
@@ -11,7 +11,7 @@ description: Migrate VM volumes between different StorageClasses without data lo
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/storage-migration"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/storage-migration"/>
 </head>
 
 Storage migration allows you to move VM volumes data from one StorageClass to another. This is useful when you need to change the storage backend for a VM — for example, migrating from Longhorn replicated storage to LVM local storage for better performance, or from local storage to replicated storage for higher availability.

--- a/versioned_docs/version-v1.8/volume/volume-security.md
+++ b/versioned_docs/version-v1.8/volume/volume-security.md
@@ -8,7 +8,7 @@ keywords:
 ---
 
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-security"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-security"/>
 </head>
 
 _Available as of v1.4.0_

--- a/versioned_docs/version-v1.8/volume/volume-snapshots.md
+++ b/versioned_docs/version-v1.8/volume/volume-snapshots.md
@@ -8,7 +8,7 @@ keywords:
 description: Take a snapshot for a volume from the Volume page.
 ---
 <head>
-  <link rel="canonical" href="https://docs.harvesterhci.io/v1.7/volume/volume-snapshots"/>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/volume/volume-snapshots"/>
 </head>
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.


### PR DESCRIPTION
Related issue: [#10166](https://github.com/harvester/harvester/issues/10166)

Scope: v1.4, v1.5, v1.6, v1.7, v1.8, v1.9

Changes:
- Update canonical links in files

Additional information:
- [What is canonicalization](https://developers.google.com/search/docs/crawling-indexing/canonicalization)
- [The rel="canonical" link element](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method)