### PR TITLE
Document LVM striped volume type deprecation

### DIFF
--- a/docs/advanced/addons/lvm-local-storage.md
+++ b/docs/advanced/addons/lvm-local-storage.md
@@ -94,7 +94,7 @@ You can only use one type of local volume in each volume group. If necessary, cr
 
       ![](/img/v1.4/csi-driver-lvm/create-lvm-sc-03.png)
 
-    - **Volume Group Type**: Select the type of local volume that matches your requirements. Harvester currently supports **striped** and **dm-thin**.
+    - **Volume Group Type**: Select **dm-thin**. This is the supported volume type for the LVM CSI driver.
 
       ![](/img/v1.4/csi-driver-lvm/create-lvm-sc-04.png)
 
@@ -105,6 +105,25 @@ You can only use one type of local volume in each volume group. If necessary, cr
     ![](/img/v1.4/csi-driver-lvm/create-lvm-sc-05.png)
 
 For more information, see [StorageClass](../storageclass.md).
+
+## dm-thin and Striped Volume Types
+
+**dm-thin** is the supported volume type for the LVM CSI driver. Use **dm-thin** for all new volume groups and StorageClasses.
+
+The **striped** volume type was available before the LVM CSI driver reached general availability, but is deprecated and is not included in the GA support scope. Striped logical volumes allocate their full capacity when they are created. Snapshots, clones, and restores also require full data copies, which consume additional capacity and I/O and can cause timeouts. Retrying an interrupted copy can also make it difficult to determine whether the operation completed successfully.
+
+:::caution
+
+Do not create new striped volume groups or StorageClasses. Existing striped volumes are not supported for GA and cannot be converted to dm-thin in place.
+
+Before upgrading to a version that removes striped-volume support, migrate data from existing striped volumes:
+
+1. Create a dm-thin volume group and StorageClass. A volume group can contain only one local volume type, so use a different volume group from the existing striped configuration.
+1. Stop or quiesce the workload to prevent changes while its data is copied.
+1. Create replacement volumes with the dm-thin StorageClass, and migrate the data using the workload's supported backup, restore, or copy procedure.
+1. Update the workload to use the replacement volumes and verify the data before removing the striped volumes and StorageClass.
+
+:::
 
 ## Creating a Volume with LVM
 

--- a/docs/advanced/csidriver.md
+++ b/docs/advanced/csidriver.md
@@ -150,7 +150,7 @@ The following is an example of an LVM storage profile:
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile
 metadata:
-  name: lvm-node-1-striped
+  name: lvm-node-1-dm-thin
 spec:
   claimPropertySets:
   - accessModes:
@@ -165,10 +165,12 @@ status:
   dataImportCronSourceFormat: pvc
   provisioner: lvm.driver.harvesterhci.io
   snapshotClass: lvm-snapshot
-  storageClass: lvm-node-1-striped
+  storageClass: lvm-node-1-dm-thin
 ```
 
 For more information, see [Storage Profiles](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/storageprofile.md) in the CDI documentation.
+
+For LVM storage, use a dm-thin StorageClass. The striped volume type is deprecated and is outside the LVM CSI GA support scope. For more information, see [dm-thin and Striped Volume Types](./addons/lvm-local-storage.md#dm-thin-and-striped-volume-types).
 
 You can define the above fields to override the default configuration showing on the status.
 


### PR DESCRIPTION
## Summary

- identify dm-thin as the supported LVM CSI volume type for GA
- deprecate striped volumes and document their snapshot, clone, restore, and capacity limitations
- add migration guidance for existing pre-GA striped volumes
- update the LVM StorageProfile example to use dm-thin

## Related Issue
harvester/harvester#11334