### PR TITLE
Replace and remove outdated information in Third-Party Storage

### DIFF
--- a/docs/advanced/csidriver.md
+++ b/docs/advanced/csidriver.md
@@ -32,7 +32,7 @@ These validated CSI drivers have the following capabilities:
 
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with Harvester to ensure greater interoperability. 
 
-The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the SUSE Rancher Prime documentation, which is accessible through the [SUSE Customer Center](https://scc.suse.com/home).
+The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the [Partner Certification and Solutions Catalog](https://www.suse.com/pcsc/home).
 
 :::
 
@@ -225,12 +225,6 @@ If the server is already running, check the `squash` option. You must disable sq
   ```
 
   Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-## References
-
-- [Use Rook Ceph External Storage with Harvester](https://harvesterhci.io/kb/use_rook_ceph_external_storage)
-- [Using NetApp Storage on Harvester](https://harvesterhci.io/kb/install_netapp_trident_csi)
-- [Third Party Storage Support](https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md) 
 
 ## Known Issues
 

--- a/versioned_docs/version-v1.5/advanced/csidriver.md
+++ b/versioned_docs/version-v1.5/advanced/csidriver.md
@@ -32,7 +32,7 @@ These validated CSI drivers have the following capabilities:
 
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with Harvester to ensure greater interoperability. 
 
-The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the SUSE Rancher Prime documentation, which is accessible through the [SUSE Customer Center](https://scc.suse.com/home).
+The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the [Partner Certification and Solutions Catalog](https://www.suse.com/pcsc/home).
 
 :::
 
@@ -206,12 +206,6 @@ If the server is already running, check the `squash` option. You must disable sq
   ```
 
   Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-## References
-
-- [Use Rook Ceph External Storage with Harvester](https://harvesterhci.io/kb/use_rook_ceph_external_storage)
-- [Using NetApp Storage on Harvester](https://harvesterhci.io/kb/install_netapp_trident_csi)
-- [Third Party Storage Support](https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md) 
 
 ## Known Issues
 

--- a/versioned_docs/version-v1.6/advanced/csidriver.md
+++ b/versioned_docs/version-v1.6/advanced/csidriver.md
@@ -32,7 +32,7 @@ These validated CSI drivers have the following capabilities:
 
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with Harvester to ensure greater interoperability. 
 
-The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the SUSE Rancher Prime documentation, which is accessible through the [SUSE Customer Center](https://scc.suse.com/home).
+The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the [Partner Certification and Solutions Catalog](https://www.suse.com/pcsc/home).
 
 :::
 
@@ -220,12 +220,6 @@ If the server is already running, check the `squash` option. You must disable sq
   ```
 
   Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-## References
-
-- [Use Rook Ceph External Storage with Harvester](https://harvesterhci.io/kb/use_rook_ceph_external_storage)
-- [Using NetApp Storage on Harvester](https://harvesterhci.io/kb/install_netapp_trident_csi)
-- [Third Party Storage Support](https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md) 
 
 ## Known Issues
 

--- a/versioned_docs/version-v1.7/advanced/csidriver.md
+++ b/versioned_docs/version-v1.7/advanced/csidriver.md
@@ -32,7 +32,7 @@ These validated CSI drivers have the following capabilities:
 
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with Harvester to ensure greater interoperability. 
 
-The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the SUSE Rancher Prime documentation, which is accessible through the [SUSE Customer Center](https://scc.suse.com/home).
+The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the [Partner Certification and Solutions Catalog](https://www.suse.com/pcsc/home).
 
 :::
 
@@ -225,12 +225,6 @@ If the server is already running, check the `squash` option. You must disable sq
   ```
 
   Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-## References
-
-- [Use Rook Ceph External Storage with Harvester](https://harvesterhci.io/kb/use_rook_ceph_external_storage)
-- [Using NetApp Storage on Harvester](https://harvesterhci.io/kb/install_netapp_trident_csi)
-- [Third Party Storage Support](https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md) 
 
 ## Known Issues
 

--- a/versioned_docs/version-v1.8/advanced/csidriver.md
+++ b/versioned_docs/version-v1.8/advanced/csidriver.md
@@ -32,7 +32,7 @@ These validated CSI drivers have the following capabilities:
 
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with Harvester to ensure greater interoperability. 
 
-The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the SUSE Rancher Prime documentation, which is accessible through the [SUSE Customer Center](https://scc.suse.com/home).
+The Harvester engineering team exclusively validates internally developed storage solutions and select open-source projects. You can find information about enterprise-grade storage solutions that are certified to be compatible with Harvester in the [Partner Certification and Solutions Catalog](https://www.suse.com/pcsc/home).
 
 :::
 
@@ -225,12 +225,6 @@ If the server is already running, check the `squash` option. You must disable sq
   ```
 
   Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-## References
-
-- [Use Rook Ceph External Storage with Harvester](https://harvesterhci.io/kb/use_rook_ceph_external_storage)
-- [Using NetApp Storage on Harvester](https://harvesterhci.io/kb/install_netapp_trident_csi)
-- [Third Party Storage Support](https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md) 
 
 ## Known Issues
 


### PR DESCRIPTION
Related issue: [#179](https://github.com/rancher/harvester-product-docs/issues/179) in `harvester-product-docs` + [SURE-11220](https://jira.suse.com/browse/SURE-11220)

Scope: v1.5, v1.6, v1.7, v1.8 (Latest), v1.9 (Dev)

Affected file: `./advanced/csidriver.md`

Changes:
- Updated note about enterprise-grade storage solutions (replaced "SUSE Customer Center" URL with "Partner Certification & Solutions Catalog" URL)
- Removed "References" section containing links to outdated KB articles and HEP for third-party storage