### PR TITLE
Add note for host network config behaviour

### DIFF
--- a/docs/networking/hostnetworkconfig.md
+++ b/docs/networking/hostnetworkconfig.md
@@ -319,7 +319,7 @@ Delete the config using the following command:
 
 :::caution
 
-If a node has multiple host interfaces, do not connect them to the same VLAN or subnet.
+If a node has multiple host interfaces, do not attach them to the same VLAN or subnet. This restriction applies to interfaces configured manually on the host and those configured through `HostNetwork` configurations.
 
 VLAN interfaces under a cluster network are derived from the same bridge and therefore use the same MAC address. This can cause the following issue:
 - **DHCP response misrouting**: When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This occurs because the DHCP `OFFER` packets can be delivered to `mgmt-br` instead of `mgmt-br.1`.

--- a/docs/networking/hostnetworkconfig.md
+++ b/docs/networking/hostnetworkconfig.md
@@ -317,6 +317,22 @@ Delete the config using the following command:
 
 `kubectl delete hostnetworkconfig cn1-vlan2012-dhcp`.
 
+:::caution
+
+If a node has multiple host interfaces, do not connect them to the same VLAN or subnet.
+
+VLAN interfaces under a cluster network are derived from the same bridge and therefore use the same MAC address. This can cause the following issue:
+- **DHCP response misrouting**: When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This occurs because the DHCP `OFFER` packets can be delivered to `mgmt-br` instead of `mgmt-br.1`.
+
+Configuring multiple interfaces in the same VLAN and subnet can result in ambiguous routing behavior.
+- **Ambiguous kernel routing**: Linux typically installs a single connected route for a subnet. When multiple interfaces are attached to the same VLAN and subnet, the kernel may associate the subnet route with only one of those interfaces, causing traffic to be forwarded through an unintended path.
+
+For example, if a host network on cluster network `cn1` uses VLAN `2017` and receives subnet `192.168.0.0/24`, while another host network on cluster network `cn2` is also configured with VLAN `2017` and receives the same subnet 192.168.0.0/24, the kernel will install the connected route for 192.168.0.0/24 via only one interface (the latest configured). As a result, traffic destined for that subnet may be routed through the wrong interface, leading to unexpected issues.
+
+This restriction applies to interfaces configured both manually on the host and through `HostNetwork` configurations.
+
+:::
+
 ### Limitations
 
 - Only tagged VLANs with a VLAN ID of 1–4094 are supported.

--- a/docs/networking/hostnetworkconfig.md
+++ b/docs/networking/hostnetworkconfig.md
@@ -327,12 +327,11 @@ VLAN interfaces used in a cluster network are derived from the same underlying b
 
 When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be incorrectly associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an active IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This failure occurs because the DHCP `OFFER` packets are delivered to `mgmt-br` instead of `mgmt-br.1`.
 
-Configuring multiple interfaces in the same VLAN and subnet can result in ambiguous routing behavior.
-- **Ambiguous kernel routing**: Linux typically installs a single connected route for a subnet. When multiple interfaces are attached to the same VLAN and subnet, the kernel may associate the subnet route with only one of those interfaces, causing traffic to be forwarded through an unintended path.
+**Ambiguous Routing Behavior**
 
-For example, if a host network on cluster network `cn1` uses VLAN `2017` and receives subnet `192.168.0.0/24`, while another host network on cluster network `cn2` is also configured with VLAN `2017` and receives the same subnet 192.168.0.0/24, the kernel will install the connected route for 192.168.0.0/24 via only one interface (the latest configured). As a result, traffic destined for that subnet may be routed through the wrong interface, leading to unexpected issues.
+Additionally, configuring multiple interfaces in the same VLAN and subnet results in ambiguous routing. The Linux kernel typically installs a single connected route for a given subnet. If multiple interfaces are attached to the same VLAN and subnet, the kernel may associate the subnet route with only one of those interfaces, causing traffic to be forwarded through an unintended physical path.
 
-This restriction applies to interfaces configured both manually on the host and through `HostNetwork` configurations.
+Example: Host networks on cluster networks `cn1` and `cn2` are both attached to VLAN `2017` and assigned the same subnet (`192.168.0.0/24`). Because both interfaces are in the same subnet, the Linux kernel will install the connected route for `192.168.0.0/24` via only one of those interfaces (typically the one configured last). Traffic destined for that subnet may be routed through the wrong interface, leading to unexpected issues.
 
 :::
 

--- a/docs/networking/hostnetworkconfig.md
+++ b/docs/networking/hostnetworkconfig.md
@@ -321,8 +321,11 @@ Delete the config using the following command:
 
 If a node has multiple host interfaces, do not attach them to the same VLAN or subnet. This restriction applies to interfaces configured manually on the host and those configured through `HostNetwork` configurations.
 
-VLAN interfaces under a cluster network are derived from the same bridge and therefore use the same MAC address. This can cause the following issue:
-- **DHCP response misrouting**: When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This occurs because the DHCP `OFFER` packets can be delivered to `mgmt-br` instead of `mgmt-br.1`.
+**DHCP Response Misrouting**
+
+VLAN interfaces used in a cluster network are derived from the same underlying bridge and consequently share the same MAC address. This shared MAC address can cause DHCP response misrouting.
+
+When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be incorrectly associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an active IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This failure occurs because the DHCP `OFFER` packets are delivered to `mgmt-br` instead of `mgmt-br.1`.
 
 Configuring multiple interfaces in the same VLAN and subnet can result in ambiguous routing behavior.
 - **Ambiguous kernel routing**: Linux typically installs a single connected route for a subnet. When multiple interfaces are attached to the same VLAN and subnet, the kernel may associate the subnet route with only one of those interfaces, causing traffic to be forwarded through an unintended path.

--- a/versioned_docs/version-v1.8/networking/hostnetworkconfig.md
+++ b/versioned_docs/version-v1.8/networking/hostnetworkconfig.md
@@ -317,6 +317,22 @@ Delete the config using the following command:
 
 `kubectl delete hostnetworkconfig cn1-vlan2012-dhcp`.
 
+:::caution
+
+If a node has multiple host interfaces, do not connect them to the same VLAN or subnet.
+
+VLAN interfaces under a cluster network are derived from the same bridge and therefore use the same MAC address. This can cause the following issue:
+- **DHCP response misrouting**: When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This occurs because the DHCP `OFFER` packets can be delivered to `mgmt-br` instead of `mgmt-br.1`.
+
+Configuring multiple interfaces in the same VLAN and subnet can result in ambiguous routing behavior.
+- **Ambiguous kernel routing**: Linux typically installs a single connected route for a subnet. When multiple interfaces are attached to the same VLAN and subnet, the kernel may associate the subnet route with only one of those interfaces, causing traffic to be forwarded through an unintended path.
+
+For example, if a host network on cluster network `cn1` uses VLAN `2017` and receives subnet `192.168.0.0/24`, while another host network on cluster network `cn2` is also configured with VLAN `2017` and receives the same subnet 192.168.0.0/24, the kernel will install the connected route for 192.168.0.0/24 via only one interface (the latest configured). As a result, traffic destined for that subnet may be routed through the wrong interface, leading to unexpected issues.
+
+This restriction applies to interfaces configured both manually on the host and through `HostNetwork` configurations.
+
+:::
+
 ### Limitations
 
 - Only tagged VLANs with a VLAN ID of 1–4094 are supported.

--- a/versioned_docs/version-v1.8/networking/hostnetworkconfig.md
+++ b/versioned_docs/version-v1.8/networking/hostnetworkconfig.md
@@ -319,17 +319,19 @@ Delete the config using the following command:
 
 :::caution
 
-If a node has multiple host interfaces, do not connect them to the same VLAN or subnet.
+If a node has multiple host interfaces, do not attach them to the same VLAN or subnet. This restriction applies to interfaces configured manually on the host and those configured through `HostNetwork` configurations.
 
-VLAN interfaces under a cluster network are derived from the same bridge and therefore use the same MAC address. This can cause the following issue:
-- **DHCP response misrouting**: When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This occurs because the DHCP `OFFER` packets can be delivered to `mgmt-br` instead of `mgmt-br.1`.
+**DHCP Response Misrouting**
 
-Configuring multiple interfaces in the same VLAN and subnet can result in ambiguous routing behavior.
-- **Ambiguous kernel routing**: Linux typically installs a single connected route for a subnet. When multiple interfaces are attached to the same VLAN and subnet, the kernel may associate the subnet route with only one of those interfaces, causing traffic to be forwarded through an unintended path.
+VLAN interfaces used in a cluster network are derived from the same underlying bridge and consequently share the same MAC address. This shared MAC address can cause DHCP response misrouting.
 
-For example, if a host network on cluster network `cn1` uses VLAN `2017` and receives subnet `192.168.0.0/24`, while another host network on cluster network `cn2` is also configured with VLAN `2017` and receives the same subnet 192.168.0.0/24, the kernel will install the connected route for 192.168.0.0/24 via only one interface (the latest configured). As a result, traffic destined for that subnet may be routed through the wrong interface, leading to unexpected issues.
+When multiple host interfaces from the same cluster network reside on the same VLAN, DHCP responses may be incorrectly associated with an existing interface instead of a newly created one. For example, if `mgmt-br` is connected to the native VLAN and has an active IP address, a DHCP client running on `mgmt-br.1` may fail to acquire a lease. This failure occurs because the DHCP `OFFER` packets are delivered to `mgmt-br` instead of `mgmt-br.1`.
 
-This restriction applies to interfaces configured both manually on the host and through `HostNetwork` configurations.
+**Ambiguous Routing Behavior**
+
+Additionally, configuring multiple interfaces in the same VLAN and subnet results in ambiguous routing. The Linux kernel typically installs a single connected route for a given subnet. If multiple interfaces are attached to the same VLAN and subnet, the kernel may associate the subnet route with only one of those interfaces, causing traffic to be forwarded through an unintended physical path.
+
+Example: Host networks on cluster networks `cn1` and `cn2` are both attached to VLAN `2017` and assigned the same subnet (`192.168.0.0/24`). Because both interfaces are in the same subnet, the Linux kernel will install the connected route for `192.168.0.0/24` via only one of those interfaces (typically the one configured last). Traffic destined for that subnet may be routed through the wrong interface, leading to unexpected issues.
 
 :::
 


### PR DESCRIPTION


#### Problem:
The issue occurs when the host is attached multiple times to the same Layer 2 network. In the VLAN 1 case, mgmt-br already represents the native/untagged VLAN 1 network, and creating mgmt-br.1 adds a second host interface to the same broadcast domain. DHCP DISCOVER packets are transmitted successfully, but the DHCP OFFER is associated with the existing interface (mgmt-br) rather than the VLAN subinterface (mgmt-br.1), causing the DHCP client to never complete lease acquisition.

More generally, a node should not have multiple host interfaces connected to the same VLAN/subnet

#### Solution:
document the behaviour so users know what to configure

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10802

#### Test plan:


#### Additional documentation or context
