### PR TITLE
feat: LHv2: drop some limitations, add memory settings, graduate to "Preview"

### DIFF
--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -14,7 +14,7 @@ The Longhorn V2 Data Engine harnesses the power of the Storage Performance Devel
 
 :::caution
 
-The Longhorn V2 Data Engine is an **Experimental** feature and should not be utilized in a production environment.
+The Longhorn V2 Data Engine is an **Preview** feature and should not be utilized in a production environment.
 
 :::
 

--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -49,7 +49,7 @@ The Longhorn V2 Data Engine is only available for newly created volumes and imag
 
   If you encounter error messages that include the phrase "not enough hugepages-2Mi capacity", allow some time for the error to be resolved. If the error persists, reboot the affected nodes.
   
-  If you do not plan to use hugepages or want to allocate a custom memory size, adjust the `longhorn-v2-data-engine-hugepage-enabled` and `longhorn-v2-data-engine-memory-size` settings, preferably before enabling the Longhorn V2 Data Engine.
+  If you do not plan to use hugepages or want to allocate a custom memory size, adjust the `longhorn-v2-data-engine-hugepage-enabled` and `longhorn-v2-data-engine-memory-size` settings, preferably before enabling the Longhorn V2 Data Engine. Disabling hugepages is currently supported only for Longhorn V2 disks that use the AIO bdev driver (the default in Harvester v1.9.0). Do not disable hugepages when using the NVMe or virtio bdev driver.
 
   To disable the Longhorn V2 Data Engine on specific nodes (for example, nodes with less processing and memory resources), go to the **Hosts** screen and add the following label to the target nodes:
 

--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -49,6 +49,8 @@ The Longhorn V2 Data Engine is only available for newly created volumes and imag
 
   If you encounter error messages that include the phrase "not enough hugepages-2Mi capacity", allow some time for the error to be resolved. If the error persists, reboot the affected nodes.
   
+  If you don't want to use huge pages and/or wish to allocate a different amount of memory, adjust the `longhorn-v2-data-engine-hugepage-enabled` and `longhorn-v2-data-engine-memory-size` options appropriately, ideally prior to enabling the Longhorn V2 data engine.
+
   To disable the Longhorn V2 Data Engine on specific nodes (for example, nodes with less processing and memory resources), go to the **Hosts** screen and add the following label to the target nodes:
 
     - label: `node.longhorn.io/disable-v2-data-engine`

--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -14,7 +14,7 @@ The Longhorn V2 Data Engine harnesses the power of the Storage Performance Devel
 
 :::caution
 
-The Longhorn V2 Data Engine is an **Preview** feature and should not be utilized in a production environment.
+The Longhorn V2 Data Engine is a **Technical Preview** feature. Explore the feature extensively before using in production environments.
 
 :::
 
@@ -49,7 +49,7 @@ The Longhorn V2 Data Engine is only available for newly created volumes and imag
 
   If you encounter error messages that include the phrase "not enough hugepages-2Mi capacity", allow some time for the error to be resolved. If the error persists, reboot the affected nodes.
   
-  If you don't want to use huge pages and/or wish to allocate a different amount of memory, adjust the `longhorn-v2-data-engine-hugepage-enabled` and `longhorn-v2-data-engine-memory-size` options appropriately, ideally prior to enabling the Longhorn V2 data engine.
+  If you do not plan to use hugepages or want to allocate a custom memory size, adjust the `longhorn-v2-data-engine-hugepage-enabled` and `longhorn-v2-data-engine-memory-size` settings, preferably before enabling the Longhorn V2 Data Engine.
 
   To disable the Longhorn V2 Data Engine on specific nodes (for example, nodes with less processing and memory resources), go to the **Hosts** screen and add the following label to the target nodes:
 

--- a/docs/advanced/longhorn-v2.md
+++ b/docs/advanced/longhorn-v2.md
@@ -28,16 +28,10 @@ Every node with an active Longhorn V2 Data Engine requires the following dedicat
 
 ## Limitations
 
-:::note
-
 The Longhorn V2 Data Engine currently does not support the following operations:
 
 - Backing image creation and usage
 - Volume encryption
-
-:::
-
-- SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines. For example, when creating an ext4 filesystem on a Linux virtual machine, use `mkfs.ext4 -E nodiscard /dev/vdb` (assuming `/dev/vdb` is your device path). On Windows virtual machines, you can disable trimming for NTFS by running the command `fsutil behavior set disabledeletenotify NTFS 1`.
 
 ## Using the Longhorn V2 Data Engine
 
@@ -65,14 +59,6 @@ The Longhorn V2 Data Engine is only available for newly created volumes and imag
 1. Go to the **Hosts** screen, and then add extra disks to each node as described in [Multi-disk Management](../host/host.md#multi-disk-management). 
 
   Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
-
-  :::info important
-
-  Harvester sets the [Longhorn disk driver](https://longhorn.io/docs/1.7.2/v2-data-engine/features/node-disk-support/) to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
-  
-  SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an *even multiple of 4096 bytes*. Non-NVMe disks that do not meet this size requirement cannot be added.  Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
-
-  :::
 
 1. Go to **Advanced** > **Storage Classes**, and then add a new StorageClass as described in [Creating a StorageClass](storageclass.md#creating-a-storageclass). 
 

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -374,6 +374,38 @@ To disable the Longhorn V2 Data Engine on specific nodes (for example, nodes wit
 true
 ```
 
+### `longhorn-v2-data-engine-hugepage-enabled`
+
+**Versions**: v1.9.0 and later
+
+**Definition**: Enable hugepages when using the Longhorn V2 data engine.
+
+Disabling hugepages reduces memory pressure on low-spec nodes and increases deployment flexibility. However, performance may be lower compared to running with hugepages.
+
+**Default Value**: `true`
+
+**Example**:
+
+```
+false
+```
+
+### `longhorn-v2-data-engine-memory-size`
+
+**Versions**: v1.9.0 and later
+
+**Definition**: The amount of memory in MiB allocated to the SPDK target daemon when using the Longhorn V2 data engine.
+
+All V2 volumes must be detached for changes to this setting to take effect.
+
+**Default Value**: `2048`
+
+**Example**:
+
+```
+4096
+```
+
 ### `ntp-servers`
 
 **Versions**: v1.2.0 and later

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -382,6 +382,12 @@ true
 
 Disabling hugepages reduces memory pressure on resource-constrained nodes and increases deployment flexibility. However, performance may be lower compared to running the engine with hugepages enabled.
 
+:::caution
+
+Disabling hugepages is currently supported only for Longhorn V2 disks that use the AIO bdev driver. Do not disable hugepages when using the NVMe or virtio bdev driver.
+
+:::
+
 **Default Value**: `true`
 
 **Example**:

--- a/docs/advanced/settings.md
+++ b/docs/advanced/settings.md
@@ -378,9 +378,9 @@ true
 
 **Versions**: v1.9.0 and later
 
-**Definition**: Enable hugepages when using the Longhorn V2 data engine.
+**Definition**: Setting that enables or disables hugepages when using the Longhorn V2 Data Engine.
 
-Disabling hugepages reduces memory pressure on low-spec nodes and increases deployment flexibility. However, performance may be lower compared to running with hugepages.
+Disabling hugepages reduces memory pressure on resource-constrained nodes and increases deployment flexibility. However, performance may be lower compared to running the engine with hugepages enabled.
 
 **Default Value**: `true`
 
@@ -394,9 +394,9 @@ false
 
 **Versions**: v1.9.0 and later
 
-**Definition**: The amount of memory in MiB allocated to the SPDK target daemon when using the Longhorn V2 data engine.
+**Definition**: Amount of memory in MiB allocated to the SPDK target daemon when using the Longhorn V2 Data Engine.
 
-All V2 volumes must be detached for changes to this setting to take effect.
+You must detach all V2 volumes before changes to this setting take effect.
 
 **Default Value**: `2048`
 


### PR DESCRIPTION
#### Problem:
Need a few updates for LHv2 support in v1.9.0

#### Solution:
- Drop aio unmap and 4096 byte block size limitations (the aio bdev driver supports unmap since https://github.com/longhorn/spdk/commit/648a541400e162c322e4337192fe5219a1a17bab went in, and uses 512 byte block sizes thanks to https://github.com/longhorn/longhorn/issues/10053)
- Add longhorn-v2-data-engine-hugepage-enabled and longhorn-v2-data-engine-memory-size settings
- Mention LHv2 is now "Preview" instead of "Experimental"

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9390
https://github.com/harvester/harvester/issues/9960

#### Test plan:
N/A

#### Additional documentation or context
