### PR TITLE
doc: update NIC renaming workaround for v1.7.2

### DIFF
--- a/docs/upgrade/v1-6-x-to-v1-7-x.md
+++ b/docs/upgrade/v1-6-x-to-v1-7-x.md
@@ -163,7 +163,7 @@ The DHCP server should return the original IP address and the affected node shou
 
 :::note
 
-Propagation of the DHCP client ID from wicked to NetworkManager occurs automatically when upgrading from v1.6.x to v1.7.1. This workaround is only required when upgrading to v1.7.0.
+Propagation of the DHCP client ID from wicked to NetworkManager occurs automatically when upgrading from v1.6.x to v1.7.1 or v1.7.2. This workaround is only required when upgrading to v1.7.0.
 
 :::
 
@@ -247,13 +247,14 @@ To resolve this issue, apply kernel arguments that restore the original names of
 
 :::note
 
-This workaround is only necessary when upgrading to v1.7.0 or if using bonded interfaces. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+This workaround is only necessary when upgrading to v1.7.0, or if using bonded interfaces with v1.7.1. In v1.7.2 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
 
 | Version | Interface | Workaround |
 | --- | --- | --- |
 | v1.7.0 | Any | Required |
-| v1.7.1+ | Standalone | Automated (No action) |
-| v1.7.1+ | Bonded | Required |
+| v1.7.1 | Standalone | Automated (No action) |
+| v1.7.1 | Bonded | Required |
+| v1.7.2+ | Any | Automated (No action) |
 
 :::
 

--- a/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-7-x.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-6-x-to-v1-7-x.md
@@ -163,7 +163,7 @@ The DHCP server should return the original IP address and the affected node shou
 
 :::note
 
-Propagation of the DHCP client ID from wicked to NetworkManager occurs automatically when upgrading from v1.6.x to v1.7.1. This workaround is only required when upgrading to v1.7.0.
+Propagation of the DHCP client ID from wicked to NetworkManager occurs automatically when upgrading from v1.6.x to v1.7.1 or v1.7.2. This workaround is only required when upgrading to v1.7.0.
 
 :::
 
@@ -247,13 +247,14 @@ To resolve this issue, apply kernel arguments that restore the original names of
 
 :::note
 
-This workaround is only necessary when upgrading to v1.7.0 or if using bonded interfaces. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+This workaround is only necessary when upgrading to v1.7.0, or if using bonded interfaces with v1.7.1. In v1.7.2 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
 
 | Version | Interface | Workaround |
 | --- | --- | --- |
 | v1.7.0 | Any | Required |
-| v1.7.1+ | Standalone | Automated (No action) |
-| v1.7.1+ | Bonded | Required |
+| v1.7.1 | Standalone | Automated (No action) |
+| v1.7.1 | Bonded | Required |
+| v1.7.2+ | Any | Automated (No action) |
 
 :::
 

--- a/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-7-x.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-6-x-to-v1-7-x.md
@@ -163,7 +163,7 @@ The DHCP server should return the original IP address and the affected node shou
 
 :::note
 
-Propagation of the DHCP client ID from wicked to NetworkManager occurs automatically when upgrading from v1.6.x to v1.7.1. This workaround is only required when upgrading to v1.7.0.
+Propagation of the DHCP client ID from wicked to NetworkManager occurs automatically when upgrading from v1.6.x to v1.7.1 or v1.7.2. This workaround is only required when upgrading to v1.7.0.
 
 :::
 
@@ -247,13 +247,14 @@ To resolve this issue, apply kernel arguments that restore the original names of
 
 :::note
 
-This workaround is only necessary when upgrading to v1.7.0 or if using bonded interfaces. In v1.7.1 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
+This workaround is only necessary when upgrading to v1.7.0, or if using bonded interfaces with v1.7.1. In v1.7.2 and later versions, these `ifname=` arguments are automatically added to prevent network disruptions during driver updates.
 
 | Version | Interface | Workaround |
 | --- | --- | --- |
 | v1.7.0 | Any | Required |
-| v1.7.1+ | Standalone | Automated (No action) |
-| v1.7.1+ | Bonded | Required |
+| v1.7.1 | Standalone | Automated (No action) |
+| v1.7.1 | Bonded | Required |
+| v1.7.2+ | Any | Automated (No action) |
 
 :::
 


### PR DESCRIPTION
#### Problem:
The NIC renaming workaround is no longer required in v1.7.2

#### Solution:
Update the v1.6.x->v1.7.x upgrade page

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10397

#### Test plan:
N/A

#### Additional documentation or context
N/A