### PR TITLE
Update ui-plugin-charts support version for harvester v1.7.2 

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -90,7 +90,7 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
   | 1.0.x | 3.4.5 |
   | 1.5.x | 4.0.5 |
   | 1.6.x | 4.1.0 |
-  | 1.7.x | 4.13.0 |
+  | 1.7.x | 4.32.0 |
   | 1.8.x | 4.30.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.

--- a/versioned_docs/version-v1.7/airgap.md
+++ b/versioned_docs/version-v1.7/airgap.md
@@ -89,7 +89,7 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
   | 1.0.x | 3.4.5 |
   | 1.5.x | 4.0.5 |
   | 1.6.x | 4.1.0 |
-  | 1.7.x | 4.13.0 |
+  | 1.7.x | 4.32.0 |
 
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.

--- a/versioned_docs/version-v1.8/airgap.md
+++ b/versioned_docs/version-v1.8/airgap.md
@@ -89,7 +89,7 @@ The Harvester UI Extension is required to access the Harvester UI in Rancher v2.
   | 1.0.x | 3.4.5 |
   | 1.5.x | 4.0.5 |
   | 1.6.x | 4.1.0 |
-  | 1.7.x | 4.13.0 |
+  | 1.7.x | 4.32.0 |
   | 1.8.x | 4.30.0 |
 
 1. On the Rancher UI, go to **Extensions**, and then select **⋮ > Manage Extension Catalogs**.


### PR DESCRIPTION


#### Problem:
Harvester ui ext 1.7.2 already put in ui-plugin-charts [4.32.0](https://github.com/rancher/ui-plugin-charts/releases). Update related support matrix.


<img width="1444" height="805" alt="Screenshot 2026-07-15 at 10 31 46 AM" src="https://github.com/user-attachments/assets/44ae5f67-328f-4a32-9de2-d7c4e971c5e8" />

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
