### PR TITLE
docs: clarify StorageClass sync note across all versioned docs

### DIFF
--- a/docs/vm/backup-restore.md
+++ b/docs/vm/backup-restore.md
@@ -143,7 +143,7 @@ Users can now restore a new VM on another cluster by leveraging the VM metadata 
 
 #### Prerequisites
 
-- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, except when a virtual machine image with the same name or display name already exists on the new cluster.
+- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, along with their associated StorageClasses, except when a virtual machine image with the same name or display name already exists on the new cluster.
 
 - Earlier than v1.4.0: You must upload and configure the virtual machine images on the new cluster. Ensure that the image names and configuration are identical so that the virtual machines can be restored. For more information, see [Upload the same VM images to a new cluster](#upload-the-same-vm-images-to-a-new-cluster).
 

--- a/versioned_docs/version-v1.4/vm/backup-restore.md
+++ b/versioned_docs/version-v1.4/vm/backup-restore.md
@@ -157,7 +157,7 @@ Users can now restore a new VM on another cluster by leveraging the VM metadata 
 
 #### Prerequisites
 
-- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, except when a virtual machine image with the same name or display name already exists on the new cluster.
+- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, along with their associated StorageClasses, except when a virtual machine image with the same name or display name already exists on the new cluster.
 
 - Earlier than v1.4.0: You must upload and configure the virtual machine images on the new cluster. Ensure that the image names and configuration are identical so that the virtual machines can be restored. For more information, see [Upload the same VM images to a new cluster](#upload-the-same-vm-images-to-a-new-cluster).
 

--- a/versioned_docs/version-v1.5/vm/backup-restore.md
+++ b/versioned_docs/version-v1.5/vm/backup-restore.md
@@ -110,7 +110,7 @@ Users can now restore a new VM on another cluster by leveraging the VM metadata 
 
 #### Prerequisites
 
-- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, except when a virtual machine image with the same name or display name already exists on the new cluster.
+- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, along with their associated StorageClasses, except when a virtual machine image with the same name or display name already exists on the new cluster.
 
 - Earlier than v1.4.0: You must upload and configure the virtual machine images on the new cluster. Ensure that the image names and configuration are identical so that the virtual machines can be restored. For more information, see [Upload the same VM images to a new cluster](#upload-the-same-vm-images-to-a-new-cluster).
 

--- a/versioned_docs/version-v1.6/vm/backup-restore.md
+++ b/versioned_docs/version-v1.6/vm/backup-restore.md
@@ -133,7 +133,7 @@ Users can now restore a new VM on another cluster by leveraging the VM metadata 
 
 #### Prerequisites
 
-- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, except when a virtual machine image with the same name or display name already exists on the new cluster.
+- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, along with their associated StorageClasses, except when a virtual machine image with the same name or display name already exists on the new cluster.
 
 - Earlier than v1.4.0: You must upload and configure the virtual machine images on the new cluster. Ensure that the image names and configuration are identical so that the virtual machines can be restored. For more information, see [Upload the same VM images to a new cluster](#upload-the-same-vm-images-to-a-new-cluster).
 

--- a/versioned_docs/version-v1.7/vm/backup-restore.md
+++ b/versioned_docs/version-v1.7/vm/backup-restore.md
@@ -143,7 +143,7 @@ Users can now restore a new VM on another cluster by leveraging the VM metadata 
 
 #### Prerequisites
 
-- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, except when a virtual machine image with the same name or display name already exists on the new cluster.
+- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, along with their associated StorageClasses, except when a virtual machine image with the same name or display name already exists on the new cluster.
 
 - Earlier than v1.4.0: You must upload and configure the virtual machine images on the new cluster. Ensure that the image names and configuration are identical so that the virtual machines can be restored. For more information, see [Upload the same VM images to a new cluster](#upload-the-same-vm-images-to-a-new-cluster).
 

--- a/versioned_docs/version-v1.8/vm/backup-restore.md
+++ b/versioned_docs/version-v1.8/vm/backup-restore.md
@@ -143,7 +143,7 @@ Users can now restore a new VM on another cluster by leveraging the VM metadata 
 
 #### Prerequisites
 
-- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, except when a virtual machine image with the same name or display name already exists on the new cluster.
+- v1.4.0 and later: The controller automatically syncs the virtual machine images with the new cluster, along with their associated StorageClasses, except when a virtual machine image with the same name or display name already exists on the new cluster.
 
 - Earlier than v1.4.0: You must upload and configure the virtual machine images on the new cluster. Ensure that the image names and configuration are identical so that the virtual machines can be restored. For more information, see [Upload the same VM images to a new cluster](#upload-the-same-vm-images-to-a-new-cluster).
 


### PR DESCRIPTION
#### Problem:
The documentation for VM image sync during cluster restore states that the controller automatically syncs virtual machine images to the new cluster, but doesn't mention that each image's associated StorageClass is also synced as part of this process. This omission could lead users to assume StorageClasses need to be manually recreated after a cluster restore.

#### Solution:
Updated the description to clarify that StorageClasses associated with each virtual machine image are also synced automatically to the new cluster, alongside the image itself. Applied consistently across the current docs and all affected versioned doc snapshots (v1.4–v1.8).

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11613