### PR TITLE
Document CDI importer OOM crash-loop known issue across upgrade paths

### DIFF
--- a/docs/upgrade/automatic.md
+++ b/docs/upgrade/automatic.md
@@ -34,6 +34,8 @@ The following table outlines the supported upgrade paths.
 
 | Installed Version | Supported Upgrade Versions |
 | --- | --- |
+| v1.8.x | [v1.9.x](./v1-8-x-to-v1-9-x.md) |
+| v1.8.x | [v1.8.y](./v1-8-x-to-v1-8-y.md) (*y* is greater than *x*) |
 | v1.7.x | [v1.8.x](./v1-7-x-to-v1-8-x.md) |
 | v1.7.x | [v1.7.y](./v1-7-x-to-v1-7-y.md) (*y* is greater than *x*) |
 | v1.6.x | [v1.7.x](./v1-6-x-to-v1-7-x.md) |
@@ -57,13 +59,13 @@ The latest Harvester versions allow the following:
 
 The following table outlines the components used in these versions:
 
-| Components | Harvester v1.5.x | Harvester v1.6.x | Harvester v1.7.x | Harvester v1.8.x |
-| --- | --- | --- | --- | --- |
-| KubeVirt | v1.4 | v1.5 | v1.6 | v1.7 |
-| Longhorn | v1.8 | v1.9 | v1.10 | v1.11 |
-| Rancher | v2.11 | v2.12 | v2.13 | v2.14 |
-| RKE2 | v1.32 | v1.33 | v1.34 | v1.35 |
-| SUSE Linux Micro | 5.5 | 5.5 | 6.1 | 6.2 |
+| Components | Harvester v1.5.x | Harvester v1.6.x | Harvester v1.7.x | Harvester v1.8.x | Harvester v1.9.x |
+| --- | --- | --- | --- | --- | --- |
+| KubeVirt | v1.4 | v1.5 | v1.6 | v1.7 | v1.8 |
+| Longhorn | v1.8 | v1.9 | v1.10 | v1.11 | v1.12 |
+| Rancher | v2.11 | v2.12 | v2.13 | v2.14 | v2.15 |
+| RKE2 | v1.32 | v1.33 | v1.34 | v1.35 | v1.36 |
+| SUSE Linux Micro | 5.5 | 5.5 | 6.1 | 6.2 | 6.2 |
 
 :::note
 

--- a/docs/upgrade/troubleshooting.md
+++ b/docs/upgrade/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 22
 sidebar_label: Troubleshooting
 title: "Troubleshooting"
 ---

--- a/docs/upgrade/v1-1-2-to-v1-2-0.md
+++ b/docs/upgrade/v1-1-2-to-v1-2-0.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 22
 sidebar_label: Upgrade from v1.1.2 to v1.2.0 (not recommended)
 title: "Upgrade from v1.1.2 to v1.2.0 (not recommended)"
 ---

--- a/docs/upgrade/v1-2-0-to-v1-2-1.md
+++ b/docs/upgrade/v1-2-0-to-v1-2-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 21
 sidebar_label: Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1
 title: "Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1"
 ---

--- a/docs/upgrade/v1-2-1-to-v1-2-2.md
+++ b/docs/upgrade/v1-2-1-to-v1-2-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 20
 sidebar_label: Upgrade from v1.2.1 to v1.2.2
 title: "Upgrade from v1.2.1 to v1.2.2"
 ---

--- a/docs/upgrade/v1-2-2-to-v1-3-1.md
+++ b/docs/upgrade/v1-2-2-to-v1-3-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 19
 sidebar_label: Upgrade from v1.2.2/v1.3.0 to v1.3.1
 title: "Upgrade from v1.2.2/v1.3.0 to v1.3.1"
 ---

--- a/docs/upgrade/v1-3-1-to-v1-3-2.md
+++ b/docs/upgrade/v1-3-1-to-v1-3-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 18
 sidebar_label: Upgrade from v1.3.1 to v1.3.2
 title: "Upgrade from v1.3.1 to v1.3.2"
 ---

--- a/docs/upgrade/v1-3-2-to-v1-4-0.md
+++ b/docs/upgrade/v1-3-2-to-v1-4-0.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 17
 sidebar_label: Upgrade from v1.3.2 to v1.4.0
 title: "Upgrade from v1.3.2 to v1.4.0"
 ---

--- a/docs/upgrade/v1-4-0-to-v1-4-1.md
+++ b/docs/upgrade/v1-4-0-to-v1-4-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 16
 sidebar_label: Upgrade from v1.4.0 to v1.4.1
 title: "Upgrade from v1.4.0 to v1.4.1"
 ---

--- a/docs/upgrade/v1-4-1-to-v1-4-2.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 sidebar_label: Upgrade from v1.4.1 to v1.4.2
 title: "Upgrade from v1.4.1 to v1.4.2"
 ---

--- a/docs/upgrade/v1-4-1-to-v1-4-3.md
+++ b/docs/upgrade/v1-4-1-to-v1-4-3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 sidebar_label: Upgrade from v1.4.1/v1.4.2 to v1.4.3
 title: "Upgrade from v1.4.1/v1.4.2 to v1.4.3"
 ---

--- a/docs/upgrade/v1-4-2-to-v1-5-0.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-0.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 13
 sidebar_label: Upgrade from v1.4.2/v1.4.3 to v1.5.0
 title: "Upgrade from v1.4.2/v1.4.3 to v1.5.0"
 ---

--- a/docs/upgrade/v1-4-2-to-v1-5-1.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 12
 sidebar_label: Upgrade from v1.4.2/v1.4.3 to v1.5.1
 title: "Upgrade from v1.4.2/v1.4.3 to v1.5.1"
 ---

--- a/docs/upgrade/v1-4-2-to-v1-5-2.md
+++ b/docs/upgrade/v1-4-2-to-v1-5-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 11
 sidebar_label: Upgrade from v1.4.2/v1.4.3 to v1.5.2
 title: "Upgrade from v1.4.2/v1.4.3 to v1.5.2"
 ---

--- a/docs/upgrade/v1-5-0-to-v1-5-1.md
+++ b/docs/upgrade/v1-5-0-to-v1-5-1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 sidebar_label: Upgrade from v1.5.0 to v1.5.1
 title: "Upgrade from v1.5.0 to v1.5.1"
 ---

--- a/docs/upgrade/v1-5-0-to-v1-5-2.md
+++ b/docs/upgrade/v1-5-0-to-v1-5-2.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 sidebar_label: Upgrade from v1.5.0/v1.5.1 to v1.5.2
 title: "Upgrade from v1.5.0/v1.5.1 to v1.5.2"
 ---

--- a/docs/upgrade/v1-5-x-to-v1-6-x.md
+++ b/docs/upgrade/v1-5-x-to-v1-6-x.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 8
 sidebar_label: Upgrade from v1.5.x to v1.6.x
 title: "Upgrade from v1.5.x to v1.6.x"
 ---

--- a/docs/upgrade/v1-6-x-to-v1-6-y.md
+++ b/docs/upgrade/v1-6-x-to-v1-6-y.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 sidebar_label: Upgrade from v1.6.x to v1.6.y
 title: "Upgrade from v1.6.x to v1.6.y"
 ---

--- a/docs/upgrade/v1-6-x-to-v1-7-x.md
+++ b/docs/upgrade/v1-6-x-to-v1-7-x.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 sidebar_label: Upgrade from v1.6.x to v1.7.x
 title: "Upgrade from v1.6.x to v1.7.x"
 ---

--- a/docs/upgrade/v1-7-x-to-v1-7-y.md
+++ b/docs/upgrade/v1-7-x-to-v1-7-y.md
@@ -97,3 +97,69 @@ kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
 After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
 
 Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)
+
+### 4. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+
+This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+
+After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+
+#### Symptoms
+
+- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
+- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+  ```
+  Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
+  Memory cgroup out of memory: Killed process ... (qemu-img) ...
+  ```
+- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+  ```
+  Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
+  ```
+
+#### Workaround
+
+1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+
+   ```bash
+   kubectl edit managedchart.management.cattle.io harvester -n fleet-local
+   ```
+
+   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+
+   ```yaml
+   spec:
+     values:
+       cdi:
+         spec:
+           config:
+             podResourceRequirements:
+               limits:
+                 memory: 4G
+   ```
+
+   :::caution
+
+   Only modify the `cdi.spec.config.podResourceRequirements.limits.memory` field. Do not modify or delete any other existing fields in the `harvester` ManagedChart resource.
+
+   The YAML snippet is an excerpt, not a full resource manifest.
+
+   :::
+
+   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
+
+1. Verify that the CDI CR reflects the change:
+
+   ```bash
+   kubectl get cdi cdi -o jsonpath='{.spec.config.podResourceRequirements.limits.memory}{"\n"}'
+   ```
+
+1. Restart the upgrade.
+
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+
+Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-7-x-to-v1-7-y.md
+++ b/docs/upgrade/v1-7-x-to-v1-7-y.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 5
 sidebar_label: Upgrade from v1.7.x to v1.7.y
 title: "Upgrade from v1.7.x to v1.7.y"
 ---

--- a/docs/upgrade/v1-7-x-to-v1-7-y.md
+++ b/docs/upgrade/v1-7-x-to-v1-7-y.md
@@ -98,38 +98,45 @@ After the restart, SUC reschedules the plan job for the affected node. The upgra
 
 Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)
 
-### 4. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+### 4. Upgrade Stuck in Crash Loop After CDI Importer Pod Is OOM-Killed
 
-During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the target ISO file and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slow destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
 
-This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+This issue stems from the CDI configuration running on the **source** cluster rather than the target release. Clusters running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` in v1.7.2, but slow destination storage and large ISO images can still drive memory consumption past this threshold.
 
-After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+After the importer pod is OOM-killed, its `/data` PVC is not cleaned up automatically (unlike the `/scratch` PVC). The partially converted disk image remains on the volume, causing subsequent retries to miscalculate available storage space and fail immediately, leaving the pod crash-looping indefinitely.
 
 #### Symptoms
 
-- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
-- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+- The `importer-prime-*` pod in the `harvester-system` namespace is in a `CrashLoopBackOff` state.
+
+- Node kernel logs indicate an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically occurring during the initial crash:
   ```
   Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
   Memory cgroup out of memory: Killed process ... (qemu-img) ...
   ```
-- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+- Subsequent restarts do not trigger an OOM-kill. Instead, the pod fails with an error message similar to the following:
   ```
   Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
   ```
 
 #### Workaround
 
-1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+1. [Stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade).
 
-1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+   This action deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource.
 
    ```bash
    kubectl edit managedchart.management.cattle.io harvester -n fleet-local
    ```
 
-   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+1. Increase the CDI importer pod's memory limit beyond the default value.
+
+   Under `spec.values`, configure a higher value for the `cdi.spec.config.podResourceRequirements.limits.memory` field based on available node memory. Slow storage backends and large images may require a higher allocation.
+
+   If the `cdi` key (or any part of its nested path) does not exist under `spec.values`, add the missing structure.
 
    ```yaml
    spec:
@@ -150,7 +157,6 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
    :::
 
-   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
 
 1. Verify that the CDI CR reflects the change:
 
@@ -160,6 +166,8 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
 1. Restart the upgrade.
 
-1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 3.
+
+    The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
 
 Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-7-x-to-v1-8-x.md
+++ b/docs/upgrade/v1-7-x-to-v1-8-x.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 sidebar_label: Upgrade from v1.7.x to v1.8.x
 title: "Upgrade from v1.7.x to v1.8.x"
 ---

--- a/docs/upgrade/v1-7-x-to-v1-8-x.md
+++ b/docs/upgrade/v1-7-x-to-v1-8-x.md
@@ -301,38 +301,45 @@ After patching, the **Migration Memory Transfer Rate** panel displays data durin
 
 Related issue: [#11390](https://github.com/harvester/harvester/issues/11390)
 
-### 5. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+### 5. Upgrade Stuck in Crash Loop After CDI Importer Pod Is OOM-Killed
 
-During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the target ISO file and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slow destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
 
-This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+This issue stems from the CDI configuration running on the **source** cluster rather than the target release. Clusters running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` in v1.7.2, but slow destination storage and large ISO images can still drive memory consumption past this threshold.
 
-After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+After the importer pod is OOM-killed, its `/data` PVC is not cleaned up automatically (unlike the `/scratch` PVC). The partially converted disk image remains on the volume, causing subsequent retries to miscalculate available storage space and fail immediately, leaving the pod crash-looping indefinitely.
 
 #### Symptoms
 
-- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
-- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+- The `importer-prime-*` pod in the `harvester-system` namespace is in a `CrashLoopBackOff` state.
+
+- Node kernel logs indicate an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically occurring during the initial crash:
   ```
   Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
   Memory cgroup out of memory: Killed process ... (qemu-img) ...
   ```
-- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+- Subsequent restarts do not trigger an OOM-kill. Instead, the pod fails with an error message similar to the following:
   ```
   Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
   ```
 
 #### Workaround
 
-1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+1. [Stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade).
 
-1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+   This action deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource.
 
    ```bash
    kubectl edit managedchart.management.cattle.io harvester -n fleet-local
    ```
 
-   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+1. Increase the CDI importer pod's memory limit beyond the default value.
+
+   Under `spec.values`, configure a higher value for the `cdi.spec.config.podResourceRequirements.limits.memory` field based on available node memory. Slow storage backends and large images may require a higher allocation.
+
+   If the `cdi` key (or any part of its nested path) does not exist under `spec.values`, add the missing structure.
 
    ```yaml
    spec:
@@ -353,7 +360,6 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
    :::
 
-   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
 
 1. Verify that the CDI CR reflects the change:
 
@@ -363,6 +369,8 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
 1. Restart the upgrade.
 
-1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 3.
+
+    The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
 
 Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-7-x-to-v1-8-x.md
+++ b/docs/upgrade/v1-7-x-to-v1-8-x.md
@@ -300,3 +300,69 @@ After patching, the **Migration Memory Transfer Rate** panel displays data durin
 ![after-patch.png](/img/v1.8/migration-metric/after-patch-memory-transfer-rate-metric.png)
 
 Related issue: [#11390](https://github.com/harvester/harvester/issues/11390)
+
+### 5. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+
+This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+
+After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+
+#### Symptoms
+
+- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
+- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+  ```
+  Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
+  Memory cgroup out of memory: Killed process ... (qemu-img) ...
+  ```
+- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+  ```
+  Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
+  ```
+
+#### Workaround
+
+1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+
+   ```bash
+   kubectl edit managedchart.management.cattle.io harvester -n fleet-local
+   ```
+
+   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+
+   ```yaml
+   spec:
+     values:
+       cdi:
+         spec:
+           config:
+             podResourceRequirements:
+               limits:
+                 memory: 4G
+   ```
+
+   :::caution
+
+   Only modify the `cdi.spec.config.podResourceRequirements.limits.memory` field. Do not modify or delete any other existing fields in the `harvester` ManagedChart resource.
+
+   The YAML snippet is an excerpt, not a full resource manifest.
+
+   :::
+
+   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
+
+1. Verify that the CDI CR reflects the change:
+
+   ```bash
+   kubectl get cdi cdi -o jsonpath='{.spec.config.podResourceRequirements.limits.memory}{"\n"}'
+   ```
+
+1. Restart the upgrade.
+
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+
+Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-8-x-to-v1-8-y.md
+++ b/docs/upgrade/v1-8-x-to-v1-8-y.md
@@ -17,3 +17,75 @@ For information about upgrading Harvester in air-gapped environments, see [Prepa
 ---
 
 ## Known Issues
+
+### 1. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+
+This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.8.0 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.8.1, but sufficiently slow storage or large images can still exceed even the higher limit.
+
+After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+
+:::note
+
+This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `2G` memory-limit fix yet. Clusters running v1.8.1 or later already have the fix, so they are less likely to hit this issue.
+
+:::
+
+#### Symptoms
+
+- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
+- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+  ```
+  Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
+  Memory cgroup out of memory: Killed process ... (qemu-img) ...
+  ```
+- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+  ```
+  Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
+  ```
+
+#### Workaround
+
+1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+
+   ```bash
+   kubectl edit managedchart.management.cattle.io harvester -n fleet-local
+   ```
+
+   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+
+   ```yaml
+   spec:
+     values:
+       cdi:
+         spec:
+           config:
+             podResourceRequirements:
+               limits:
+                 memory: 4G
+   ```
+
+   :::caution
+
+   Only modify the `cdi.spec.config.podResourceRequirements.limits.memory` field. Do not modify or delete any other existing fields in the `harvester` ManagedChart resource.
+
+   The YAML snippet is an excerpt, not a full resource manifest.
+
+   :::
+
+   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
+
+1. Verify that the CDI CR reflects the change:
+
+   ```bash
+   kubectl get cdi cdi -o jsonpath='{.spec.config.podResourceRequirements.limits.memory}{"\n"}'
+   ```
+
+1. Restart the upgrade.
+
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+
+Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-8-x-to-v1-8-y.md
+++ b/docs/upgrade/v1-8-x-to-v1-8-y.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 3
+sidebar_label: Upgrade from v1.8.x to v1.8.y
+title: "Upgrade from v1.8.x to v1.8.y"
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-8-x-to-v1-8-y"/>
+</head>
+
+## General Information
+
+An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvester version that you can upgrade to becomes available. For more information, see [Start an upgrade](./automatic.md#start-an-upgrade).
+
+For information about upgrading Harvester in air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
+
+---
+
+## Known Issues

--- a/docs/upgrade/v1-8-x-to-v1-8-y.md
+++ b/docs/upgrade/v1-8-x-to-v1-8-y.md
@@ -18,13 +18,13 @@ For information about upgrading Harvester in air-gapped environments, see [Prepa
 
 ## Known Issues
 
-### 1. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+### 1. Upgrade Stuck in Crash Loop After CDI Importer Pod Is OOM-Killed
 
-During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the target ISO file and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slow destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
 
-This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.8.0 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.8.1, but sufficiently slow storage or large images can still exceed even the higher limit.
+This issue stems from the CDI configuration running on the **source** cluster rather than the target release. Clusters running v1.8.0 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` in v1.8.1, but slow destination storage and large ISO images can still drive memory consumption past this threshold.
 
-After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+After the importer pod is OOM-killed, its `/data` PVC is not cleaned up automatically (unlike the `/scratch` PVC). The partially converted disk image remains on the volume, causing subsequent retries to miscalculate available storage space and fail immediately, leaving the pod crash-looping indefinitely.
 
 :::note
 
@@ -34,28 +34,35 @@ This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `
 
 #### Symptoms
 
-- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
-- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+- The `importer-prime-*` pod in the `harvester-system` namespace is in a `CrashLoopBackOff` state.
+
+- Node kernel logs indicate an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically occurring during the initial crash:
   ```
   Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
   Memory cgroup out of memory: Killed process ... (qemu-img) ...
   ```
-- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+- Subsequent restarts do not trigger an OOM-kill. Instead, the pod fails with an error message similar to the following:
   ```
   Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
   ```
 
 #### Workaround
 
-1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+1. [Stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade).
 
-1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+   This action deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource.
 
    ```bash
    kubectl edit managedchart.management.cattle.io harvester -n fleet-local
    ```
 
-   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+1. Increase the CDI importer pod's memory limit beyond the default value.
+
+   Under `spec.values`, configure a higher value for the `cdi.spec.config.podResourceRequirements.limits.memory` field based on available node memory. Slow storage backends and large images may require a higher allocation.
+
+   If the `cdi` key (or any part of its nested path) does not exist under `spec.values`, add the missing structure.
 
    ```yaml
    spec:
@@ -76,7 +83,6 @@ This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `
 
    :::
 
-   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
 
 1. Verify that the CDI CR reflects the change:
 
@@ -86,6 +92,8 @@ This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `
 
 1. Restart the upgrade.
 
-1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 3.
+
+    The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
 
 Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-8-x-to-v1-9-x.md
+++ b/docs/upgrade/v1-8-x-to-v1-9-x.md
@@ -34,3 +34,75 @@ You must use a compatible version (v1.9.x) of the Harvester UI Extension to impo
 ---
 
 ## Known Issues
+
+### 1. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+
+This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.8.0 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.8.1, but sufficiently slow storage or large images can still exceed even the higher limit.
+
+After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+
+:::note
+
+This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `2G` memory-limit fix yet. Clusters running v1.8.1 or later already have the fix, so they are less likely to hit this issue.
+
+:::
+
+#### Symptoms
+
+- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
+- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+  ```
+  Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
+  Memory cgroup out of memory: Killed process ... (qemu-img) ...
+  ```
+- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+  ```
+  Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
+  ```
+
+#### Workaround
+
+1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+
+   ```bash
+   kubectl edit managedchart.management.cattle.io harvester -n fleet-local
+   ```
+
+   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+
+   ```yaml
+   spec:
+     values:
+       cdi:
+         spec:
+           config:
+             podResourceRequirements:
+               limits:
+                 memory: 4G
+   ```
+
+   :::caution
+
+   Only modify the `cdi.spec.config.podResourceRequirements.limits.memory` field. Do not modify or delete any other existing fields in the `harvester` ManagedChart resource.
+
+   The YAML snippet is an excerpt, not a full resource manifest.
+
+   :::
+
+   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
+
+1. Verify that the CDI CR reflects the change:
+
+   ```bash
+   kubectl get cdi cdi -o jsonpath='{.spec.config.podResourceRequirements.limits.memory}{"\n"}'
+   ```
+
+1. Restart the upgrade.
+
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+
+Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-8-x-to-v1-9-x.md
+++ b/docs/upgrade/v1-8-x-to-v1-9-x.md
@@ -35,13 +35,13 @@ You must use a compatible version (v1.9.x) of the Harvester UI Extension to impo
 
 ## Known Issues
 
-### 1. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+### 1. Upgrade Stuck in Crash Loop After CDI Importer Pod Is OOM-Killed
 
-During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the target ISO file and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slow destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
 
-This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.8.0 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.8.1, but sufficiently slow storage or large images can still exceed even the higher limit.
+This issue stems from the CDI configuration running on the **source** cluster rather than the target release. Clusters running v1.8.0 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` in v1.8.1, but slow destination storage and large ISO images can still drive memory consumption past this threshold.
 
-After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+After the importer pod is OOM-killed, its `/data` PVC is not cleaned up automatically (unlike the `/scratch` PVC). The partially converted disk image remains on the volume, causing subsequent retries to miscalculate available storage space and fail immediately, leaving the pod crash-looping indefinitely.
 
 :::note
 
@@ -51,28 +51,35 @@ This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `
 
 #### Symptoms
 
-- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
-- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+- The `importer-prime-*` pod in the `harvester-system` namespace is in a `CrashLoopBackOff` state.
+
+- Node kernel logs indicate an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically occurring during the initial crash:
   ```
   Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
   Memory cgroup out of memory: Killed process ... (qemu-img) ...
   ```
-- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+- Subsequent restarts do not trigger an OOM-kill. Instead, the pod fails with an error message similar to the following:
   ```
   Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
   ```
 
 #### Workaround
 
-1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+1. [Stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade).
 
-1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+   This action deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource.
 
    ```bash
    kubectl edit managedchart.management.cattle.io harvester -n fleet-local
    ```
 
-   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+1. Increase the CDI importer pod's memory limit beyond the default value.
+
+   Under `spec.values`, configure a higher value for the `cdi.spec.config.podResourceRequirements.limits.memory` field based on available node memory. Slow storage backends and large images may require a higher allocation.
+
+   If the `cdi` key (or any part of its nested path) does not exist under `spec.values`, add the missing structure.
 
    ```yaml
    spec:
@@ -93,7 +100,6 @@ This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `
 
    :::
 
-   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
 
 1. Verify that the CDI CR reflects the change:
 
@@ -103,6 +109,8 @@ This issue mostly happens when upgrading from v1.8.0. v1.8.0 does not have the `
 
 1. Restart the upgrade.
 
-1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 3.
+
+    The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
 
 Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/docs/upgrade/v1-8-x-to-v1-9-x.md
+++ b/docs/upgrade/v1-8-x-to-v1-9-x.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 2
+sidebar_label: Upgrade from v1.8.x to v1.9.x
+title: "Upgrade from v1.8.x to v1.9.x"
+---
+
+<head>
+  <link rel="canonical" href="https://docs.harvesterhci.io/v1.8/upgrade/v1-8-x-to-v1-9-x"/>
+</head>
+
+## General Information
+
+An **Upgrade** button appears on the **Dashboard** screen whenever a new Harvester version that you can upgrade to becomes available. For more information, see [Start an upgrade](./automatic.md#start-an-upgrade).
+
+Clusters running v1.8.x can upgrade to v1.9.x directly because Harvester allows a maximum of one minor version upgrade for underlying components. For more information, see [Upgrade paths](./automatic.md#upgrade-paths).
+
+For information about upgrading Harvester in air-gapped environments, see [Prepare an air-gapped upgrade](./automatic.md#prepare-an-air-gapped-upgrade).
+
+### Update Harvester UI Extension on Rancher v2.15
+
+You must use a compatible version (v1.9.x) of the Harvester UI Extension to import Harvester v1.9.x clusters on Rancher v2.15.
+
+1. On the Rancher UI, go to **local > Apps > Repositories**.
+
+1. Locate the repository named **harvester**, and then select **⋮ > Refresh**.
+
+1. Go to the **Extensions** screen.
+
+1. Locate the extension named **Harvester**, and then click **Update**.
+
+1. Select a compatible version, and then click **Update**.
+
+1. Allow some time for the extension to be updated and then refresh the screen.
+---
+
+## Known Issues

--- a/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
@@ -97,3 +97,69 @@ kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
 After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
 
 Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)
+
+### 4. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+
+This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+
+After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+
+#### Symptoms
+
+- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
+- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+  ```
+  Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
+  Memory cgroup out of memory: Killed process ... (qemu-img) ...
+  ```
+- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+  ```
+  Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
+  ```
+
+#### Workaround
+
+1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+
+   ```bash
+   kubectl edit managedchart.management.cattle.io harvester -n fleet-local
+   ```
+
+   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+
+   ```yaml
+   spec:
+     values:
+       cdi:
+         spec:
+           config:
+             podResourceRequirements:
+               limits:
+                 memory: 4G
+   ```
+
+   :::caution
+
+   Only modify the `cdi.spec.config.podResourceRequirements.limits.memory` field. Do not modify or delete any other existing fields in the `harvester` ManagedChart resource.
+
+   The YAML snippet is an excerpt, not a full resource manifest.
+
+   :::
+
+   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
+
+1. Verify that the CDI CR reflects the change:
+
+   ```bash
+   kubectl get cdi cdi -o jsonpath='{.spec.config.podResourceRequirements.limits.memory}{"\n"}'
+   ```
+
+1. Restart the upgrade.
+
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+
+Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.7/upgrade/v1-7-x-to-v1-7-y.md
@@ -98,38 +98,45 @@ After the restart, SUC reschedules the plan job for the affected node. The upgra
 
 Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)
 
-### 4. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+### 4. Upgrade Stuck in Crash Loop After CDI Importer Pod Is OOM-Killed
 
-During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the target ISO file and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slow destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
 
-This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+This issue stems from the CDI configuration running on the **source** cluster rather than the target release. Clusters running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` in v1.7.2, but slow destination storage and large ISO images can still drive memory consumption past this threshold.
 
-After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+After the importer pod is OOM-killed, its `/data` PVC is not cleaned up automatically (unlike the `/scratch` PVC). The partially converted disk image remains on the volume, causing subsequent retries to miscalculate available storage space and fail immediately, leaving the pod crash-looping indefinitely.
 
 #### Symptoms
 
-- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
-- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+- The `importer-prime-*` pod in the `harvester-system` namespace is in a `CrashLoopBackOff` state.
+
+- Node kernel logs indicate an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically occurring during the initial crash:
   ```
   Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
   Memory cgroup out of memory: Killed process ... (qemu-img) ...
   ```
-- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+- Subsequent restarts do not trigger an OOM-kill. Instead, the pod fails with an error message similar to the following:
   ```
   Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
   ```
 
 #### Workaround
 
-1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+1. [Stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade).
 
-1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+   This action deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource.
 
    ```bash
    kubectl edit managedchart.management.cattle.io harvester -n fleet-local
    ```
 
-   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+1. Increase the CDI importer pod's memory limit beyond the default value.
+
+   Under `spec.values`, configure a higher value for the `cdi.spec.config.podResourceRequirements.limits.memory` field based on available node memory. Slow storage backends and large images may require a higher allocation.
+
+   If the `cdi` key (or any part of its nested path) does not exist under `spec.values`, add the missing structure.
 
    ```yaml
    spec:
@@ -150,7 +157,6 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
    :::
 
-   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
 
 1. Verify that the CDI CR reflects the change:
 
@@ -160,6 +166,8 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
 1. Restart the upgrade.
 
-1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 3.
+
+    The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
 
 Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
@@ -97,3 +97,69 @@ kubectl rollout restart deployment/system-upgrade-controller -n cattle-system
 After the restart, SUC reschedules the plan job for the affected node. The upgrade should resume automatically within a few minutes.
 
 Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)
+
+### 4. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+
+This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+
+After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+
+#### Symptoms
+
+- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
+- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+  ```
+  Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
+  Memory cgroup out of memory: Killed process ... (qemu-img) ...
+  ```
+- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+  ```
+  Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
+  ```
+
+#### Workaround
+
+1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+
+   ```bash
+   kubectl edit managedchart.management.cattle.io harvester -n fleet-local
+   ```
+
+   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+
+   ```yaml
+   spec:
+     values:
+       cdi:
+         spec:
+           config:
+             podResourceRequirements:
+               limits:
+                 memory: 4G
+   ```
+
+   :::caution
+
+   Only modify the `cdi.spec.config.podResourceRequirements.limits.memory` field. Do not modify or delete any other existing fields in the `harvester` ManagedChart resource.
+
+   The YAML snippet is an excerpt, not a full resource manifest.
+
+   :::
+
+   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
+
+1. Verify that the CDI CR reflects the change:
+
+   ```bash
+   kubectl get cdi cdi -o jsonpath='{.spec.config.podResourceRequirements.limits.memory}{"\n"}'
+   ```
+
+1. Restart the upgrade.
+
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+
+Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-7-y.md
@@ -98,38 +98,45 @@ After the restart, SUC reschedules the plan job for the affected node. The upgra
 
 Related issue: [#9880](https://github.com/harvester/harvester/issues/9880)
 
-### 4. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+### 4. Upgrade Stuck in Crash Loop After CDI Importer Pod Is OOM-Killed
 
-During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the target ISO file and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slow destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
 
-This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+This issue stems from the CDI configuration running on the **source** cluster rather than the target release. Clusters running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` in v1.7.2, but slow destination storage and large ISO images can still drive memory consumption past this threshold.
 
-After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+After the importer pod is OOM-killed, its `/data` PVC is not cleaned up automatically (unlike the `/scratch` PVC). The partially converted disk image remains on the volume, causing subsequent retries to miscalculate available storage space and fail immediately, leaving the pod crash-looping indefinitely.
 
 #### Symptoms
 
-- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
-- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+- The `importer-prime-*` pod in the `harvester-system` namespace is in a `CrashLoopBackOff` state.
+
+- Node kernel logs indicate an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically occurring during the initial crash:
   ```
   Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
   Memory cgroup out of memory: Killed process ... (qemu-img) ...
   ```
-- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+- Subsequent restarts do not trigger an OOM-kill. Instead, the pod fails with an error message similar to the following:
   ```
   Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
   ```
 
 #### Workaround
 
-1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+1. [Stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade).
 
-1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+   This action deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource.
 
    ```bash
    kubectl edit managedchart.management.cattle.io harvester -n fleet-local
    ```
 
-   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+1. Increase the CDI importer pod's memory limit beyond the default value.
+
+   Under `spec.values`, configure a higher value for the `cdi.spec.config.podResourceRequirements.limits.memory` field based on available node memory. Slow storage backends and large images may require a higher allocation.
+
+   If the `cdi` key (or any part of its nested path) does not exist under `spec.values`, add the missing structure.
 
    ```yaml
    spec:
@@ -150,7 +157,6 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
    :::
 
-   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
 
 1. Verify that the CDI CR reflects the change:
 
@@ -160,6 +166,8 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
 1. Restart the upgrade.
 
-1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 3.
+
+    The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
 
 Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-8-x.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-8-x.md
@@ -301,38 +301,45 @@ After patching, the **Migration Memory Transfer Rate** panel displays data durin
 
 Related issue: [#11390](https://github.com/harvester/harvester/issues/11390)
 
-### 5. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+### 5. Upgrade Stuck in Crash Loop After CDI Importer Pod Is OOM-Killed
 
-During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the target ISO file and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slow destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
 
-This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+This issue stems from the CDI configuration running on the **source** cluster rather than the target release. Clusters running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` in v1.7.2, but slow destination storage and large ISO images can still drive memory consumption past this threshold.
 
-After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+After the importer pod is OOM-killed, its `/data` PVC is not cleaned up automatically (unlike the `/scratch` PVC). The partially converted disk image remains on the volume, causing subsequent retries to miscalculate available storage space and fail immediately, leaving the pod crash-looping indefinitely.
 
 #### Symptoms
 
-- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
-- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+- The `importer-prime-*` pod in the `harvester-system` namespace is in a `CrashLoopBackOff` state.
+
+- Node kernel logs indicate an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically occurring during the initial crash:
   ```
   Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
   Memory cgroup out of memory: Killed process ... (qemu-img) ...
   ```
-- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+- Subsequent restarts do not trigger an OOM-kill. Instead, the pod fails with an error message similar to the following:
   ```
   Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
   ```
 
 #### Workaround
 
-1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+1. [Stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade).
 
-1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+   This action deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource.
 
    ```bash
    kubectl edit managedchart.management.cattle.io harvester -n fleet-local
    ```
 
-   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+1. Increase the CDI importer pod's memory limit beyond the default value.
+
+   Under `spec.values`, configure a higher value for the `cdi.spec.config.podResourceRequirements.limits.memory` field based on available node memory. Slow storage backends and large images may require a higher allocation.
+
+   If the `cdi` key (or any part of its nested path) does not exist under `spec.values`, add the missing structure.
 
    ```yaml
    spec:
@@ -353,7 +360,6 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
    :::
 
-   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
 
 1. Verify that the CDI CR reflects the change:
 
@@ -363,6 +369,8 @@ After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC
 
 1. Restart the upgrade.
 
-1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 3.
+
+    The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
 
 Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)

--- a/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-8-x.md
+++ b/versioned_docs/version-v1.8/upgrade/v1-7-x-to-v1-8-x.md
@@ -300,3 +300,69 @@ After patching, the **Migration Memory Transfer Rate** panel displays data durin
 ![after-patch.png](/img/v1.8/migration-metric/after-patch-memory-transfer-rate-metric.png)
 
 Related issue: [#11390](https://github.com/harvester/harvester/issues/11390)
+
+### 5. Upgrade Gets Stuck in a Crash Loop After the CDI Importer Pod Is OOM-Killed
+
+During Phase 1 (Provision an Upgrade Repository Virtual Machine), the Containerized Data Importer (CDI) downloads the release ISO and converts it to a raw disk image using `qemu-img convert -t writeback`, which buffers converted data in memory. On slower destination storage, this buffer can grow until it exceeds the CDI importer pod's memory limit, causing the pod to be OOM-killed.
+
+This issue stems from the CDI configuration already running on the **source** cluster, not the target release. Clusters still running v1.7.0 or v1.7.1 use the default importer pod memory limit of `600M`, which is prone to this failure. The limit was raised to `2G` starting in v1.7.2, but sufficiently slow storage or large images can still exceed even the higher limit.
+
+After the importer pod is OOM-killed, its `/data` PVC (unlike the `/scratch` PVC) is not cleaned up automatically. A partially converted disk image remains, so the next retry miscalculates the available space and fails immediately, leaving the pod crash-looping indefinitely.
+
+#### Symptoms
+
+- The `importer-prime-*` pod in the `harvester-system` namespace is in `CrashLoopBackOff`.
+- Node kernel logs show an `oom-kill` event for the `virt-cdi-import` and `qemu-img` processes, typically only on the first crash:
+  ```
+  Memory cgroup out of memory: Killed process ... (virt-cdi-import) ...
+  Memory cgroup out of memory: Killed process ... (qemu-img) ...
+  ```
+- On subsequent restarts, the pod no longer gets OOM-killed. Instead, the importer logs show an error similar to:
+  ```
+  Unable to convert source data to target format: virtual image size <X> is larger than the reported available storage <Y>. A larger PVC is required
+  ```
+
+#### Workaround
+
+1. If the upgrade is already stuck in this crash loop, [stop the ongoing upgrade](./troubleshooting.md#stop-the-ongoing-upgrade) first. This deletes the `Upgrade` CR along with its associated DataVolume and PVCs, clearing the stale `/data` content.
+
+1. Edit the `harvester` ManagedChart resource to raise the CDI importer pod's memory limit beyond the default:
+
+   ```bash
+   kubectl edit managedchart.management.cattle.io harvester -n fleet-local
+   ```
+
+   Under `spec.values`, add or update the `cdi.spec.config.podResourceRequirements.limits.memory` field to a higher value. The `cdi` key (or parts of its nested path) may not already exist under `spec.values`; if so, add the missing nested structure as shown below:
+
+   ```yaml
+   spec:
+     values:
+       cdi:
+         spec:
+           config:
+             podResourceRequirements:
+               limits:
+                 memory: 4G
+   ```
+
+   :::caution
+
+   Only modify the `cdi.spec.config.podResourceRequirements.limits.memory` field. Do not modify or delete any other existing fields in the `harvester` ManagedChart resource.
+
+   The YAML snippet is an excerpt, not a full resource manifest.
+
+   :::
+
+   Adjust the value based on available node memory. Larger upgrade images or slower storage backends may require an even higher limit.
+
+1. Verify that the CDI CR reflects the change:
+
+   ```bash
+   kubectl get cdi cdi -o jsonpath='{.spec.config.podResourceRequirements.limits.memory}{"\n"}'
+   ```
+
+1. Restart the upgrade.
+
+1. After the upgrade completes successfully, remove the `podResourceRequirements` override you added to the `harvester` ManagedChart resource in step 2. The version you upgraded to already includes the memory-limit fix, so the override is no longer needed.
+
+Related issues: [#11143](https://github.com/harvester/harvester/issues/11143) and [#10056](https://github.com/harvester/harvester/issues/10056)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- Add v1.9 upgrade matrix and known issues pages
- Document CDI importer OOM crash-loop known issue across upgrade paths
  - Upgrades from v1.7.0/v1.7.1 or v1.8.0 can get stuck when the CDI importer pod is OOM-killed while converting the release ISO, leaving a stale /data image that crash-loops on every retry. Add the known issue (symptoms + ManagedChart memory-limit workaround) to every affected upgrade doc, including the already-published v1.7 and v1.8 versioned snapshots.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/11143

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
