### PR TITLE
docs: update 1.8.x ui-plugin-charts version

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -91,7 +91,7 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
   | 1.5.x | 4.0.5 |
   | 1.6.x | 4.1.0 |
   | 1.7.x | 4.13.0 |
-  | 1.8.x | 4.23.0 |
+  | 1.8.x | 4.30.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 

--- a/versioned_docs/version-v1.8/airgap.md
+++ b/versioned_docs/version-v1.8/airgap.md
@@ -90,7 +90,7 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
   | 1.5.x | 4.0.5 |
   | 1.6.x | 4.1.0 |
   | 1.7.x | 4.13.0 |
-  | 1.8.x | 4.23.0 |
+  | 1.8.x | 4.30.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.
 


### PR DESCRIPTION


#### Problem:
harvester v1.8.1 ui extension is released in ui-plugin-charts v4.30.0. Updated related matrix.

See [4.30.0](https://github.com/rancher/ui-plugin-charts/releases/tag/4.30.0)


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
