### PR TITLE
Enhance and backport server_URL setting information

### DIFF
--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: "" # empty or absent in create mode; set to https://cluster-VIP:443 in join mode
+server_url: "" # omitted or empty in CREATE mode; set to https://cluster-VIP:443 in JOIN mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:
@@ -143,34 +143,36 @@ Make sure that your custom configuration always has the correct scheme version.
 
 #### Definition
 
-`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
+URL that nodes use when joining an existing Harvester cluster.
 
-This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `https://cluster-VIP:443`.
-In `CREATE` mode the parameter must be absent or with empty value (`""`). Otherwise the installation fails.
+The configuration depends on the installation task that you are performing.
 
-:::note
+- Creating a new cluster (`CREATE` mode): This setting must be omitted or contain an empty value (`""`). Specifying any other value results in installation failure.
+- Adding a node to an existing cluster (`JOIN` mode): This configuration is mandatory. The default format is `https://cluster-VIP:443`.
 
-To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster [VIP](#installvip) or a domain name in `server_url`.
+:::info important
+
+To ensure high availability (HA), you must specify either the Harvester cluster [VIP](#installvip) or a domain name.
 
 :::
 
-#### Example
+#### Examples
 
-for cluster creation
+- Creating a new cluster (`CREATE` mode)
 
-```yaml
-server_url: '' # or remove this line
-install:
-  mode: create
-```
+  ```yaml
+  server_url: '' # You can also remove this line.
+  install:
+    mode: create
+  ```
 
-or to join a cluster
+- Adding a node to an existing cluster (`JOIN` mode)
 
-```yaml
-server_url: https://cluster-VIP:443
-install:
-  mode: join
-```
+  ```yaml
+  server_url: https://cluster-VIP:443
+  install:
+   mode: join
+  ```
 
 ### `token`
 

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: "" # omitted or empty in CREATE mode; set to https://cluster-VIP:443 in JOIN mode
+server_url: "" # empty or absent in create mode; set to https://cluster-VIP:443 in join mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:
@@ -143,36 +143,34 @@ Make sure that your custom configuration always has the correct scheme version.
 
 #### Definition
 
-URL that nodes use when joining an existing Harvester cluster.
+`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
 
-The configuration depends on the installation task that you are performing.
+This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `https://cluster-VIP:443`.
+In `CREATE` mode the parameter must be absent or with empty value (`""`). Otherwise the installation fails.
 
-- Creating a new cluster (`CREATE` mode): This setting must be omitted or contain an empty value (`""`). Specifying any other value results in installation failure.
-- Adding a node to an existing cluster (`JOIN` mode): This configuration is mandatory. The default format is `https://cluster-VIP:443`.
+:::note
 
-:::info important
-
-To ensure high availability (HA), you must specify either the Harvester cluster [VIP](#installvip) or a domain name.
+To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster [VIP](#installvip) or a domain name in `server_url`.
 
 :::
 
-#### Examples
+#### Example
 
-- Creating a new cluster (`CREATE` mode)
+for cluster creation
 
-  ```yaml
-  server_url: '' # You can also remove this line.
-  install:
-    mode: create
-  ```
+```yaml
+server_url: '' # or remove this line
+install:
+  mode: create
+```
 
-- Adding a node to an existing cluster (`JOIN` mode)
+or to join a cluster
 
-  ```yaml
-  server_url: https://cluster-VIP:443
-  install:
-   mode: join
-  ```
+```yaml
+server_url: https://cluster-VIP:443
+install:
+  mode: join
+```
 
 ### `token`
 

--- a/versioned_docs/version-v1.5/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.5/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: https://cluster-VIP:443
+server_url: "" # omitted or empty in CREATE mode; set to https://cluster-VIP:443 in JOIN mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:
@@ -130,23 +130,36 @@ Make sure that your custom configuration always has the correct scheme version.
 
 #### Definition
 
-`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
+URL that nodes use when joining an existing Harvester cluster.
 
-This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `https://cluster-VIP:443`.
+The configuration depends on the installation task that you are performing.
 
-:::note
+- Creating a new cluster (`CREATE` mode): This setting must be omitted or contain an empty value (`""`). Specifying any other value results in installation failure.
+- Adding a node to an existing cluster (`JOIN` mode): This configuration is mandatory. The default format is `https://cluster-VIP:443`.
 
-To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster [VIP](#installvip) or a domain name in `server_url`.
+:::info important
+
+To ensure high availability (HA), you must specify either the Harvester cluster [VIP](#installvip) or a domain name.
 
 :::
 
-#### Example
+#### Examples
 
-```yaml
-server_url: https://cluster-VIP:443
-install:
-  mode: join
-```
+- Creating a new cluster (`CREATE` mode)
+
+  ```yaml
+  server_url: '' # You can also remove this line.
+  install:
+    mode: create
+  ```
+
+- Adding a node to an existing cluster (`JOIN` mode)
+
+  ```yaml
+  server_url: https://cluster-VIP:443
+  install:
+   mode: join
+  ```
 
 ### `token`
 

--- a/versioned_docs/version-v1.6/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.6/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: https://cluster-VIP:443
+server_url: "" # omitted or empty in CREATE mode; set to https://cluster-VIP:443 in JOIN mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:
@@ -130,23 +130,36 @@ Make sure that your custom configuration always has the correct scheme version.
 
 #### Definition
 
-`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
+URL that nodes use when joining an existing Harvester cluster.
 
-This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `https://cluster-VIP:443`.
+The configuration depends on the installation task that you are performing.
 
-:::note
+- Creating a new cluster (`CREATE` mode): This setting must be omitted or contain an empty value (`""`). Specifying any other value results in installation failure.
+- Adding a node to an existing cluster (`JOIN` mode): This configuration is mandatory. The default format is `https://cluster-VIP:443`.
 
-To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster [VIP](#installvip) or a domain name in `server_url`.
+:::info important
+
+To ensure high availability (HA), you must specify either the Harvester cluster [VIP](#installvip) or a domain name.
 
 :::
 
-#### Example
+#### Examples
 
-```yaml
-server_url: https://cluster-VIP:443
-install:
-  mode: join
-```
+- Creating a new cluster (`CREATE` mode)
+
+  ```yaml
+  server_url: '' # You can also remove this line.
+  install:
+    mode: create
+  ```
+
+- Adding a node to an existing cluster (`JOIN` mode)
+
+  ```yaml
+  server_url: https://cluster-VIP:443
+  install:
+   mode: join
+  ```
 
 ### `token`
 

--- a/versioned_docs/version-v1.7/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.7/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: https://cluster-VIP:443
+server_url: "" # omitted or empty in CREATE mode; set to https://cluster-VIP:443 in JOIN mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:
@@ -144,23 +144,36 @@ Make sure that your custom configuration always has the correct scheme version.
 
 #### Definition
 
-`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
+URL that nodes use when joining an existing Harvester cluster.
 
-This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `https://cluster-VIP:443`.
+The configuration depends on the installation task that you are performing.
 
-:::note
+- Creating a new cluster (`CREATE` mode): This setting must be omitted or contain an empty value (`""`). Specifying any other value results in installation failure.
+- Adding a node to an existing cluster (`JOIN` mode): This configuration is mandatory. The default format is `https://cluster-VIP:443`.
 
-To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster [VIP](#installvip) or a domain name in `server_url`.
+:::info important
+
+To ensure high availability (HA), you must specify either the Harvester cluster [VIP](#installvip) or a domain name.
 
 :::
 
-#### Example
+#### Examples
 
-```yaml
-server_url: https://cluster-VIP:443
-install:
-  mode: join
-```
+- Creating a new cluster (`CREATE` mode)
+
+  ```yaml
+  server_url: '' # You can also remove this line.
+  install:
+    mode: create
+  ```
+
+- Adding a node to an existing cluster (`JOIN` mode)
+
+  ```yaml
+  server_url: https://cluster-VIP:443
+  install:
+   mode: join
+  ```
 
 ### `token`
 

--- a/versioned_docs/version-v1.8/install/harvester-configuration.md
+++ b/versioned_docs/version-v1.8/install/harvester-configuration.md
@@ -21,7 +21,7 @@ Harvester configuration file can be provided during manual or automatic installa
 
 ```yaml
 scheme_version: 1
-server_url: https://cluster-VIP:443
+server_url: "" # omitted or empty in CREATE mode; set to https://cluster-VIP:443 in JOIN mode
 token: TOKEN_VALUE
 os:
   ssh_authorized_keys:
@@ -143,23 +143,36 @@ Make sure that your custom configuration always has the correct scheme version.
 
 #### Definition
 
-`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
+URL that nodes use when joining an existing Harvester cluster.
 
-This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `https://cluster-VIP:443`.
+The configuration depends on the installation task that you are performing.
 
-:::note
+- Creating a new cluster (`CREATE` mode): This setting must be omitted or contain an empty value (`""`). Specifying any other value results in installation failure.
+- Adding a node to an existing cluster (`JOIN` mode): This configuration is mandatory. The default format is `https://cluster-VIP:443`.
 
-To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster [VIP](#installvip) or a domain name in `server_url`.
+:::info important
+
+To ensure high availability (HA), you must specify either the Harvester cluster [VIP](#installvip) or a domain name.
 
 :::
 
-#### Example
+#### Examples
 
-```yaml
-server_url: https://cluster-VIP:443
-install:
-  mode: join
-```
+- Creating a new cluster (`CREATE` mode)
+
+  ```yaml
+  server_url: '' # You can also remove this line.
+  install:
+    mode: create
+  ```
+
+- Adding a node to an existing cluster (`JOIN` mode)
+
+  ```yaml
+  server_url: https://cluster-VIP:443
+  install:
+   mode: join
+  ```
 
 ### `token`
 


### PR DESCRIPTION
Related issue: [#10325](https://github.com/harvester/harvester/issues/10325)

Scope: v1.9, v1.8, v1.7, v1.6, v1.5

Changes:
- Reorganized and rewrote `server_URL` setting information (recently updated in PR [#1002](https://github.com/harvester/docs/pull/1002/))
- Applied changes to all non-EOL versions