### PR TITLE
docs: clarify managed dhcp use with kube-ovn overlay netwokrs

### DIFF
--- a/docs/advanced/addons/managed-dhcp.md
+++ b/docs/advanced/addons/managed-dhcp.md
@@ -14,7 +14,7 @@ title: "Managed DHCP (Experimental)"
 
 :::
 
-You can configure IP pool information and serve IP addresses to VMs running on Harvester clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
+You can configure IP pool information and serve IP addresses to VMs on Harvester VM Networks that do not have a standalone DHCP server. The Managed DHCP feature leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
 
 :::note
 
@@ -29,6 +29,12 @@ Harvester uses the planned infrastructure network so you must ensure that networ
 - The Managed DHCP agents can still serve DHCP requests for existing entities even if the cluster's control plane stops working, ensuring that your virtual machine workload's network remains available.
 
 ## Limitations
+
+:::caution
+
+The Managed DHCP add-on is not compatible with overlay networks backed by Kube-OVN. For VMs connected to these networks, use the Kube-OVN per-subnet DHCP service and the `managedTap` binding plug-in. For instructions, see [Create a VPC](../../networking/kubeovn-vpc.md#create-a-vpc).
+
+:::
 
 - The Managed DHCP feature only works with the network interfaces specified in the VirtualMachine CRs. Network interfaces created in the virtual machine are not supported.
 - IP addresses are not allocated or deallocated when you add or remove network interfaces after the virtual machine is created. The actual MAC addresses are recorded in the VirtualMachineNetworkConfig CRs.

--- a/docs/networking/harvester-network.md
+++ b/docs/networking/harvester-network.md
@@ -229,3 +229,5 @@ The overlay network implementation in Harvester v1.6 has the following limitatio
     - Enable the DHCP service for the overlay network. You must set a valid default gateway.
 
     - Manually update the underlying virtual machine spec to adapt the `managedTap` binding interface for the downstream cluster during the cluster provision period.
+
+- The [Managed DHCP add-on](../advanced/addons/managed-dhcp.md) is not compatible with Kube-OVN overlay networks. Use Kube-OVN's native per-subnet DHCP service for virtual machines connected to these networks.

--- a/versioned_docs/version-v1.6/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.6/advanced/addons/managed-dhcp.md
@@ -14,7 +14,7 @@ title: "Managed DHCP (Experimental)"
 
 :::
 
-You can configure IP pool information and serve IP addresses to VMs running on Harvester clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
+You can configure IP pool information and serve IP addresses to VMs on Harvester VM Networks that do not have a standalone DHCP server. The Managed DHCP feature leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
 
 :::note
 
@@ -29,6 +29,12 @@ Harvester uses the planned infrastructure network so you must ensure that networ
 - The Managed DHCP agents can still serve DHCP requests for existing entities even if the cluster's control plane stops working, ensuring that your virtual machine workload's network remains available.
 
 ## Limitations
+
+:::caution
+
+The Managed DHCP add-on is not compatible with overlay networks backed by Kube-OVN. For VMs connected to these networks, use the Kube-OVN per-subnet DHCP service and the `managedTap` binding plug-in. For instructions, see [Create a VPC](../../networking/kubeovn-vpc.md#create-a-vpc).
+
+:::
 
 - The Managed DHCP feature only works with the network interfaces specified in the VirtualMachine CRs. Network interfaces created in the virtual machine are not supported.
 - IP addresses are not allocated or deallocated when you add or remove network interfaces after the virtual machine is created. The actual MAC addresses are recorded in the VirtualMachineNetworkConfig CRs.

--- a/versioned_docs/version-v1.6/networking/harvester-network.md
+++ b/versioned_docs/version-v1.6/networking/harvester-network.md
@@ -187,3 +187,5 @@ The overlay network implementation in Harvester v1.6 has the following limitatio
     - Enable the DHCP service for the overlay network. You must set a valid default gateway.
 
     - Manually update the underlying virtual machine spec to adapt the `managedTap` binding interface for the downstream cluster during the cluster provision period.
+
+- The [Managed DHCP add-on](../advanced/addons/managed-dhcp.md) is not compatible with Kube-OVN overlay networks. Use Kube-OVN's native per-subnet DHCP service for virtual machines connected to these networks.

--- a/versioned_docs/version-v1.7/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.7/advanced/addons/managed-dhcp.md
@@ -14,7 +14,7 @@ title: "Managed DHCP (Experimental)"
 
 :::
 
-You can configure IP pool information and serve IP addresses to VMs running on Harvester clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
+You can configure IP pool information and serve IP addresses to VMs on Harvester VM Networks that do not have a standalone DHCP server. The Managed DHCP feature leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
 
 :::note
 
@@ -29,6 +29,12 @@ Harvester uses the planned infrastructure network so you must ensure that networ
 - The Managed DHCP agents can still serve DHCP requests for existing entities even if the cluster's control plane stops working, ensuring that your virtual machine workload's network remains available.
 
 ## Limitations
+
+:::caution
+
+The Managed DHCP add-on is not compatible with overlay networks backed by Kube-OVN. For VMs connected to these networks, use the Kube-OVN per-subnet DHCP service and the `managedTap` binding plug-in. For instructions, see [Create a VPC](../../networking/kubeovn-vpc.md#create-a-vpc).
+
+:::
 
 - The Managed DHCP feature only works with the network interfaces specified in the VirtualMachine CRs. Network interfaces created in the virtual machine are not supported.
 - IP addresses are not allocated or deallocated when you add or remove network interfaces after the virtual machine is created. The actual MAC addresses are recorded in the VirtualMachineNetworkConfig CRs.

--- a/versioned_docs/version-v1.7/networking/harvester-network.md
+++ b/versioned_docs/version-v1.7/networking/harvester-network.md
@@ -229,3 +229,5 @@ The overlay network implementation in Harvester v1.6 has the following limitatio
     - Enable the DHCP service for the overlay network. You must set a valid default gateway.
 
     - Manually update the underlying virtual machine spec to adapt the `managedTap` binding interface for the downstream cluster during the cluster provision period.
+
+- The [Managed DHCP add-on](../advanced/addons/managed-dhcp.md) is not compatible with Kube-OVN overlay networks. Use Kube-OVN's native per-subnet DHCP service for virtual machines connected to these networks.

--- a/versioned_docs/version-v1.8/advanced/addons/managed-dhcp.md
+++ b/versioned_docs/version-v1.8/advanced/addons/managed-dhcp.md
@@ -14,7 +14,7 @@ title: "Managed DHCP (Experimental)"
 
 :::
 
-You can configure IP pool information and serve IP addresses to VMs running on Harvester clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
+You can configure IP pool information and serve IP addresses to VMs on Harvester VM Networks that do not have a standalone DHCP server. The Managed DHCP feature leverages the [harvester-vm-dhcp-controller](https://github.com/harvester/vm-dhcp-controller) add-on to simplify guest cluster deployment.
 
 :::note
 
@@ -29,6 +29,12 @@ Harvester uses the planned infrastructure network so you must ensure that networ
 - The Managed DHCP agents can still serve DHCP requests for existing entities even if the cluster's control plane stops working, ensuring that your virtual machine workload's network remains available.
 
 ## Limitations
+
+:::caution
+
+The Managed DHCP add-on is not compatible with overlay networks backed by Kube-OVN. For VMs connected to these networks, use the Kube-OVN per-subnet DHCP service and the `managedTap` binding plug-in. For instructions, see [Create a VPC](../../networking/kubeovn-vpc.md#create-a-vpc).
+
+:::
 
 - The Managed DHCP feature only works with the network interfaces specified in the VirtualMachine CRs. Network interfaces created in the virtual machine are not supported.
 - IP addresses are not allocated or deallocated when you add or remove network interfaces after the virtual machine is created. The actual MAC addresses are recorded in the VirtualMachineNetworkConfig CRs.

--- a/versioned_docs/version-v1.8/networking/harvester-network.md
+++ b/versioned_docs/version-v1.8/networking/harvester-network.md
@@ -229,3 +229,5 @@ The overlay network implementation in Harvester v1.6 has the following limitatio
     - Enable the DHCP service for the overlay network. You must set a valid default gateway.
 
     - Manually update the underlying virtual machine spec to adapt the `managedTap` binding interface for the downstream cluster during the cluster provision period.
+
+- The [Managed DHCP add-on](../advanced/addons/managed-dhcp.md) is not compatible with Kube-OVN overlay networks. Use Kube-OVN's native per-subnet DHCP service for virtual machines connected to these networks.


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Users may get confused and think the Managed DHCP add-on can be used along with Kube-OVN-backed overlay VM networks.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Clearly stated that the Managed DHCP add-on is designed for non-Kube-OVN-backed overlay VM networks.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

harvester/harvester#8919

#### Test plan:
<!-- Describe the test plan by steps. -->

N/A

#### Additional documentation or context
