### PR TITLE
Clarify that RWX filesystem volumes require migratable=false with dataEngine=v2

### DIFF
--- a/versioned_docs/version-v1.4/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.4/rancher/csi-driver.md
@@ -344,6 +344,16 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
     nfsOptions: "vers=4.2,noresvport,softerr,timeo=600,retrans=5"
   ```
 
+  :::info important
+
+  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
+
+  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
+
+  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+
+  :::
+
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-01.png)
 
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-02.png)

--- a/versioned_docs/version-v1.4/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.4/rancher/csi-driver.md
@@ -346,7 +346,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+  To use standard RWX filesystem volumes, the `migratable` parameter must be empty or explicitly set to `false`.
 
   :::
 

--- a/versioned_docs/version-v1.4/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.4/rancher/csi-driver.md
@@ -346,10 +346,6 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
-
-  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
-
   To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
 
   :::

--- a/versioned_docs/version-v1.4/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.4/rancher/csi-driver.md
@@ -336,6 +336,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
   allowVolumeExpansion: true
   reclaimPolicy: Delete
   volumeBindingMode: Immediate
+  migratable: false # Must be empty or set to `false` when using standard RWX filesystem volumes
   parameters:
     numberOfReplicas: "3"
     staleReplicaTimeout: "2880"

--- a/versioned_docs/version-v1.5/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.5/rancher/csi-driver.md
@@ -344,6 +344,16 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
     nfsOptions: "vers=4.2,noresvport,softerr,timeo=600,retrans=5"
   ```
 
+  :::info important
+
+  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
+
+  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
+
+  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+
+  :::
+
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-01.png)
 
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-02.png)

--- a/versioned_docs/version-v1.5/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.5/rancher/csi-driver.md
@@ -346,7 +346,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+  To use standard RWX filesystem volumes, the `migratable` parameter must be empty or explicitly set to `false`.
 
   :::
 

--- a/versioned_docs/version-v1.5/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.5/rancher/csi-driver.md
@@ -346,10 +346,6 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
-
-  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
-
   To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
 
   :::

--- a/versioned_docs/version-v1.5/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.5/rancher/csi-driver.md
@@ -336,6 +336,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
   allowVolumeExpansion: true
   reclaimPolicy: Delete
   volumeBindingMode: Immediate
+  migratable: false # Must be empty or set to `false` when using standard RWX filesystem volumes
   parameters:
     numberOfReplicas: "3"
     staleReplicaTimeout: "2880"

--- a/versioned_docs/version-v1.6/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.6/rancher/csi-driver.md
@@ -320,6 +320,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
   allowVolumeExpansion: true
   reclaimPolicy: Delete
   volumeBindingMode: Immediate
+  migratable: false # Must be empty or set to `false` when using standard RWX filesystem volumes
   parameters:
     numberOfReplicas: "3"
     staleReplicaTimeout: "2880"

--- a/versioned_docs/version-v1.6/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.6/rancher/csi-driver.md
@@ -328,6 +328,16 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
     nfsOptions: "vers=4.2,noresvport,softerr,timeo=600,retrans=5"
   ```
 
+  :::info important
+
+  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
+
+  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
+
+  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+
+  :::
+
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-01.png)
 
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-02.png)

--- a/versioned_docs/version-v1.6/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.6/rancher/csi-driver.md
@@ -330,10 +330,6 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
-
-  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
-
   To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
 
   :::

--- a/versioned_docs/version-v1.6/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.6/rancher/csi-driver.md
@@ -330,7 +330,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+  To use standard RWX filesystem volumes, the `migratable` parameter must be empty or explicitly set to `false`.
 
   :::
 

--- a/versioned_docs/version-v1.7/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.7/rancher/csi-driver.md
@@ -323,6 +323,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
   allowVolumeExpansion: true
   reclaimPolicy: Delete
   volumeBindingMode: Immediate
+  migratable: false # Must be empty or set to `false` when using standard RWX filesystem volumes
   parameters:
     numberOfReplicas: "3"
     staleReplicaTimeout: "2880"

--- a/versioned_docs/version-v1.7/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.7/rancher/csi-driver.md
@@ -331,6 +331,16 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
     nfsOptions: "vers=4.2,noresvport,softerr,timeo=600,retrans=5"
   ```
 
+  :::info important
+
+  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
+
+  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
+
+  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+
+  :::
+
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-01.png)
 
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-02.png)

--- a/versioned_docs/version-v1.7/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.7/rancher/csi-driver.md
@@ -333,7 +333,7 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+  To use standard RWX filesystem volumes, the `migratable` parameter must be empty or explicitly set to `false`.
 
   :::
 

--- a/versioned_docs/version-v1.7/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.7/rancher/csi-driver.md
@@ -333,10 +333,6 @@ RWX volumes currently only work with a dedicated storage network. [GitHub issue 
 
   :::info important
 
-  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
-
-  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
-
   To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
 
   :::

--- a/versioned_docs/version-v1.8/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.8/rancher/csi-driver.md
@@ -322,10 +322,6 @@ Now you can create a new StorageClass that you intend to use in your guest Kuber
 
   :::info important
 
-  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
-
-  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
-
   To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
 
   :::

--- a/versioned_docs/version-v1.8/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.8/rancher/csi-driver.md
@@ -320,6 +320,16 @@ Now you can create a new StorageClass that you intend to use in your guest Kuber
     nfsOptions: "vers=4.2,noresvport,softerr,timeo=600,retrans=5"
   ```
 
+  :::info important
+
+  The `migratable=true` parameter instructs Longhorn to create a migratable RWX block volume intended for VM live migration workflows, rather than a standard RWX filesystem volume.
+
+  When `migratable=true` is set, the standard RWX filesystem sharing layer managed by Longhorn `share-manager` and NFS services is not used.
+
+  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+
+  :::
+
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-01.png)
 
   ![](/img/v1.4/rancher/create-rwx-sc-host-cluster-02.png)

--- a/versioned_docs/version-v1.8/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.8/rancher/csi-driver.md
@@ -322,7 +322,7 @@ Now you can create a new StorageClass that you intend to use in your guest Kuber
 
   :::info important
 
-  To use standard RWX filesystem volumes, `migratable` must remain unset or be explicitly set to `false`.
+  To use standard RWX filesystem volumes, the `migratable` parameter must be empty or explicitly set to `false`.
 
   :::
 

--- a/versioned_docs/version-v1.8/rancher/csi-driver.md
+++ b/versioned_docs/version-v1.8/rancher/csi-driver.md
@@ -312,6 +312,7 @@ Now you can create a new StorageClass that you intend to use in your guest Kuber
   allowVolumeExpansion: true
   reclaimPolicy: Delete
   volumeBindingMode: Immediate
+  migratable: false # Must be empty or set to `false` when using standard RWX filesystem volumes
   parameters:
     numberOfReplicas: "3"
     staleReplicaTimeout: "2880"


### PR DESCRIPTION
#### Problem:
When `migratable=true` is set, Longhorn creates a migratable RWX block volume intended for VM live migration workflows instead of a standard RWX filesystem volume.

As a result, the standard RWX filesystem sharing mechanism based on Longhorn `share-manager` and NFS is not used, and RWX filesystem volumes do not function as expected.

#### Solution:
Do not use `migratable=true` for standard RWX filesystem volumes. Ensure `migratable` is unset or explicitly set to `false` to enable the Longhorn `share-manager` and NFS-based RWX filesystem sharing layer.