### PR TITLE
Add limitation for Guest clusters created from ovn networks

### DIFF
--- a/docs/rancher/guest-cluster-kubeovn-network.md
+++ b/docs/rancher/guest-cluster-kubeovn-network.md
@@ -84,3 +84,7 @@ For virtual machines provisioned as downstream cluster nodes, ensure external co
 Because guest cluster nodes on Kube-OVN overlay networks use private IP addresses, you must configure a route to the virtual machine node subnet on the Rancher virtual machine, specifying the Kube-OVN EIP (configured during VPC NAT gateway EIP setup) as the next hop. This ensures network reachability between the Rancher virtual machine and guest cluster nodes, enabling SSH access through the Rancher UI for debugging.
 
 :::
+
+## Limitations
+
+This release supports basic guest cluster VM provisioning for running workloads. However, LoadBalancer services and CSI-based RWX (ReadWriteMany) volumes are not supported for guest clusters using Kube-OVN networks.

--- a/docs/rancher/guest-cluster-kubeovn-network.md
+++ b/docs/rancher/guest-cluster-kubeovn-network.md
@@ -87,4 +87,4 @@ Because guest cluster nodes on Kube-OVN overlay networks use private IP addresse
 
 ## Limitations
 
-This release supports basic guest cluster VM provisioning for running workloads. However, LoadBalancer services and CSI-based RWX (ReadWriteMany) volumes are not supported for guest clusters using Kube-OVN networks.
+Harvester v1.9.0 supports basic virtual machine provisioning for guest cluster workloads. However, `LoadBalancer` services and CSI-based ReadWriteMany (RWX) volumes are not supported on guest clusters using Kube-OVN networks.


### PR DESCRIPTION

#### Problem:
Guest clusters created from kubeovn networks currently support only basic VM node provisioning

#### Solution:
Add other services as limitation to the doc

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9682

#### Test plan:


#### Additional documentation or context
