### PR TITLE
feat: add install.cordoned configuration option

### DIFF
--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -51,8 +51,8 @@ Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to
 
 :::note
 
-- Cordoned worker nodes will never be considered for promotion to management nodes.
-- When upgrading Harvester to a newer version, all nodes must be uncordoned for the upgrade to proceed.
+- Cordoned worker nodes are never considered for promotion to management nodes.
+- You must uncordon all nodes before upgrading Harvester to a newer version.
 
 :::
 

--- a/docs/host/host.md
+++ b/docs/host/host.md
@@ -49,6 +49,13 @@ Cordoned nodes are marked as unschedulable. Cordoning is useful when you want to
 
 ![cordon-node.png](/img/v1.2/host/cordon-nodes.png)
 
+:::note
+
+- Cordoned worker nodes will never be considered for promotion to management nodes.
+- When upgrading Harvester to a newer version, all nodes must be uncordoned for the upgrade to proceed.
+
+:::
+
 ## Deleting a Node
 
 :::caution

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -567,6 +567,57 @@ install:
 
 When enabled, the configuration is either retrieved from the value of `harvester.install.config_url` or defined individually using kernel parameters.
 
+### `install.cluster_dns`
+
+**Definition**: IP of the Harvester DNS service.
+
+Use this field to override the default DNS service IP of 10.53.0.10.
+
+:::info important
+
+This IP must be within the range defined by the `cluster_service_cidr` field.
+
+:::
+
+**Example**:
+
+```yaml
+install:
+  cluster_dns: 172.16.0.10
+```
+
+### `install.cluster_pod_cidr`
+
+**Definition**: CIDR of the Harvester pods.
+
+Use this field to override the default pod CIDR of 10.52.0.0/16.
+
+**Example**:
+
+```yaml
+install:
+  cluster_pod_cidr: 172.16.0.0/16
+```
+
+### `install.cluster_service_cidr`
+
+**Definition**: CIDR of the Harvester services.
+
+Use this field to override the default service CIDR of 10.53.0.0/16.
+
+:::info important
+
+If you change this CIDR, you must ensure that the cluster DNS IP (`install.cluster_dns`) is within this range.
+
+:::
+
+**Example**:
+
+```yaml
+install:
+  cluster_service_cidr: 172.22.0.0/16
+```
+
 ### `install.data_disk`
 
 **Versions**: v1.0.1 and later
@@ -835,57 +886,6 @@ install:
   vip: 10.10.0.19
   vip_mode: dhcp
   vip_hw_addr: 52:54:00:ec:0e:0b
-```
-
-### `install.cluster_pod_cidr`
-
-**Definition**: CIDR of the Harvester pods.
-
-Use this field to override the default pod CIDR of 10.52.0.0/16.
-
-**Example**:
-
-```yaml
-install:
-  cluster_pod_cidr: 172.16.0.0/16
-```
-
-### `install.cluster_service_cidr`
-
-**Definition**: CIDR of the Harvester services.
-
-Use this field to override the default service CIDR of 10.53.0.0/16.
-
-:::info important
-
-If you change this CIDR, you must ensure that the cluster DNS IP (`install.cluster_dns`) is within this range.
-
-:::
-
-**Example**:
-
-```yaml
-install:
-  cluster_service_cidr: 172.22.0.0/16
-```
-
-### `install.cluster_dns`
-
-**Definition**: IP of the Harvester DNS service.
-
-Use this field to override the default DNS service IP of 10.53.0.10.
-
-:::info important
-
-This IP must be within the range defined by the `cluster_service_cidr` field.
-
-:::
-
-**Example**:
-
-```yaml
-install:
-  cluster_dns: 172.16.0.10
 ```
 
 ### `install.webhooks`

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -571,11 +571,11 @@ When enabled, the configuration is either retrieved from the value of `harvester
 
 **Definition**: IP of the Harvester DNS service.
 
-Use this field to override the default DNS service IP of 10.53.0.10.
+Use this setting to override the default DNS service IP (`10.53.0.10`).
 
 :::info important
 
-This IP must be within the range defined by the `cluster_service_cidr` field.
+This IP must be within the range defined by the `cluster_service_cidr` setting.
 
 :::
 
@@ -588,9 +588,9 @@ install:
 
 ### `install.cluster_pod_cidr`
 
-**Definition**: CIDR of the Harvester pods.
+**Definition**: CIDR block allocated for Harvester pods.
 
-Use this field to override the default pod CIDR of 10.52.0.0/16.
+Use this setting to override the default pod CIDR (`10.52.0.0/16`).
 
 **Example**:
 
@@ -601,9 +601,9 @@ install:
 
 ### `install.cluster_service_cidr`
 
-**Definition**: CIDR of the Harvester services.
+**Definition**: CIDR block allocated for Harvester services.
 
-Use this field to override the default service CIDR of 10.53.0.0/16.
+Use this setting to override the default service CIDR (`10.53.0.0/16`).
 
 :::info important
 
@@ -622,11 +622,11 @@ install:
 
 **Versions**: v1.9.0 and later
 
-**Definition**: When joining the node to an existing cluster, bring it up in a [cordoned](../host/host.md#cordoning-a-node) state.
+**Definition**: Setting that initializes the node in a [cordoned](../host/host.md#cordoning-a-node) state when joining an existing cluster.
 
-This can be useful if some post-installation configuration of nodes is required prior to having them run VMs. Once you are ready for the node to host workloads it can be uncordoned via the Harvester GUI, or by running `kubectl uncordon <node name>`.
+This setting is useful when post-installation node configuration is required before scheduling workloads. Once the node is ready to host virtual machines, you can uncordon it using the Harvester UI or by running `kubectl uncordon <node-name>`.
 
-This option cannot be used in create mode for the first node in a cluster, nor can it be used for witness nodes.
+You cannot use this setting when initializing the first node in the cluster or when configuring witness nodes.
 
 **Default value**: `false`
 
@@ -639,7 +639,7 @@ install:
 
 :::note
 
-Cordoned nodes will never be considered for promotion to management nodes. This means that when first deploying Harvester, if the second two nodes are deployed with `install.cordoned = true`, they will not be automatically promoted to management until they are uncordoned by the user.
+Cordoned worker nodes are never considered for promotion to management nodes. When initially deploying a Harvester cluster, if the second and third nodes join with `install.cordoned = true`, they are not automatically promoted until you uncordon them.
 
 :::
 

--- a/docs/install/harvester-configuration.md
+++ b/docs/install/harvester-configuration.md
@@ -618,6 +618,31 @@ install:
   cluster_service_cidr: 172.22.0.0/16
 ```
 
+### `install.cordoned`
+
+**Versions**: v1.9.0 and later
+
+**Definition**: When joining the node to an existing cluster, bring it up in a [cordoned](../host/host.md#cordoning-a-node) state.
+
+This can be useful if some post-installation configuration of nodes is required prior to having them run VMs. Once you are ready for the node to host workloads it can be uncordoned via the Harvester GUI, or by running `kubectl uncordon <node name>`.
+
+This option cannot be used in create mode for the first node in a cluster, nor can it be used for witness nodes.
+
+**Default value**: `false`
+
+**Example**:
+
+```yaml
+install:
+  cordoned: true
+```
+
+:::note
+
+Cordoned nodes will never be considered for promotion to management nodes. This means that when first deploying Harvester, if the second two nodes are deployed with `install.cordoned = true`, they will not be automatically promoted to management until they are uncordoned by the user.
+
+:::
+
 ### `install.data_disk`
 
 **Versions**: v1.0.1 and later


### PR DESCRIPTION
#### Problem:
Need to document the new `install.cordoned` Harvester config file option, and the behaviour of the promote controller when applied to cordoned nodes.

#### Solution:
This PR

#### Related Issue(s):
https://github.com/harvester/harvester/issues/4424
https://github.com/harvester/harvester/issues/11074

#### Test plan:
N/A

#### Additional documentation or context
I've also fixed the alphabetisation of the `install.cluster_*` config options