### PR TITLE
docs: add rancher/ui-plugin-catalog support matrix

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -85,13 +85,13 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
 
 1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
 
-| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
-| --- | --- |
-| 1.0.x | 3.4.5 |
-| 1.5.x | 4.0.5 |
-| 1.6.x | 4.1.0 |
-| 1.7.x | 4.13.0 |
-| 1.8.x | 4.23.0 |
+  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | --- | --- |
+  | 1.0.x | 3.4.5 |
+  | 1.5.x | 4.0.5 |
+  | 1.6.x | 4.1.0 |
+  | 1.7.x | 4.13.0 |
+  | 1.8.x | 4.23.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -83,7 +83,15 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
 
 
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the newest tag.
+1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
+
+| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+| --- | --- |
+| 1.0.x | 3.4.5 |
+| 1.5.x | 4.0.5 |
+| 1.6.x | 4.1.0 |
+| 1.7.x | 4.13.0 |
+| 1.8.x | 4.23.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -79,13 +79,13 @@ docker load -i /tmp/rancher-agent-<version>.tar
 
 ## Harvester UI extension with Rancher Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. This extension's assets are served on the Rancher UI through the [ui-plugin-catalog container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags). Installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
+1. Pull the [`ui-plugin-catalog` container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) that matches the required Harvester UI Extension version.
 
-  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | Harvester UI Extension Version | ui-plugin-catalog Image Version |
   | --- | --- |
   | 1.0.x | 3.4.5 |
   | 1.5.x | 4.0.5 |

--- a/versioned_docs/version-v1.5/airgap.md
+++ b/versioned_docs/version-v1.5/airgap.md
@@ -82,8 +82,12 @@ docker load -i /tmp/rancher-agent-<version>.tar
 The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 
+1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the newest tag.
+| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+| --- | --- |
+| 1.0.x | 3.4.5 |
+| 1.5.x | 4.0.5 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.5/airgap.md
+++ b/versioned_docs/version-v1.5/airgap.md
@@ -79,15 +79,15 @@ docker load -i /tmp/rancher-agent-<version>.tar
 
 ## Harvester UI extension with Rancher Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. This extension's assets are served on the Rancher UI through the [ui-plugin-catalog container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags). Installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
+1. Pull the [`ui-plugin-catalog` container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) that matches the required Harvester UI Extension version.
 
-| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
-| --- | --- |
-| 1.0.x | 3.4.5 |
-| 1.5.x | 4.0.5 |
+  | Harvester UI Extension Version | ui-plugin-catalog Image Version |
+  | --- | --- |
+  | 1.0.x | 3.4.5 |
+  | 1.5.x | 4.0.5 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.6/airgap.md
+++ b/versioned_docs/version-v1.6/airgap.md
@@ -79,12 +79,12 @@ docker load -i /tmp/rancher-agent-<version>.tar
 
 ## Harvester UI extension with Rancher Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. This extension's assets are served on the Rancher UI through the [ui-plugin-catalog container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags). Installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
+1. Pull the [`ui-plugin-catalog` container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) that matches the required Harvester UI Extension version.
 
-  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | Harvester UI Extension Version | ui-plugin-catalog Image Version |
   | --- | --- |
   | 1.0.x | 3.4.5 |
   | 1.5.x | 4.0.5 |

--- a/versioned_docs/version-v1.6/airgap.md
+++ b/versioned_docs/version-v1.6/airgap.md
@@ -82,8 +82,13 @@ docker load -i /tmp/rancher-agent-<version>.tar
 The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 
+1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the newest tag.
+| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+| --- | --- |
+| 1.0.x | 3.4.5 |
+| 1.5.x | 4.0.5 |
+| 1.6.x | 4.1.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.6/airgap.md
+++ b/versioned_docs/version-v1.6/airgap.md
@@ -84,11 +84,11 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
 
 1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
 
-| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
-| --- | --- |
-| 1.0.x | 3.4.5 |
-| 1.5.x | 4.0.5 |
-| 1.6.x | 4.1.0 |
+  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | --- | --- |
+  | 1.0.x | 3.4.5 |
+  | 1.5.x | 4.0.5 |
+  | 1.6.x | 4.1.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.7/airgap.md
+++ b/versioned_docs/version-v1.7/airgap.md
@@ -83,7 +83,15 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
 
 
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the newest tag.
+1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
+
+| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+| --- | --- |
+| 1.0.x | 3.4.5 |
+| 1.5.x | 4.0.5 |
+| 1.6.x | 4.1.0 |
+| 1.7.x | 4.13.0 |
+
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.7/airgap.md
+++ b/versioned_docs/version-v1.7/airgap.md
@@ -79,13 +79,12 @@ docker load -i /tmp/rancher-agent-<version>.tar
 
 ## Harvester UI extension with Rancher Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. This extension's assets are served on the Rancher UI through the [ui-plugin-catalog container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags). Installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 
+1. Pull the [`ui-plugin-catalog` container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) that matches the required Harvester UI Extension version.
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
-
-  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | Harvester UI Extension Version | ui-plugin-catalog Image Version |
   | --- | --- |
   | 1.0.x | 3.4.5 |
   | 1.5.x | 4.0.5 |

--- a/versioned_docs/version-v1.7/airgap.md
+++ b/versioned_docs/version-v1.7/airgap.md
@@ -85,12 +85,12 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
 
 1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
 
-| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
-| --- | --- |
-| 1.0.x | 3.4.5 |
-| 1.5.x | 4.0.5 |
-| 1.6.x | 4.1.0 |
-| 1.7.x | 4.13.0 |
+  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | --- | --- |
+  | 1.0.x | 3.4.5 |
+  | 1.5.x | 4.0.5 |
+  | 1.6.x | 4.1.0 |
+  | 1.7.x | 4.13.0 |
 
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.

--- a/versioned_docs/version-v1.8/airgap.md
+++ b/versioned_docs/version-v1.8/airgap.md
@@ -85,13 +85,13 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
 
 1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
 
-| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
-| --- | --- |
-| 1.0.x | 3.4.5 |
-| 1.5.x | 4.0.5 |
-| 1.6.x | 4.1.0 |
-| 1.7.x | 4.13.0 |
-| 1.8.x | 4.23.0 |
+  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | --- | --- |
+  | 1.0.x | 3.4.5 |
+  | 1.5.x | 4.0.5 |
+  | 1.6.x | 4.1.0 |
+  | 1.7.x | 4.13.0 |
+  | 1.8.x | 4.23.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.8/airgap.md
+++ b/versioned_docs/version-v1.8/airgap.md
@@ -83,7 +83,15 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
 
 
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the newest tag.
+1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
+
+| Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+| --- | --- |
+| 1.0.x | 3.4.5 |
+| 1.5.x | 4.0.5 |
+| 1.6.x | 4.1.0 |
+| 1.7.x | 4.13.0 |
+| 1.8.x | 4.23.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.8/airgap.md
+++ b/versioned_docs/version-v1.8/airgap.md
@@ -79,13 +79,12 @@ docker load -i /tmp/rancher-agent-<version>.tar
 
 ## Harvester UI extension with Rancher Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. This extension's assets are served on the Rancher UI through the [ui-plugin-catalog container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags). Installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 
+1. Pull the [`ui-plugin-catalog` container image](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) that matches the required Harvester UI Extension version.
 
-1. Pull the image [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags) with the following support version.
-
-  | Harvester UI Extension Version | rancher/ui-plugin-catalog version |
+  | Harvester UI Extension Version | ui-plugin-catalog Image Version |
   | --- | --- |
   | 1.0.x | 3.4.5 |
   | 1.5.x | 4.0.5 |


### PR DESCRIPTION
#### Problem:
Add `rancher/ui-plugin-catalog` and `harvester ui ext` support matrix.

#### Solution:


#### Related Issue(s):
jira  10868


#### Test plan:
<img width="821" height="404" alt="Screenshot 2026-05-28 at 2 12 02 PM" src="https://github.com/user-attachments/assets/122d5573-2978-4501-b397-d3fb5c95a5c6" />



#### Additional documentation or context
