### PR TITLE
docs(upgrade): add known issue for SUC prepare plan retry failure

### DIFF
--- a/docs/upgrade/v1-7-x-to-v1-7-y.md
+++ b/docs/upgrade/v1-7-x-to-v1-7-y.md
@@ -40,3 +40,60 @@ Starting from v1.8.0, this process is handled automatically. The workaround desc
 :::
 
 Please see the instruction on this [page](./v1-5-x-to-v1-6-x.md#10-unnecessary-live-migrations-during-the-upgrade).
+
+### 3. Upgrade Stalls During Image Preloading Due to System-Upgrade-Controller Failing to Retry a Plan
+
+During Phase 2 (Preload Container Images) of the upgrade, Harvester creates a system-upgrade-controller (SUC) plan for each node to preload the container images required for the new release. If SUC fails to reschedule a plan job after a transient failure, the affected node's plan remains stuck in the `applying` state, stalling the upgrade indefinitely.
+
+This is an intermittent issue: once a plan job fails and is deleted (by the default job TTL of 900 seconds), SUC may stop rescheduling it for the affected node.
+
+:::note
+
+Although the prepare stage is the most common upgrade stage where this issue manifests, the same SUC behavior can also affect other stages that rely on SUC plans.
+
+:::
+
+#### Symptoms
+
+- The upgrade has shown no progress for an extended period (typically more than 30 minutes) while in the image preloading phase.
+- No job has been created for the affected node's prepare plan in the `cattle-system` namespace:
+
+  ```bash
+  kubectl get jobs -n cattle-system | grep prepare
+  ```
+
+- One or more SUC prepare plans are stuck in the `applying` state:
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io -n cattle-system | grep prepare
+  ```
+
+  Check the status of the stuck plan (replace `<plan-name>` with the actual plan name from the previous command):
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io <plan-name> -n cattle-system -o yaml | yq .status
+  ```
+
+  If the issue is present, the affected node appears under `applying`, and the `Complete` condition is `False`:
+
+  ```yaml
+  applying:
+  - <node-name>
+  conditions:
+  - lastUpdateTime: "..."
+    reason: SyncJob
+    status: "False"
+    type: Complete
+  ```
+
+#### Workaround
+
+Restart the `system-upgrade-controller` deployment to force SUC to reconcile all plans and reschedule any stuck jobs:
+
+```bash
+kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
+```
+
+After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
+
+Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)

--- a/docs/upgrade/v1-7-x-to-v1-8-x.md
+++ b/docs/upgrade/v1-7-x-to-v1-8-x.md
@@ -210,3 +210,62 @@ If your upgrade is stuck due to this issue, follow these steps to recover:
 1. Monitor the upgrade process and verify that it is completed successfully.
 
 Related issue: [#10532](https://github.com/harvester/harvester/issues/10532)
+
+---
+
+### 3. Upgrade Stalls During Image Preloading Due to System-Upgrade-Controller Failing to Retry a Plan
+
+During Phase 2 (Preload Container Images) of the upgrade, Harvester creates a system-upgrade-controller (SUC) plan for each node to preload the container images required for the new release. If SUC fails to reschedule a plan job after a transient failure, the affected node's plan remains stuck in the `applying` state, stalling the upgrade indefinitely.
+
+This is an intermittent issue: once a plan job fails and is deleted (by the default job TTL of 900 seconds), SUC may stop rescheduling it for the affected node.
+
+:::note
+
+Although the prepare stage is the most common upgrade stage where this issue manifests, the same SUC behavior can also affect other stages that rely on SUC plans.
+
+:::
+
+#### Symptoms
+
+- The upgrade has shown no progress for an extended period (typically more than 30 minutes) while in the image preloading phase.
+- No job has been created for the affected node's prepare plan in the `cattle-system` namespace:
+
+  ```bash
+  kubectl get jobs -n cattle-system | grep prepare
+  ```
+
+- One or more SUC prepare plans are stuck in the `applying` state:
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io -n cattle-system | grep prepare
+  ```
+
+  Check the status of the stuck plan (replace `<plan-name>` with the actual plan name from the previous command):
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io <plan-name> -n cattle-system -o yaml | yq .status
+  ```
+
+  If the issue is present, the affected node appears under `applying`, and the `Complete` condition is `False`:
+
+  ```yaml
+  applying:
+  - <node-name>
+  conditions:
+  - lastUpdateTime: "..."
+    reason: SyncJob
+    status: "False"
+    type: Complete
+  ```
+
+#### Workaround
+
+Restart the `system-upgrade-controller` deployment to force SUC to reconcile all plans and reschedule any stuck jobs:
+
+```bash
+kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
+```
+
+After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
+
+Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)

--- a/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
@@ -40,3 +40,60 @@ Starting from v1.8.0, this process is handled automatically. The workaround desc
 :::
 
 Please see the instruction on this [page](./v1-5-x-to-v1-6-x.md#10-unnecessary-live-migrations-during-the-upgrade).
+
+### 3. Upgrade Stalls During Image Preloading Due to System-Upgrade-Controller Failing to Retry a Plan
+
+During Phase 2 (Preload Container Images) of the upgrade, Harvester creates a system-upgrade-controller (SUC) plan for each node to preload the container images required for the new release. If SUC fails to reschedule a plan job after a transient failure, the affected node's plan remains stuck in the `applying` state, stalling the upgrade indefinitely.
+
+This is an intermittent issue: once a plan job fails and is deleted (by the default job TTL of 900 seconds), SUC may stop rescheduling it for the affected node.
+
+:::note
+
+Although the prepare stage is the most common upgrade stage where this issue manifests, the same SUC behavior can also affect other stages that rely on SUC plans.
+
+:::
+
+#### Symptoms
+
+- The upgrade has shown no progress for an extended period (typically more than 30 minutes) while in the image preloading phase.
+- No job has been created for the affected node's prepare plan in the `cattle-system` namespace:
+
+  ```bash
+  kubectl get jobs -n cattle-system | grep prepare
+  ```
+
+- One or more SUC prepare plans are stuck in the `applying` state:
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io -n cattle-system | grep prepare
+  ```
+
+  Check the status of the stuck plan (replace `<plan-name>` with the actual plan name from the previous command):
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io <plan-name> -n cattle-system -o yaml | yq .status
+  ```
+
+  If the issue is present, the affected node appears under `applying`, and the `Complete` condition is `False`:
+
+  ```yaml
+  applying:
+  - <node-name>
+  conditions:
+  - lastUpdateTime: "..."
+    reason: SyncJob
+    status: "False"
+    type: Complete
+  ```
+
+#### Workaround
+
+Restart the `system-upgrade-controller` deployment to force SUC to reconcile all plans and reschedule any stuck jobs:
+
+```bash
+kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
+```
+
+After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
+
+Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)

--- a/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
@@ -40,3 +40,60 @@ Starting from v1.8.0, this process is handled automatically. The workaround desc
 :::
 
 Please see the instruction on this [page](./v1-5-x-to-v1-6-x.md#10-unnecessary-live-migrations-during-the-upgrade).
+
+### 3. Upgrade Stalls During Image Preloading Due to System-Upgrade-Controller Failing to Retry a Plan
+
+During Phase 2 (Preload Container Images) of the upgrade, Harvester creates a system-upgrade-controller (SUC) plan for each node to preload the container images required for the new release. If SUC fails to reschedule a plan job after a transient failure, the affected node's plan remains stuck in the `applying` state, stalling the upgrade indefinitely.
+
+This is an intermittent issue: once a plan job fails and is deleted (by the default job TTL of 900 seconds), SUC may stop rescheduling it for the affected node.
+
+:::note
+
+Although the prepare stage is the most common upgrade stage where this issue manifests, the same SUC behavior can also affect other stages that rely on SUC plans.
+
+:::
+
+#### Symptoms
+
+- The upgrade has shown no progress for an extended period (typically more than 30 minutes) while in the image preloading phase.
+- No job has been created for the affected node's prepare plan in the `cattle-system` namespace:
+
+  ```bash
+  kubectl get jobs -n cattle-system | grep prepare
+  ```
+
+- One or more SUC prepare plans are stuck in the `applying` state:
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io -n cattle-system | grep prepare
+  ```
+
+  Check the status of the stuck plan (replace `<plan-name>` with the actual plan name from the previous command):
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io <plan-name> -n cattle-system -o yaml | yq .status
+  ```
+
+  If the issue is present, the affected node appears under `applying`, and the `Complete` condition is `False`:
+
+  ```yaml
+  applying:
+  - <node-name>
+  conditions:
+  - lastUpdateTime: "..."
+    reason: SyncJob
+    status: "False"
+    type: Complete
+  ```
+
+#### Workaround
+
+Restart the `system-upgrade-controller` deployment to force SUC to reconcile all plans and reschedule any stuck jobs:
+
+```bash
+kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
+```
+
+After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
+
+Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)

--- a/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-8-x.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-8-x.md
@@ -210,3 +210,62 @@ If your upgrade is stuck due to this issue, follow these steps to recover:
 1. Monitor the upgrade process and verify that it is completed successfully.
 
 Related issue: [#10532](https://github.com/harvester/harvester/issues/10532)
+
+---
+
+### 3. Upgrade Stalls During Image Preloading Due to System-Upgrade-Controller Failing to Retry a Plan
+
+During Phase 2 (Preload Container Images) of the upgrade, Harvester creates a system-upgrade-controller (SUC) plan for each node to preload the container images required for the new release. If SUC fails to reschedule a plan job after a transient failure, the affected node's plan remains stuck in the `applying` state, stalling the upgrade indefinitely.
+
+This is an intermittent issue: once a plan job fails and is deleted (by the default job TTL of 900 seconds), SUC may stop rescheduling it for the affected node.
+
+:::note
+
+Although the prepare stage is the most common upgrade stage where this issue manifests, the same SUC behavior can also affect other stages that rely on SUC plans.
+
+:::
+
+#### Symptoms
+
+- The upgrade has shown no progress for an extended period (typically more than 30 minutes) while in the image preloading phase.
+- No job has been created for the affected node's prepare plan in the `cattle-system` namespace:
+
+  ```bash
+  kubectl get jobs -n cattle-system | grep prepare
+  ```
+
+- One or more SUC prepare plans are stuck in the `applying` state:
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io -n cattle-system | grep prepare
+  ```
+
+  Check the status of the stuck plan (replace `<plan-name>` with the actual plan name from the previous command):
+
+  ```bash
+  kubectl get plans.upgrade.cattle.io <plan-name> -n cattle-system -o yaml | yq .status
+  ```
+
+  If the issue is present, the affected node appears under `applying`, and the `Complete` condition is `False`:
+
+  ```yaml
+  applying:
+  - <node-name>
+  conditions:
+  - lastUpdateTime: "..."
+    reason: SyncJob
+    status: "False"
+    type: Complete
+  ```
+
+#### Workaround
+
+Restart the `system-upgrade-controller` deployment to force SUC to reconcile all plans and reschedule any stuck jobs:
+
+```bash
+kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
+```
+
+After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
+
+Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

SUC (system-upgrade-controller) might stop working on newly created Plans out of a blue. The root cause is still unknown, as it cannot be reproduced steadily. Harvester Upgrade relies on SUC to perform node-level tasks, one of the most well-known ones is the `prepare` Plan, which preloads container images to each node.

If such a Plan does not get reconciled by SUC, the entire Harvester Upgrade procedure stalls.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

By manually restarting the SUC deployment, the upgrade should resume immediately.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

harvester/harvester#9880

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
