### PR TITLE
Refine rwx network doc to avoid misunderstanding

### DIFF
--- a/docs/advanced/rwxnetwork.md
+++ b/docs/advanced/rwxnetwork.md
@@ -10,7 +10,7 @@ title: "RWX Network"
 
 _Available as of v1.8.0_
 
-Harvester uses Longhorn to provide ReadWriteMany (RWX) volumes for workloads that require shared filesystem access. By default, RWX traffic uses the Kubernetes cluster network. You can configure the [`rwx-network`](./settings.md#rwx-network) setting to either share it with the existing [storage network](./storagenetwork.md), or isolate RWX traffic on a dedicated network for better network bandwidth, performance, and security.
+Harvester uses Longhorn to provide ReadWriteMany (RWX) volumes for workloads that require shared filesystem access. By default, RWX traffic uses the default Kubernetes pod network. You can configure the [`rwx-network`](./settings.md#rwx-network) setting to either share it with the existing [storage network](./storagenetwork.md), or isolate RWX traffic on a dedicated network for better network bandwidth, performance, and security.
 
 :::note
 
@@ -81,9 +81,9 @@ You can [enable](#enable-the-rwx-network) and [disable](#disable-the-rwx-network
 }
 ```
 
-To configure a _shared_ RWX network, set `share-store-network` to `true`. Setting this field to `false` with a non-empty `network` field enables a _dedicated_ RWX network.
+To configure a _shared_ RWX network, set `share-storage-network` to `true`. Setting this field to `false` with a non-empty `network` field enables a _dedicated_ RWX network.
 
-The `network` field is only required when `share-storage-network` is `false`. If `share-storage-network` is `false` and no `network` is specified, RWX traffic uses the Kubernetes default cluster network. This is the default behavior when the `rwx-network` setting is not configured.
+The `network` field is only required when `share-storage-network` is `false`. If `share-storage-network` is `false` and no `network` is specified, RWX traffic uses the Kubernetes default pod network. This is the default behavior when the `rwx-network` setting is not configured.
 
 The following occur once the `rwx-network` setting is applied:
 

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -576,7 +576,7 @@ spec:
 
 **Definition**: Network configuration for isolating Longhorn RWX volume traffic.
 
-By default (`share-storage-network: false` with no `network` specified), RWX traffic uses the Kubernetes default cluster network. You can configure a dedicated network or share the existing storage network to improve bandwidth, performance, and security. For more information, see [RWX Network](./rwxnetwork.md).
+By default (`share-storage-network: false` with no `network` specified), RWX traffic uses the Kubernetes default pod network. You can configure a dedicated network or share the existing storage network to improve bandwidth, performance, and security. For more information, see [RWX Network](./rwxnetwork.md).
 
 :::info important
 
@@ -610,7 +610,7 @@ Changing this setting restarts all `longhorn-csi-plugin` pods, which temporarily
 
 **Supported options and values**:
 
-- `share-storage-network`: If `true`, RWX traffic reuses the existing [storage network](./storagenetwork.md) configuration. If `false`, RWX traffic uses either a dedicated network (when `network` is specified) or the Kubernetes default cluster network.
+- `share-storage-network`: If `true`, RWX traffic reuses the existing [storage network](./storagenetwork.md) configuration. If `false`, RWX traffic uses either a dedicated network (when `network` is specified) or the Kubernetes default pod network.
 - `network`: Required only when `share-storage-network` is `false` and a dedicated network is desired.
   - `vlan`: (Optional) VLAN ID for RWX network traffic.
   - `clusterNetwork`: Cluster network to use (must be pre-configured).

--- a/versioned_docs/version-v1.8/advanced/rwxnetwork.md
+++ b/versioned_docs/version-v1.8/advanced/rwxnetwork.md
@@ -10,7 +10,7 @@ title: "RWX Network"
 
 _Available as of v1.8.0_
 
-Harvester uses Longhorn to provide ReadWriteMany (RWX) volumes for workloads that require shared filesystem access. By default, RWX traffic uses the Kubernetes cluster network. You can configure the [`rwx-network`](./settings.md#rwx-network) setting to either share it with the existing [storage network](./storagenetwork.md), or isolate RWX traffic on a dedicated network for better network bandwidth, performance, and security.
+Harvester uses Longhorn to provide ReadWriteMany (RWX) volumes for workloads that require shared filesystem access. By default, RWX traffic uses the default Kubernetes pod network. You can configure the [`rwx-network`](./settings.md#rwx-network) setting to either share it with the existing [storage network](./storagenetwork.md), or isolate RWX traffic on a dedicated network for better network bandwidth, performance, and security.
 
 :::note
 
@@ -81,9 +81,9 @@ You can [enable](#enable-the-rwx-network) and [disable](#disable-the-rwx-network
 }
 ```
 
-To configure a _shared_ RWX network, set `share-store-network` to `true`. Setting this field to `false` with a non-empty `network` field enables a _dedicated_ RWX network.
+To configure a _shared_ RWX network, set `share-storage-network` to `true`. Setting this field to `false` with a non-empty `network` field enables a _dedicated_ RWX network.
 
-The `network` field is only required when `share-storage-network` is `false`. If `share-storage-network` is `false` and no `network` is specified, RWX traffic uses the Kubernetes default cluster network. This is the default behavior when the `rwx-network` setting is not configured.
+The `network` field is only required when `share-storage-network` is `false`. If `share-storage-network` is `false` and no `network` is specified, RWX traffic uses the Kubernetes default pod network. This is the default behavior when the `rwx-network` setting is not configured.
 
 The following occur once the `rwx-network` setting is applied:
 

--- a/versioned_docs/version-v1.8/advanced/settings.md
+++ b/versioned_docs/version-v1.8/advanced/settings.md
@@ -576,7 +576,7 @@ spec:
 
 **Definition**: Network configuration for isolating Longhorn RWX volume traffic.
 
-By default (`share-storage-network: false` with no `network` specified), RWX traffic uses the Kubernetes default cluster network. You can configure a dedicated network or share the existing storage network to improve bandwidth, performance, and security. For more information, see [RWX Network](./rwxnetwork.md).
+By default (`share-storage-network: false` with no `network` specified), RWX traffic uses the Kubernetes default pod network. You can configure a dedicated network or share the existing storage network to improve bandwidth, performance, and security. For more information, see [RWX Network](./rwxnetwork.md).
 
 :::info important
 
@@ -610,7 +610,7 @@ Changing this setting restarts all `longhorn-csi-plugin` pods, which temporarily
 
 **Supported options and values**:
 
-- `share-storage-network`: If `true`, RWX traffic reuses the existing [storage network](./storagenetwork.md) configuration. If `false`, RWX traffic uses either a dedicated network (when `network` is specified) or the Kubernetes default cluster network.
+- `share-storage-network`: If `true`, RWX traffic reuses the existing [storage network](./storagenetwork.md) configuration. If `false`, RWX traffic uses either a dedicated network (when `network` is specified) or the Kubernetes default pod network.
 - `network`: Required only when `share-storage-network` is `false` and a dedicated network is desired.
   - `vlan`: (Optional) VLAN ID for RWX network traffic.
   - `clusterNetwork`: Cluster network to use (must be pre-configured).


### PR DESCRIPTION
Change the term `default cluster network` to `default pod network`. Using "cluster network" may lead users to believe it refers to the [Harvester Cluster Network](https://docs.harvesterhci.io/v1.8/networking/index/), which is incorrect. This update avoids confusion by explicitly specifying that it uses the default pod network.